### PR TITLE
Fix iOS simulator bundling failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "concurrently": "^8.2.2"
   },
   "dependencies": {
+    "@react-native/virtualized-lists": "^0.81.5",
     "@types/leaflet": "^1.9.21",
     "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
## Summary
- Add missing `@react-native/virtualized-lists@0.81.5` dependency required by React Native 0.81.5
- Fixes Metro bundling crash on iOS simulator: `Unable to resolve "@react-native/virtualized-lists"`

## Note
There is also a bug in `react-native-css-interop@0.2.1` where `parseAspectRatio` crashes on undefined `ratio` values. This was patched locally in `node_modules` but is not included in this PR — consider using `patch-package` or upgrading the library when a fix is released.

## Test plan
- [x] Verified iOS simulator bundles and launches successfully
- [x] Verified web app still works on localhost:8081

🤖 Generated with [Claude Code](https://claude.com/claude-code)