### PR TITLE
Fix center detail page rendering and wire to live data

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react'
-import { View, Text, ScrollView, Image, Pressable, Linking } from 'react-native'
+import React, { useState, useMemo } from 'react'
+import { View, Text, ScrollView, Image, Pressable, Linking, ActivityIndicator } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import Toast from 'react-native-toast-message'
 import {
   MapPin,
   Globe,
@@ -10,259 +9,341 @@ import {
   User,
   ChevronRight,
   ChevronLeft,
-  ThumbsUp,
-  MessageCircle,
 } from 'lucide-react-native'
 import { TabSegment, IconButton, SecondaryButton, PrimaryButton, Card } from '../../components/ui'
+import { useCenterDetail, EventDisplay } from '../../hooks/useApiData'
 
-// Hardcoded center data
-const centerData = {
-  '1': {
-    id: '1',
-    name: 'Chinmaya Mission San Jose',
-    image: 'https://images.unsplash.com/photo-1582407947304-fd86f028f716?w=400&h=250&fit=crop',
-    address: '10160 Clayton Rd, San Jose, CA 95127',
-    website: 'https://www.cmsj.org/',
-    phone: '+1 408 254 8392',
-    upcomingEvents: 24,
-    pointOfContact: 'Ramesh Ji',
-    acharya: 'Acharya Brahmachari Soham Ji',
-  },
-  '2': {
-    id: '2',
-    name: 'Chinmaya Mission West',
-    image: 'https://images.unsplash.com/photo-1464822759844-d150baec93d5?w=400&h=250&fit=crop',
-    address: '560 Bridgeway, Sausalito, CA 94965',
-    website: 'https://www.chinmayamissionwest.org/',
-    phone: '+1 415 332 2182',
-    upcomingEvents: 18,
-    pointOfContact: 'Priya Ji',
-    acharya: 'Acharya Swami Ishwarananda',
-  },
-  '3': {
-    id: '3',
-    name: 'Chinmaya Mission San Francisco',
-    image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=250&fit=crop',
-    address: '631 Irving St, San Francisco, CA 94122',
-    website: 'https://www.chinmayasf.org/',
-    phone: '+1 415 661 8499',
-    upcomingEvents: 15,
-    pointOfContact: 'Anjali Ji',
-    acharya: 'Acharya Swami Tejomayananda',
-  },
+// ── Calendar helpers ──────────────────────────────────────────────────
+
+function getMonthGrid(year: number, month: number): (number | null)[][] {
+  const firstDay = new Date(year, month, 1).getDay()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const weeks: (number | null)[][] = []
+  let week: (number | null)[] = new Array(firstDay).fill(null)
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    week.push(day)
+    if (week.length === 7) {
+      weeks.push(week)
+      week = []
+    }
+  }
+  if (week.length > 0) {
+    while (week.length < 7) week.push(null)
+    weeks.push(week)
+  }
+  return weeks
 }
 
-// Sample events data for the calendar
-const sampleEvents = [
-  {
-    id: 1,
-    date: 26,
-    time: 'TODAY • 10:30 AM - 11:30 AM',
-    location: 'Young Museum',
-    title: 'Bhagavad Gita Study Circle - Chapter 12',
-    attendees: 14,
-    likes: 0,
-    comments: 0,
-    color: 'red' as const,
-  },
-  {
-    id: 2,
-    date: 29,
-    time: 'SUN, 8 PM - 11:49 PM',
-    location: 'Meditation Hall',
-    title: 'Hanuman Chalisa Chanting Marathon',
-    attendees: 14,
-    likes: 0,
-    comments: 0,
-    color: 'blue' as const,
-  },
-  {
-    id: 3,
-    date: 31,
-    time: 'TUE, 7 PM - 8:30 PM',
-    location: 'Main Hall',
-    title: 'Yoga and Meditation Session',
-    attendees: 8,
-    likes: 2,
-    comments: 1,
-    color: 'green' as const,
-  },
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
 ]
 
-export default function CenterDetailPage() {
-  const { id } = useLocalSearchParams()
-  const router = useRouter()
-  const [activeTab, setActiveTab] = useState('Details')
+const EVENT_COLORS = ['bg-red-100', 'bg-blue-100', 'bg-green-100', 'bg-amber-100']
+const EVENT_DOT_COLORS = ['bg-red-500', 'bg-blue-500', 'bg-green-500', 'bg-amber-500']
 
-  const center = centerData[id as string]
+// ── CalendarView component ────────────────────────────────────────────
 
-  if (!center) {
-    return (
-      <View className="flex-1 justify-center items-center px-4">
-        <Text className="text-2xl font-semibold text-foreground mb-4">Center not found</Text>
-        <Pressable onPress={() => router.back()} className="bg-primary rounded-xl px-6 py-3">
-          <Text className="text-primary-foreground font-semibold">Go Back</Text>
-        </Pressable>
-      </View>
-    )
+function CalendarView({
+  events,
+  onEventPress,
+}: {
+  events: EventDisplay[]
+  onEventPress: (event: EventDisplay) => void
+}) {
+  const now = new Date()
+  const [viewYear, setViewYear] = useState(now.getFullYear())
+  const [viewMonth, setViewMonth] = useState(now.getMonth())
+
+  const todayDate = now.getDate()
+  const isCurrentMonth = viewYear === now.getFullYear() && viewMonth === now.getMonth()
+  const weeks = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth])
+
+  // Map event index to date for color coding (simple heuristic)
+  const eventDateMap = useMemo(() => {
+    const map: Record<number, number> = {}
+    events.forEach((evt, i) => {
+      // Try to parse a date from the event time string
+      const dateMatch = evt.time.match(/(\d{1,2})/)
+      if (dateMatch) {
+        map[parseInt(dateMatch[1], 10)] = i
+      }
+    })
+    return map
+  }, [events])
+
+  const goToPrevMonth = () => {
+    if (viewMonth === 0) {
+      setViewYear(viewYear - 1)
+      setViewMonth(11)
+    } else {
+      setViewMonth(viewMonth - 1)
+    }
   }
 
-  // Calendar component
-  const CalendarView = () => {
-    const daysOfWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
-    const dates = [
-      [null, null, null, null, 1, 2, 3],
-      [4, 5, 6, 7, 8, 9, 10],
-      [11, 12, 13, 14, 15, 16, 17],
-      [18, 19, 20, 21, 22, 23, 24],
-      [25, 26, 27, 28, 29, 30, 31],
-    ]
-
-    const getEventForDate = (date: number) => {
-      return sampleEvents.find((event) => event.date === date)
+  const goToNextMonth = () => {
+    if (viewMonth === 11) {
+      setViewYear(viewYear + 1)
+      setViewMonth(0)
+    } else {
+      setViewMonth(viewMonth + 1)
     }
+  }
 
-    const getDateColor = (date: number) => {
-      const event = getEventForDate(date)
-      if (!event) return ''
-      return event.color === 'red'
-        ? 'bg-red-100'
-        : event.color === 'blue'
-        ? 'bg-blue-100'
-        : 'bg-green-100'
-    }
+  const daysOfWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
-    const getDotColor = (color: 'red' | 'blue' | 'green') => {
-      return color === 'red' ? 'bg-red-500' : color === 'blue' ? 'bg-blue-500' : 'bg-green-500'
-    }
+  return (
+    <View className="gap-4">
+      {/* Calendar Header */}
+      <View className="flex-row justify-between items-center px-2">
+        <IconButton onPress={goToPrevMonth}>
+          <ChevronLeft size={16} />
+        </IconButton>
+        <Text className="text-lg font-semibold text-content dark:text-content-dark">
+          {MONTH_NAMES[viewMonth]} {viewYear}
+        </Text>
+        <IconButton onPress={goToNextMonth}>
+          <ChevronRight size={16} />
+        </IconButton>
+      </View>
 
-    return (
-      <View className="gap-4">
-        {/* Calendar Header */}
-        <View className="flex-row justify-between items-center px-2">
-          <IconButton
-            onPress={() => {
-              Toast.show({
-                type: 'info',
-                text1: 'Previous Month',
-                text2: 'July 2025',
-              })
-            }}
-          >
-            <ChevronLeft size={16} />
-          </IconButton>
-          <Text className="text-lg font-semibold text-foreground">August 2025</Text>
-          <IconButton
-            onPress={() => {
-              Toast.show({
-                type: 'info',
-                text1: 'Next Month',
-                text2: 'September 2025',
-              })
-            }}
-          >
-            <ChevronRight size={16} />
-          </IconButton>
-        </View>
+      {/* Days of week header */}
+      <View className="flex-row justify-between px-2">
+        {daysOfWeek.map((day, index) => (
+          <View key={index} className="w-10 items-center">
+            <Text className="text-sm text-contentStrong dark:text-contentStrong-dark font-medium">
+              {day}
+            </Text>
+          </View>
+        ))}
+      </View>
 
-        {/* Days of week header */}
-        <View className="flex-row justify-between px-2">
-          {daysOfWeek.map((day, index) => (
-            <View key={index} className="w-10 items-center">
-              <Text className="text-sm text-muted-foreground font-medium">{day}</Text>
-            </View>
-          ))}
-        </View>
+      {/* Calendar grid */}
+      <View className="gap-1">
+        {weeks.map((week, weekIndex) => (
+          <View key={weekIndex} className="flex-row justify-between px-2">
+            {week.map((date, dayIndex) => {
+              const eventIdx = date !== null ? eventDateMap[date] : undefined
+              const hasEvent = eventIdx !== undefined
+              const isToday = isCurrentMonth && date === todayDate
 
-        {/* Calendar grid */}
-        <View className="gap-1">
-          {dates.map((week, weekIndex) => (
-            <View key={weekIndex} className="flex-row justify-between px-2">
-              {week.map((date, dayIndex) => (
+              return (
                 <View key={dayIndex} className="w-10 items-center">
-                  {date && (
+                  {date !== null && (
                     <Pressable
                       onPress={() => {
-                        const event = getEventForDate(date)
-                        if (event) {
-                          Toast.show({
-                            type: 'info',
-                            text1: `${event.title}`,
-                            text2: event.time,
-                          })
-                        }
+                        if (hasEvent) onEventPress(events[eventIdx!])
                       }}
                       className={`w-9 h-9 rounded-lg justify-center items-center relative ${
-                        date === 26 ? 'bg-foreground' : getDateColor(date)
+                        isToday
+                          ? 'bg-primary'
+                          : hasEvent
+                          ? EVENT_COLORS[eventIdx! % EVENT_COLORS.length]
+                          : ''
                       }`}
                     >
                       <Text
                         className={`text-sm ${
-                          date === 26
-                            ? 'font-semibold text-background'
-                            : 'font-normal text-foreground'
+                          isToday
+                            ? 'font-semibold text-white'
+                            : 'font-normal text-content dark:text-content-dark'
                         }`}
                       >
                         {date}
                       </Text>
-                      {getEventForDate(date) && date !== 26 && (
+                      {hasEvent && !isToday && (
                         <View
-                          className={`absolute bottom-0.5 w-1 h-1 rounded-full ${getDotColor(
-                            getEventForDate(date)!.color
-                          )}`}
+                          className={`absolute bottom-0.5 w-1 h-1 rounded-full ${
+                            EVENT_DOT_COLORS[eventIdx! % EVENT_DOT_COLORS.length]
+                          }`}
                         />
                       )}
                     </Pressable>
                   )}
                 </View>
-              ))}
-            </View>
-          ))}
-        </View>
+              )
+            })}
+          </View>
+        ))}
+      </View>
 
-        {/* Events List */}
-        <View className="gap-3 mt-2">
-          {sampleEvents
-            .filter((event) => event.date === 26)
-            .map((event) => (
-              <EventCard key={event.id} event={event} opacity={1} />
-            ))}
+      {/* Events List */}
+      <View className="gap-3 mt-2">
+        {events.map((event) => (
+          <CenterEventCard key={event.id} event={event} onPress={() => onEventPress(event)} />
+        ))}
+      </View>
+    </View>
+  )
+}
 
-          {sampleEvents
-            .filter((event) => event.date !== 26)
-            .map((event) => (
-              <EventCard key={event.id} event={event} opacity={0.8} />
-            ))}
-        </View>
+// ── CenterEventCard component ─────────────────────────────────────────
+
+function CenterEventCard({
+  event,
+  onPress,
+}: {
+  event: EventDisplay
+  onPress: () => void
+}) {
+  return (
+    <Card pressable onPress={onPress} padding="sm" overflowHidden>
+      <View className="gap-2">
+        <Text className="text-sm text-primary font-medium">{event.time}</Text>
+        <Text className="text-sm text-contentStrong dark:text-contentStrong-dark">
+          {event.location}
+        </Text>
+        <Text className="text-base font-semibold text-content dark:text-content-dark leading-tight">
+          {event.title}
+        </Text>
+        <Text className="text-sm text-contentStrong dark:text-contentStrong-dark mt-1">
+          {event.attendees} people
+        </Text>
+      </View>
+    </Card>
+  )
+}
+
+// ── Main page component ───────────────────────────────────────────────
+
+export default function CenterDetailPage() {
+  const { id } = useLocalSearchParams()
+  const router = useRouter()
+  const [activeTab, setActiveTab] = useState('Details')
+  const { center, events, loading } = useCenterDetail(id as string)
+
+  const handleEventPress = (event: EventDisplay) => {
+    router.push(`/events/${event.id}`)
+  }
+
+  if (loading) {
+    return (
+      <View className="flex-1 justify-center items-center bg-background dark:bg-background-dark">
+        <ActivityIndicator size="large" color="#ea580c" />
       </View>
     )
   }
 
-  const EventCard = ({ event, opacity }: { event: (typeof sampleEvents)[0]; opacity: number }) => {
+  if (!center) {
     return (
-      <Card
-        pressable
-        onPress={() => {
-          router.push(`/events/${event.id}`)
-          Toast.show({
-            type: 'success',
-            text1: 'Event Selected',
-            text2: event.title,
-          })
-        }}
-        style={{ opacity }}
-        padding="sm"
-        overflowHidden
-      >
-        <View className="gap-2">
-          <Text className="text-sm text-primary font-medium">{event.time}</Text>
-          <Text className="text-sm text-muted-foreground">{event.location}</Text>
-          <Text className="text-base font-semibold text-foreground leading-tight">
-            {event.title}
-          </Text>
-          <Text className="text-sm text-muted-foreground mt-1">{event.attendees} people</Text>
-        </View>
-      </Card>
+      <View className="flex-1 justify-center items-center px-4 bg-background dark:bg-background-dark">
+        <Text className="text-2xl font-semibold text-content dark:text-content-dark mb-4">
+          Center not found
+        </Text>
+        <Pressable onPress={() => router.back()} className="bg-primary rounded-xl px-6 py-3">
+          <Text className="text-white font-semibold">Go Back</Text>
+        </Pressable>
+      </View>
     )
   }
+
+  const renderDetailsTab = () => (
+    <View className="gap-4">
+      {/* Center Image */}
+      <View className="rounded-xl overflow-hidden shadow">
+        <Image source={{ uri: center.image }} style={{ width: '100%', height: 200 }} />
+      </View>
+
+      {/* Center Information */}
+      <View className="gap-3">
+        {/* Address */}
+        <Pressable
+          className="flex-row items-center gap-2"
+          onPress={() => Linking.openURL(`https://maps.google.com/?q=${encodeURIComponent(center.address)}`)}
+        >
+          <MapPin size={20} color="#f97316" />
+          <Text className="text-base font-medium text-content dark:text-content-dark flex-1">
+            {center.address}
+          </Text>
+        </Pressable>
+
+        {/* Website */}
+        <Pressable
+          className="flex-row items-center gap-2"
+          onPress={() => Linking.openURL(center.website)}
+        >
+          <Globe size={20} color="#f97316" />
+          <Text className="text-base font-medium text-primary">{center.website}</Text>
+        </Pressable>
+
+        {/* Phone */}
+        <Pressable
+          className="flex-row items-center gap-2"
+          onPress={() => Linking.openURL(`tel:${center.phone}`)}
+        >
+          <Phone size={20} color="#f97316" />
+          <Text className="text-base font-medium text-content dark:text-content-dark">
+            {center.phone}
+          </Text>
+        </Pressable>
+
+        {/* Upcoming Events */}
+        <View className="flex-row items-center gap-2">
+          <Calendar size={20} color="#f97316" />
+          <Text className="text-base font-medium text-content dark:text-content-dark">
+            {center.upcomingEvents} upcoming events
+          </Text>
+        </View>
+
+        {/* Point of Contact */}
+        <View className="flex-row items-center gap-2">
+          <User size={20} color="#f97316" />
+          <View className="flex-1">
+            <Text className="text-sm text-contentStrong dark:text-contentStrong-dark">
+              Point of Contact:
+            </Text>
+            <Text className="text-base font-medium text-content dark:text-content-dark">
+              {center.pointOfContact}
+            </Text>
+          </View>
+        </View>
+
+        {/* Acharya */}
+        {center.acharya && (
+          <View className="gap-1 mt-2">
+            <Text className="text-lg font-semibold text-content dark:text-content-dark">
+              Acharya
+            </Text>
+            <Text className="text-base text-contentStrong dark:text-contentStrong-dark">
+              {center.acharya}
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  )
+
+  return (
+    <ScrollView className="flex-1 bg-background dark:bg-background-dark">
+      <View className="flex-1">
+        {/* Center Name */}
+        <View className="px-4 py-3 bg-background dark:bg-background-dark border-b border-borderColor dark:border-borderColor-dark">
+          <Text className="text-2xl font-bold text-center text-content dark:text-content-dark">
+            {center.name}
+          </Text>
+        </View>
+
+        {/* Tab Navigation */}
+        <View className="bg-background dark:bg-background-dark px-4 py-2">
+          <TabSegment
+            options={[
+              { value: 'Details', label: 'Details' },
+              { value: 'Events', label: 'Events' },
+            ]}
+            value={activeTab}
+            onValueChange={setActiveTab}
+            variant="subtle"
+          />
+        </View>
+
+        <View className="px-4 gap-4 pb-8">
+          {activeTab === 'Details' && renderDetailsTab()}
+          {activeTab === 'Events' && (
+            <CalendarView events={events} onEventPress={handleEventPress} />
+          )}
+        </View>
+      </View>
+    </ScrollView>
+  )
 }


### PR DESCRIPTION
## Summary
- **Bug fix**: Center detail page had no return statement when a center was found — rendered a blank page
- Add `useCenterDetail` hook fetching from `fetchCenter` + `fetchEventsByCenter` with sample data fallback
- Dynamic calendar computing current month grid with month navigation (no longer hardcoded to August 2025)
- Extract `CalendarView` and `CenterEventCard` as top-level components (were broken inner functions)
- Add loading state with ActivityIndicator
- Remove inappropriate `Toast.show` calls

## Test plan
- [ ] Navigate to `/center/1`, `/center/2`, `/center/3` → page actually renders (was blank before)
- [ ] Calendar shows current month with today highlighted
- [ ] Month navigation arrows work
- [ ] Tap event card → navigates to event detail
- [ ] Details tab shows center info with clickable address/website/phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)