### PR TITLE
Add dedicated My Events list page

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -73,7 +73,7 @@ export default function HomeScreen() {
             <Text className="text-content dark:text-content-dark font-inter text-xl font-semibold">
               Your week
             </Text>
-            <SecondaryButton onPress={() => router.push('/explore')}>
+            <SecondaryButton onPress={() => router.push('/events')}>
               See All
             </SecondaryButton>
           </View>

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -157,7 +157,7 @@ export default function HomeScreenWeb() {
                 <Text className="text-content dark:text-content-dark font-inter text-2xl font-bold">
                   Upcoming Events
                 </Text>
-                <SecondaryButton onPress={() => router.push('/explore')}>
+                <SecondaryButton onPress={() => router.push('/events')}>
                   See All
                 </SecondaryButton>
               </View>

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -138,6 +138,14 @@ function RootLayoutNav() {
           options={{ headerShown: true }} // Explicitly show for settings
         />
         <Stack.Screen
+          name="events/index"
+          options={{
+            headerShown: true,
+            title: 'My Events',
+            headerBackTitle: '',
+          }}
+        />
+        <Stack.Screen
           name="events/[id]"
           options={{
             headerShown: true,

--- a/packages/frontend/app/events/index.tsx
+++ b/packages/frontend/app/events/index.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { View, Text, ScrollView, ActivityIndicator, RefreshControl, Pressable } from 'react-native'
+import { useRouter } from 'expo-router'
+import { Calendar, MapPin, ThumbsUp, MessageCircle } from 'lucide-react-native'
+import { useUser } from '../../components/contexts'
+import { useMyEvents, EventDisplay } from '../../hooks/useApiData'
+import { Card } from '../../components/ui'
+
+export default function EventsListPage() {
+  const router = useRouter()
+  const { user } = useUser()
+  const { events, loading, refetch } = useMyEvents(user?.username)
+  const [refreshing, setRefreshing] = React.useState(false)
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    await refetch()
+    setRefreshing(false)
+  }
+
+  const handleEventPress = (event: EventDisplay) => {
+    router.push(`/events/${event.id}`)
+  }
+
+  if (loading && !refreshing) {
+    return (
+      <View className="flex-1 justify-center items-center bg-background dark:bg-background-dark">
+        <ActivityIndicator size="large" color="#ea580c" />
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background dark:bg-background-dark"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+    >
+      <View className="px-4 pt-4 pb-8 gap-4">
+        <Text className="text-content dark:text-content-dark font-inter text-2xl font-bold">
+          My Events
+        </Text>
+
+        {events.length > 0 ? (
+          <View className="gap-3">
+            {events.map((event) => (
+              <Card key={event.id} pressable onPress={() => handleEventPress(event)} padding="sm">
+                <View className="gap-2">
+                  <Text className="font-inter text-sm text-primary font-medium">{event.time}</Text>
+                  <Text className="text-content dark:text-content-dark font-inter text-sm">
+                    {event.location}
+                  </Text>
+                  <Text className="text-content dark:text-content-dark font-inter text-lg font-semibold leading-tight">
+                    {event.title}
+                  </Text>
+                  <Text className="text-content dark:text-content-dark text-sm mt-1">
+                    {event.attendees} people
+                  </Text>
+                </View>
+              </Card>
+            ))}
+          </View>
+        ) : (
+          <View className="items-center py-16 gap-4">
+            <Calendar size={48} color="#a1a1aa" />
+            <Text className="text-lg text-contentStrong dark:text-contentStrong-dark font-inter">
+              No events yet
+            </Text>
+            <Text className="text-sm text-contentStrong dark:text-contentStrong-dark font-inter text-center px-8">
+              Events you register for will appear here
+            </Text>
+          </View>
+        )}
+      </View>
+    </ScrollView>
+  )
+}


### PR DESCRIPTION
## Summary
- Create `app/events/index.tsx` — dedicated page showing events the user is registered for
- Add `useMyEvents(username)` hook calling `getUserEvents` API with sample fallback
- Register `events/index` route in root layout (before `events/[id]`)
- Change "See All" buttons on home screens to navigate to `/events`
- Includes loading state, empty state ("No events yet"), and pull-to-refresh

## Dependencies
> ⚠️ Merge after #15 (`feature/wire-event-registration`) which adds the `getUserEvents` API function. This branch includes its own copy so it compiles independently, but merging #15 first avoids a duplicate definition.

## Test plan
- [ ] "See All" on Home → navigates to events list
- [ ] Events list shows registered events (or sample fallback)
- [ ] Tap event card → navigates to event detail
- [ ] Empty state shows when no events
- [ ] Pull to refresh works

🤖 Generated with [Claude Code](https://claude.com/claude-code)