### PR TITLE
feat: redesign profile/settings pages and add mobile profile popover

### DIFF
--- a/packages/frontend/app/settings/settings.tsx
+++ b/packages/frontend/app/settings/settings.tsx
@@ -7,6 +7,7 @@ import {
   Switch,
   Linking,
   Modal,
+  Platform,
   ActivityIndicator,
   Alert,
 } from 'react-native'
@@ -52,7 +53,7 @@ export default function Settings() {
 
   return (
     <ScrollView style={{ flex: 1, backgroundColor: isDark ? '#171717' : '#FAFAF7' }}>
-      <View style={{ maxWidth: 900, width: '100%', alignSelf: 'center', padding: 40, paddingHorizontal: 60 }}>
+      <View style={{ maxWidth: 900, width: '100%', alignSelf: 'center', padding: Platform.OS === 'web' ? 40 : 20, paddingHorizontal: Platform.OS === 'web' ? 60 : 20 }}>
         {/* Header */}
         <View className="mb-8">
           <Text className="text-3xl font-inter font-bold text-content dark:text-content-dark mb-1">


### PR DESCRIPTION
## Summary
- Add mobile profile popover menu in the tab header with avatar, name, navigation links (Profile, Settings), and logout
- Redesign profile page with platform-specific layouts — mobile uses a centered hero with stacked fields, web uses a sidebar with card-based two-column form
- Replace X icon with back chevron + "Back" text on mobile settings header
- Remove redundant X button from web settings sidebar
- Remove username alias from profile dropdown popover (shows display name only)
- Use `DestructiveButton` component for delete account actions on both platforms
- Fix Reanimated crash on iOS by stripping NativeWind transition classes (`transition-all`, `active:scale-*`, `hover:scale-*`) from native layouts
- Add `react-native-reanimated` to frontend `package.json` dependencies
- Make settings sidebar web-only to prevent native layout issues

## Test plan
- [ ] Verify mobile profile popover opens/closes correctly when tapping the user icon in the header
- [ ] Verify popover dismisses when tapping outside (backdrop)
- [ ] Verify Profile, Settings, and Log Out links navigate correctly from the popover
- [ ] Verify mobile settings header shows back chevron with "Back" text
- [ ] Verify web settings sidebar no longer has X button
- [ ] Verify profile page renders correctly on mobile (centered avatar, stacked fields, interest chips)
- [ ] Verify profile page renders correctly on web (header row, profile card, two-column fields)
- [ ] Verify delete account button uses DestructiveButton component styling
- [ ] Verify no Reanimated crashes on iOS when navigating to settings/profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)