### PR TITLE
fix: make BirthdatePicker responsive width

### DIFF
--- a/packages/frontend/components/BirthdatePicker.web.tsx
+++ b/packages/frontend/components/BirthdatePicker.web.tsx
@@ -126,7 +126,7 @@ export default function BirthdatePicker({ value, onChange }) {
   }
 
   return (
-    <View className="p-4 w-[480px]">
+    <View className="p-4 w-full max-w-[480px]">
       <View className="flex-row justify-between space-x-2">
         {/* Month */}
         <Select


### PR DESCRIPTION
## Summary
- Changed `BirthdatePicker.web.tsx` from fixed `w-[480px]` to `w-full max-w-[480px]`
- Allows the picker to adapt to smaller containers while preserving max size on wider screens

## Test plan
- [ ] Verify BirthdatePicker renders correctly at desktop widths
- [ ] Verify it shrinks properly in containers narrower than 480px

🤖 Generated with [Claude Code](https://claude.com/claude-code)