### PR TITLE
feat(backend): flatten DynamoDB schema, add missing fields, messages & membership

### DIFF
--- a/packages/backend/.gitignore
+++ b/packages/backend/.gitignore
@@ -19,3 +19,8 @@ amplifytools.xcconfig
 .secret-*
 **.sample
 #amplify-do-not-edit-end
+
+# Local environment files — never commit these
+.env
+.env.local
+.env.*.local

--- a/packages/backend/authentication/authenticateMethods.js
+++ b/packages/backend/authentication/authenticateMethods.js
@@ -228,10 +228,9 @@ async function getUserByUsername(username) {
     if (!existing) {
       return null
     }
-    let constructedUser = new user.User(username)
-    if (existing.userObject) {
-      constructedUser.buildFromJSON(existing.userObject)
-    }
+    let constructedUser = new user.User(username, true)
+    // buildFromJSON handles both flat records and legacy nested userObject
+    constructedUser.buildFromJSON(existing)
     return constructedUser
   } catch (err) {
     console.error('Get user by username error:', err)
@@ -244,15 +243,14 @@ async function getUserByUsername(username) {
  * @param {user.User} user The user to update the user data with.
  * @returns {boolean} A boolean representing if the operation was successful.
  */
-async function updateUserData(username, user) {
+async function updateUserData(username, userObj) {
   try {
     const existing = await db.getUserByUsername(username)
     if (!existing) {
       return false
     }
-    const updates = {
-      userObject: user.toJSON(),
-    }
+    // Write flat top-level fields — no more nested userObject wrapper
+    const updates = typeof userObj.toJSON === 'function' ? userObj.toJSON() : userObj
     const result = await db.updateUser(existing.id, updates)
     return result.success
   } catch (err) {
@@ -289,10 +287,9 @@ async function getCenterByCenterID(centerID) {
       return null
     }
 
-    const c = new center.Center(new location.Location(0, 0), 'Hello World!')
-    if (dbCenter.centerObject) {
-      c.buildFromJSON(dbCenter.centerObject)
-    }
+    const c = new center.Center(new location.Location(0, 0), '')
+    // buildFromJSON handles both flat records and legacy nested centerObject
+    c.buildFromJSON(dbCenter)
     return c
   } catch (err) {
     console.error('Get center by ID error:', err)
@@ -317,9 +314,10 @@ async function storeCenter(centerID, centerObject) {
       return false
     }
 
+    // Write flat top-level fields — no more nested centerObject wrapper
     const centerData = {
       centerID: centerID,
-      centerObject: centerObject.toJSON(),
+      ...centerObject.toJSON(),
     }
 
     const result = await db.createCenter(centerData)
@@ -342,9 +340,8 @@ async function updateCenter(centerID, centerObject) {
       return false
     }
 
-    const updates = {
-      centerObject: centerObject.toJSON(),
-    }
+    // Write flat top-level fields — no more nested centerObject wrapper
+    const updates = centerObject.toJSON()
 
     const result = await db.updateCenter(centerID, updates)
     return result.success
@@ -394,7 +391,7 @@ async function getAllCenters() {
  * Called after user completes all onboarding steps
  */
 async function completeOnboarding(req, res) {
-  const { firstName, lastName, dateOfBirth, centerID, profileComplete, phoneNumber, interests } =
+  const { firstName, lastName, dateOfBirth, centerID, profileComplete, phoneNumber, interests, bio, profileImage } =
     req.body
 
   if (!req.user?.id) {
@@ -418,6 +415,8 @@ async function completeOnboarding(req, res) {
       ...(profileComplete !== undefined ? { profileComplete } : {}),
       ...(phoneNumber !== undefined ? { phoneNumber } : {}),
       ...(interests !== undefined ? { interests } : {}),
+      ...(bio !== undefined ? { bio } : {}),
+      ...(profileImage !== undefined ? { profileImage } : {}),
     }
 
     const result = await db.updateUser(req.user.id, updates)

--- a/packages/backend/centralSequence.js
+++ b/packages/backend/centralSequence.js
@@ -28,7 +28,7 @@ import fs from 'fs'
 console.log('Fs')
 //Constants
 console.log('Constants')
-const PORT = 8008
+const PORT = process.env.PORT || 8008
 
 //App init
 console.log('Entering init')

--- a/packages/backend/config/dynamoConfig.js
+++ b/packages/backend/config/dynamoConfig.js
@@ -5,17 +5,23 @@
  */
 
 export function getDynamoDBConfig() {
-    return {
+    const config = {
         region: process.env.AWS_REGION || "us-east-1",
         credentials : {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+            accessKeyId: process.env.AWS_ACCESS_KEY_ID || "local",
+            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "local"
         },
     }
+    // When DYNAMODB_ENDPOINT is set (e.g. local dev), point the client there instead of AWS
+    if (process.env.DYNAMODB_ENDPOINT) {
+        config.endpoint = process.env.DYNAMODB_ENDPOINT
+    }
+    return config
 }
 
 export const TABLES = {
     USERS: process.env.USERS_TABLE || "ChinmayaJanata-Users",
     CENTERS: process.env.CENTERS_TABLE || "ChinmayaJanata-Centers",
-    EVENTS: process.env.EVENTS_TABLE || "ChinmayaJanata-Events"
+    EVENTS: process.env.EVENTS_TABLE || "ChinmayaJanata-Events",
+    MESSAGES: process.env.MESSAGES_TABLE || "ChinmayaJanata-Messages",
 };

--- a/packages/backend/constants.js
+++ b/packages/backend/constants.js
@@ -37,6 +37,7 @@ const __dirname = dirname(__filename)
 const USERS_TABLE = process.env.USERS_TABLE || 'ChinmayaJanata-Users'
 const EVENTS_TABLE = process.env.EVENTS_TABLE || 'ChinmayaJanata-Events'
 const CENTERS_TABLE = process.env.CENTERS_TABLE || 'ChinmayaJanata-Centers'
+const MESSAGES_TABLE = process.env.MESSAGES_TABLE || 'ChinmayaJanata-Messages'
 
 //Admin constants
 const ADMIN_NAME = 'Brahman'
@@ -66,6 +67,7 @@ export default {
   USERS_TABLE,
   EVENTS_TABLE,
   CENTERS_TABLE,
+  MESSAGES_TABLE,
   ADMIN_NAME,
   ADMIN_CUTOFF,
   NORMAL_USER,

--- a/packages/backend/database/dynamoHelpers.js
+++ b/packages/backend/database/dynamoHelpers.js
@@ -444,6 +444,99 @@ export async function getAllEvents() {
   }
 }
 
+// Message-related DynamoDB helper functions
+
+/**
+ * Creates a new message in the Messages table.
+ * @param {Object} messageItem - Must include eventID, authorUsername, text, and optionally image.
+ * @returns {{success: boolean, messageID?: string, error?: string}}
+ */
+export async function createMessage(messageItem) {
+  try {
+    if (!messageItem.messageID) {
+      messageItem.messageID = uuidv4()
+    }
+    const now = new Date().toISOString()
+    await constants.docClient.send(
+      new PutCommand({
+        TableName: constants.MESSAGES_TABLE,
+        Item: {
+          ...messageItem,
+          createdAt: now,
+          timestamp: now,
+        },
+        ConditionExpression: 'attribute_not_exists(messageID)',
+      })
+    )
+    return { success: true, messageID: messageItem.messageID }
+  } catch (err) {
+    console.error('Error creating message:', err)
+    return { success: false, error: err.message }
+  }
+}
+
+/**
+ * Gets all messages for an event, sorted by createdAt ascending.
+ * @param {string} eventID
+ * @returns {Array}
+ */
+export async function getMessagesByEventId(eventID) {
+  try {
+    const command = new QueryCommand({
+      TableName: constants.MESSAGES_TABLE,
+      IndexName: 'eventID-index',
+      KeyConditionExpression: 'eventID = :eid',
+      ExpressionAttributeValues: { ':eid': eventID },
+    })
+    const result = await constants.docClient.send(command)
+    const items = result.Items || []
+    items.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''))
+    return items
+  } catch (err) {
+    console.error('Error getting messages by event:', err)
+    return []
+  }
+}
+
+/**
+ * Deletes a message by messageID.
+ * @param {string} messageID
+ * @returns {{success: boolean, error?: string}}
+ */
+export async function deleteMessage(messageID) {
+  try {
+    await constants.docClient.send(
+      new DeleteCommand({
+        TableName: constants.MESSAGES_TABLE,
+        Key: { messageID },
+      })
+    )
+    return { success: true }
+  } catch (err) {
+    console.error('Error deleting message:', err)
+    return { success: false, error: err.message }
+  }
+}
+
+/**
+ * Gets a single message by messageID.
+ * @param {string} messageID
+ * @returns {Object | null}
+ */
+export async function getMessageById(messageID) {
+  try {
+    const command = new GetCommand({
+      TableName: constants.MESSAGES_TABLE,
+      Key: { messageID },
+    })
+    const result = await constants.docClient.send(command)
+    return result.Item || null
+  } catch (err) {
+    console.error('Error retrieving message:', err)
+    return null
+  }
+}
+
 // Default export for backward compatibility
 export default {
   createUser,
@@ -462,4 +555,8 @@ export default {
   deleteCenter,
   getAllCenters,
   getAllEvents,
+  createMessage,
+  getMessagesByEventId,
+  deleteMessage,
+  getMessageById,
 }

--- a/packages/backend/events/event.js
+++ b/packages/backend/events/event.js
@@ -1,6 +1,6 @@
 /**
  * event.js
- * 
+ *
  * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
  * Author: Sahanav Sai Ramesh
  * Date Authored: August 30, 2025
@@ -8,7 +8,6 @@
  * All the methods concerning an event.
  */
 import location from '../location/location.js';
-import center from '../profiles/center.js';
 import user from '../profiles/user.js';
 import constants from '../constants.js';
 import store from './eventStorage.js';
@@ -22,19 +21,24 @@ class Event{
    * Constructs an event.
    * @param {location.Location} loc The location of the Event.
    * @param {Date} date The Date at which the Event takes place.
-   * @param {string} cen The Center ID of the Center with which the Event is affiliated.
+   * @param {string} cen The centerID (UUID string) of the center with which the Event is affiliated.
    */
   constructor(loc, date, cen)
   {
-    this.location = loc;
-    this.date = date;
-    this.center = cen;
-    this.endorsers = []; //An array of strings containing all the event endorser usernames. Must have status of greater than constants.SEVAK
-    this.id = 0; //TODO make a method for this. A number that represents the unique ID of this event.
-    this.tier = 0; //The calculated tier of the event.
-    this.peopleAttending = 0; //A number that represents how many people are going to the event.
-    this.usersAttending = []; 
-    this.description = "";
+    this.location = loc || new location.Location(0, 0);
+    this.date = date || new Date();
+    this.centerID = cen || null; // Store only the ID, not the full center object
+    this.endorsers = []; // Array of endorser usernames
+    this.id = 0;
+    this.tier = 0;
+    this.peopleAttending = 0;
+    this.usersAttending = [];
+    this.description = '';
+    this.title = '';
+    this.address = '';
+    this.pointOfContact = '';
+    this.image = '';
+    this.endDate = null;
   }
   /**
    * Adds an endorser to this event.
@@ -50,11 +54,7 @@ class Event{
   }
   /**
    * Calculates the Tier of an event in accordance with the Tier Ranking system.
-   * The Tier Ranking System does the following:
-   * Takes the sum of all this.endorsers.points*this.endorsers.verificationLevel
-   * Adds to it the amount of people within the event multiplied by the numerical ranking constants.NORMAL_USER.
-   * Multiplies it by the 1 + amount of people with numerical ranking constants.BRAHMACHARI or above.
-   * 
+   *
    * @returns {number} The tier of the event.
    */
   calculateTier()
@@ -63,18 +63,17 @@ class Event{
     let brahmachariAndAbove = 0;
     for(let i = 0; i < this.endorsers.length; i++)
     {
-      tier += this.endorsers[i].points*this.endorsers.verificationLevel;
+      tier += this.endorsers[i].points * this.endorsers[i].verificationLevel;
       if(this.endorsers[i].verificationLevel >= constants.BRAHMACHARI)
       {
         brahmachariAndAbove++;
       }
     }
-    brahmachariAndAbove;
-    tier += this.peopleAttending*constants.NORMAL_USER;
-    tier *= brahmachariAndAbove+1;
+    tier += this.peopleAttending * constants.NORMAL_USER;
+    tier *= brahmachariAndAbove + 1;
     tier /= constants.TIER_DESCALE;
+    this.tier = tier;
     return tier;
-    
   }
   /**
    * Sets the description of this Event.
@@ -85,56 +84,81 @@ class Event{
     this.description = desc;
   }
   /**
-   * Turns this Event object into JSON.
-   * 
+   * Turns this Event object into flat JSON (no nested eventObject wrapper).
+   * Stores only centerID, not the full embedded center object.
+   *
    * @returns {JSON} This Event as JSON.
    */
   toJSON()
   {
-    let endorserJSON = [];
-    for(i in this.endorsers)
-    {
-      endorserJSON += this.endorsers[i].toJSON();
+    const endorserJSON = [];
+    for (let i = 0; i < this.endorsers.length; i++) {
+      if (this.endorsers[i] && typeof this.endorsers[i].toJSON === 'function') {
+        endorserJSON.push(this.endorsers[i].toJSON());
+      } else {
+        endorserJSON.push(this.endorsers[i]);
+      }
     }
     return {
       'location': this.location.toJSON(),
-      'date': this.date.toISOString(),
-      'center': this.center.toJSON(),
+      'date': this.date instanceof Date ? this.date.toISOString() : this.date,
+      'centerID': this.centerID,
       'endorsers': endorserJSON,
       'id': this.id,
       'tier': this.tier,
       'peopleAttending': this.peopleAttending,
       'usersAttending': this.usersAttending,
-      'description': this.description
+      'description': this.description,
+      'title': this.title,
+      'address': this.address,
+      'pointOfContact': this.pointOfContact,
+      'image': this.image,
+      'endDate': this.endDate instanceof Date ? this.endDate.toISOString() : this.endDate,
     };
   }
-/**
- * Builds this object from JSON data.
- * @param {JSON} data The data from which the Event should be built.
- */
+  /**
+   * Builds this object from flat JSON data (or legacy nested eventObject).
+   * @param {JSON} data The data from which the Event should be built.
+   */
   buildFromJSON(data)
   {
-    let loc = new location.Location(0,0);
-    loc.buildFromJSON(data.location);
+    // Support both flat top-level fields and legacy nested eventObject
+    const src = data.eventObject || data;
+    const loc = new location.Location(0, 0);
+    loc.buildFromJSON(src.location || {});
     this.location = loc;
-    this.date = new Date(data.date);
-    this.center = data.center;
-    this.endorsers = data.endorsers;
-    this.id = parseInt(data.id);
-    this.tier = parseInt(data.tier);
-    this.peopleAttending = parseInt(data.peopleAttending);
-    this.usersAttending = data.usersAttending;
-    this.description = data.description;
+    this.date = src.date ? new Date(src.date) : new Date();
+    // Normalize center: accept centerID string or extract from embedded center object
+    if (src.centerID) {
+      this.centerID = src.centerID;
+    } else if (src.center && typeof src.center === 'object' && src.center.centerID) {
+      this.centerID = src.center.centerID;
+    } else if (src.center && typeof src.center === 'string') {
+      this.centerID = src.center;
+    } else {
+      this.centerID = null;
+    }
+    this.endorsers = src.endorsers || [];
+    this.id = src.id !== undefined ? src.id : 0;
+    this.tier = src.tier !== undefined ? parseFloat(src.tier) : 0;
+    this.peopleAttending = src.peopleAttending !== undefined ? parseInt(src.peopleAttending) : 0;
+    this.usersAttending = src.usersAttending || [];
+    this.description = src.description || '';
+    this.title = src.title || '';
+    this.address = src.address || '';
+    this.pointOfContact = src.pointOfContact || '';
+    this.image = src.image || '';
+    this.endDate = src.endDate ? new Date(src.endDate) : null;
   }
   /**
    * Assigns a new unique ID to this object.
-   * 
+   *
    * @returns The ID assigned.
    */
   assignID()
   {
     let me = Math.round(Math.random()*constants.EVENT_ID_VARIABILITY);
-    while(!store.checkEventUniqueness(id))
+    while(!store.checkEventUniqueness(me))
     {
       me = Math.round(Math.random()*constants.EVENT_ID_VARIABILITY);
     }
@@ -163,7 +187,7 @@ class Event{
       return null;
     })();
   }
-    /**
+  /**
    * Adds an event to the user.
    * @param {user.User} u The User to add.
    * @returns {user.User | null} The User with the event added

--- a/packages/backend/events/eventStorage.js
+++ b/packages/backend/events/eventStorage.js
@@ -23,15 +23,16 @@ import center from '../profiles/center.js'
  */
 async function storeEvent(eventToStore) {
   try {
-    const existing = await db.getEventById(eventToStore.id)
+    const eventID = String(eventToStore.id)
+    const existing = await db.getEventById(eventID)
     if (existing) {
       return false
     }
 
     const eventData = {
-      eventID: eventToStore.id,
-      eventObject: eventToStore.toJSON(),
-      centerID: eventToStore.center?.centerID || null,
+      eventID: eventID,
+      ...eventToStore.toJSON(),
+      id: eventID, // store as string — avoids Number.MAX_SAFE_INTEGER violation
     }
 
     const result = await db.createEvent(eventData)
@@ -48,16 +49,15 @@ async function storeEvent(eventToStore) {
  */
 async function updateEvent(eventObject) {
   try {
-    const existing = await db.getEventById(eventObject.id)
+    const eventID = String(eventObject.id)
+    const existing = await db.getEventById(eventID)
     if (!existing) {
       return false
     }
 
-    const updates = {
-      eventObject: eventObject.toJSON(),
-    }
+    const updates = { ...eventObject.toJSON(), id: eventID }
 
-    const result = await db.updateEvent(eventObject.id, updates)
+    const result = await db.updateEvent(eventID, updates)
     return result.success
   } catch (err) {
     console.error('Update event error:', err)
@@ -72,7 +72,7 @@ async function updateEvent(eventObject) {
  */
 async function checkEventUniqueness(id) {
   try {
-    const event = await db.getEventById(id)
+    const event = await db.getEventById(String(id))
     return !event
   } catch (err) {
     console.error('Check event uniqueness error:', err)
@@ -86,7 +86,7 @@ async function checkEventUniqueness(id) {
  */
 async function getEventByID(id) {
   try {
-    const doc = await db.getEventById(id)
+    const doc = await db.getEventById(String(id))
     return doc || null
   } catch (err) {
     console.error('Get event by ID error:', err)
@@ -100,7 +100,7 @@ async function getEventByID(id) {
  */
 async function removeEventByID(id) {
   try {
-    const result = await db.deleteEvent(id)
+    const result = await db.deleteEvent(String(id))
     return result.success
   } catch (err) {
     console.error('Remove event by ID error:', err)

--- a/packages/backend/profiles/center.js
+++ b/packages/backend/profiles/center.js
@@ -1,6 +1,6 @@
 /**
  * center.js
- * 
+ *
  * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
  * Author: Sahanav Sai Ramesh
  * Date Authored: August 30, 2025
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
  * Represents a center on the app.
  */
 class Center{
-  
+
   /**
    * Constructs a new Center object.
    * @param {location.Location} loc The Location representing the latitudinal-longitudinal pair of the center.
@@ -28,10 +28,16 @@ class Center{
     this.centerID = -1;
     this.memberCount = 0;
     this.isVerified = false;
+    this.address = '';
+    this.website = '';
+    this.phone = '';
+    this.image = '';
+    this.pointOfContact = '';
+    this.acharya = '';
   }
   /**
-   * Returns this Center as a JSON object.
-   * 
+   * Returns this Center as a flat JSON object (no nested centerObject wrapper).
+   *
    * @returns {JSON} This Center as a JSON object.
    */
   toJSON()
@@ -41,25 +47,39 @@ class Center{
       'name': this.name,
       'centerID': this.centerID,
       'memberCount': this.memberCount,
-      'isVerified': this.isVerified
+      'isVerified': this.isVerified,
+      'address': this.address,
+      'website': this.website,
+      'phone': this.phone,
+      'image': this.image,
+      'pointOfContact': this.pointOfContact,
+      'acharya': this.acharya,
     }
   }
   /**
-   * Builds this Center from a JSON object.
+   * Builds this Center from a flat DynamoDB record (or legacy nested centerObject).
    * @param data The data from which to build this Center object.
    */
   buildFromJSON(data)
   {
-    this.location = new Location(0,0);
-    this.location.buildFromJSON(data.location);
-    this.name = data.name;
-    this.centerID = data.centerID;
-    this.memberCount = data.memberCount;
-    this.isVerified = data.isVerified;
+    // Support both flat top-level fields and legacy nested centerObject
+    const src = data.centerObject || data;
+    this.location = new location.Location(0, 0);
+    this.location.buildFromJSON(src.location || {});
+    this.name = src.name || '';
+    this.centerID = src.centerID;
+    this.memberCount = src.memberCount || 0;
+    this.isVerified = src.isVerified || false;
+    this.address = src.address || '';
+    this.website = src.website || '';
+    this.phone = src.phone || '';
+    this.image = src.image || '';
+    this.pointOfContact = src.pointOfContact || '';
+    this.acharya = src.acharya || '';
   }
   /**
    * Verifies this center.
-   * @param {JSON} req A request made by the admin user to verify that admin is making this request. 
+   * @param {JSON} req A request made by the admin user to verify that admin is making this request.
    * @returns {boolean} A boolean representing if the verification was successful or not.
    */
   verify(req)

--- a/packages/backend/profiles/user.js
+++ b/packages/backend/profiles/user.js
@@ -28,8 +28,9 @@ class User {
       this.firstName = ''
       this.lastName = ''
       this.dateOfBirth = null // Stored as a Date object.
-      this.profilePictureURL = this.getDefaultAvatar()
-      this.center = -1
+      this.profileImage = this.getDefaultAvatar()
+      this.centerID = -1
+      this.centerMemberships = [] // List of centerIDs the user has joined
       this.points = 0
       this.isVerified = false
       this.verificationLevel = constants.NORMAL_USER
@@ -37,6 +38,11 @@ class User {
       this.isActive = false
       this.id = ''
       this.events = []
+      this.email = ''
+      this.profileComplete = false
+      this.phoneNumber = ''
+      this.interests = []
+      this.bio = ''
     } else {
       console.error('User does not exist!')
       this.exists = false
@@ -77,12 +83,12 @@ class User {
     return true
   }
   /**
-   * Sets the center.
-   * @param {number} centerId The center ID of the center.
+   * Sets the home center.
+   * @param {string} centerId The center ID of the center.
    * @returns {boolean} A boolean representing success.
    */
   setCenter(centerId) {
-    center = centerId
+    this.centerID = centerId
     return true
   }
   /**
@@ -112,7 +118,7 @@ class User {
     this.isActive = false
   }
   /**
-   * Turns this User into JSON.
+   * Turns this User into JSON (flat — all fields at top level, no nested userObject).
    *
    * @returns {JSON} The user represented as JSON.
    */
@@ -122,8 +128,9 @@ class User {
       firstName: this.firstName,
       lastName: this.lastName,
       dateOfBirth: this.dateOfBirth,
-      profilePictureURL: this.profilePictureURL,
-      center: this.center,
+      profileImage: this.profileImage,
+      centerID: this.centerID,
+      centerMemberships: this.centerMemberships,
       points: this.points,
       isVerified: this.isVerified,
       verificationLevel: this.verificationLevel,
@@ -131,6 +138,11 @@ class User {
       isActive: this.isActive,
       id: this.id,
       events: this.events,
+      email: this.email,
+      profileComplete: this.profileComplete,
+      phoneNumber: this.phoneNumber,
+      interests: this.interests,
+      bio: this.bio,
     }
   }
   /**
@@ -142,29 +154,38 @@ class User {
     return JSON.stringify(this.toJSON())
   }
   /**
-   * Builds this user from JSON.
+   * Builds this user from a flat DynamoDB record (or legacy nested userObject).
    * @param {JSON} data The JSON from which to build the user.
    */
   buildFromJSON(data) {
-    if (data.exists) {
-      this.username = data.username
-      this.firstName = data.firstName
-      this.lastName = data.lastName
-      this.dateOfBirth = data.dateOfBirth
-      this.profilePictureURL = data.profilePictureURL
-      this.center = data.center
-      this.points = data.points
-      this.isVerified = data.isVerified
-      this.verificationLevel = data.verificationLevel
-      this.exists = data.exists
-      this.isActive = data.isActive
-      this.id = data.id
-      this.events = data.events
+    // Support both flat top-level fields and legacy nested userObject
+    const src = data.userObject || data
+    if (src.exists !== false) {
+      this.username = src.username || this.username
+      this.firstName = src.firstName || ''
+      this.lastName = src.lastName || ''
+      this.dateOfBirth = src.dateOfBirth || null
+      // Support legacy profilePictureURL field name
+      this.profileImage = src.profileImage || src.profilePictureURL || this.getDefaultAvatar()
+      // Support legacy 'center' field name
+      this.centerID = src.centerID !== undefined ? src.centerID : (src.center !== undefined ? src.center : -1)
+      this.centerMemberships = src.centerMemberships || []
+      this.points = src.points || 0
+      this.isVerified = src.isVerified || false
+      this.verificationLevel = src.verificationLevel || constants.NORMAL_USER
+      this.exists = src.exists !== undefined ? src.exists : true
+      this.isActive = src.isActive || false
+      this.id = src.id || ''
+      this.events = src.events || []
+      this.email = src.email || ''
+      this.profileComplete = src.profileComplete || false
+      this.phoneNumber = src.phoneNumber || ''
+      this.interests = src.interests || []
+      this.bio = src.bio || ''
     }
   }
   /**
    * Retrieves the unique user ID from users.db and sets this User's ID to that.
-   * NOTE: This method may have to be changed with the classic variability method used in Center and Event based on how testing and deployment flows.
    * @returns {boolean | string} A boolean representing the success of this operation, or the ID fetched.
    */
   async retrieveID() {

--- a/packages/backend/routes/api.js
+++ b/packages/backend/routes/api.js
@@ -7,6 +7,7 @@ import eventMethods from '../events/eventStorage.js'
 import user from '../profiles/user.js'
 import center from '../profiles/center.js'
 import location from '../location/location.js'
+import { v4 as uuidv4 } from 'uuid'
 
 const router = express.Router()
 
@@ -79,6 +80,13 @@ router.post('/addCenter', async (req, res) => {
       new location.Location(req.body.latitude, req.body.longitude),
       req.body.centerName
     )
+    // Set optional new fields if provided
+    if (req.body.address) c.address = req.body.address
+    if (req.body.website) c.website = req.body.website
+    if (req.body.phone) c.phone = req.body.phone
+    if (req.body.image) c.image = req.body.image
+    if (req.body.pointOfContact) c.pointOfContact = req.body.pointOfContact
+    if (req.body.acharya) c.acharya = req.body.acharya
     let id = await c.assignCenterID()
     let success = await authMethods.storeCenter(id, c)
     if (!success) {
@@ -93,8 +101,7 @@ router.post('/addCenter', async (req, res) => {
 
 router.post('/verifyCenter', async (req, res) => {
   try {
-    let centerID =
-      req.body.centerID instanceof Number ? req.body.centerID : parseInt(req.body.centerID)
+    const centerID = req.body.centerID
     let c = await authMethods.getCenterByCenterID(centerID)
     if (c && c.verify(req)) {
       return res.status(200).json({ message: 'Successful verification!' })
@@ -110,8 +117,7 @@ router.post('/verifyCenter', async (req, res) => {
 
 router.post('/removeCenter', async (req, res) => {
   try {
-    let centerID =
-      req.body.centerID instanceof Number ? req.body.centerID : parseInt(req.body.centerID)
+    const centerID = req.body.centerID
     if (authMethods.removeCenter(centerID, req)) {
       return res.status(200).json({ message: 'Successful removal!' })
     }
@@ -125,10 +131,17 @@ router.post('/removeCenter', async (req, res) => {
 router.post('/fetchAllCenters', async (req, res) => {
   try {
     let li = await authMethods.getAllCenters()
-    if (li) {
-      return res.status(200).json({ message: 'Successful', centersList: li })
+    if (!li) {
+      return res.status(500).json({ message: 'Internal server error.' })
     }
-    return res.status(500).json({ message: 'Internal server error.' })
+    // If username provided, compute isMember flag for each center
+    const username = req.body.username
+    if (username) {
+      const u = await authMethods.getUserByUsername(username)
+      const memberships = (u && u.centerMemberships) ? u.centerMemberships : []
+      li = li.map((c) => ({ ...c, isMember: memberships.includes(c.centerID) }))
+    }
+    return res.status(200).json({ message: 'Successful', centersList: li })
   } catch (error) {
     console.error('Error fetching centers:', error)
     res.status(500).json({ error: 'Internal server error' })
@@ -137,12 +150,17 @@ router.post('/fetchAllCenters', async (req, res) => {
 
 router.post('/fetchCenter', async (req, res) => {
   try {
-    let centerID =
-      req.body.centerID instanceof Number ? req.body.centerID : parseInt(req.body.centerID)
-    let c = await authMethods.getCenterByCenterID(centerID)
-    return c
-      ? res.status(200).json({ message: 'Success', center: c.toJSON() })
-      : res.status(400).json({ message: 'Malformed centerID' })
+    const { centerID, username } = req.body
+    const c = await authMethods.getCenterByCenterID(centerID)
+    if (!c) return res.status(400).json({ message: 'Malformed centerID' })
+
+    const centerJSON = c.toJSON()
+    if (username) {
+      const u = await authMethods.getUserByUsername(username)
+      const memberships = (u && u.centerMemberships) ? u.centerMemberships : []
+      centerJSON.isMember = memberships.includes(centerID)
+    }
+    return res.status(200).json({ message: 'Success', center: centerJSON })
   } catch (error) {
     console.error('Error fetching center:', error)
     res.status(500).json({ error: 'Internal server error' })
@@ -156,12 +174,10 @@ router.post('/verifyUser', async (req, res) => {
     if (!dbUser) {
       return res.status(404).json({ message: 'User not found.' })
     }
-    let u = new user.User(req.body.usernameToVerify)
-    if (dbUser.userObject) {
-      u.buildFromJSON(dbUser.userObject)
-    }
+    let u = new user.User(req.body.usernameToVerify, true)
+    u.buildFromJSON(dbUser)
     let status = u.verify(req.body.verificationLevel, req)
-    await authMethods.updateUserData(req.body.username, u)
+    await authMethods.updateUserData(req.body.usernameToVerify, u)
     if (status) {
       return res.status(200).json({ message: 'Verification successful.' })
     }
@@ -230,20 +246,23 @@ router.post('/getUserEvents', async (req, res) => {
 router.post('/addevent', async (req, res) => {
   try {
     const data = req.body
-    const centerID = data.centerID instanceof Number ? data.centerID : parseInt(data.centerID)
+    const centerID = data.centerID // UUID string — do not parseInt
     const exists = await authMethods.centerIDExists(centerID)
     if (!exists) {
-      return res.status(404).send({ message: 'Center not found.' })
-    }
-    const centerObj = await authMethods.getCenterByCenterID(centerID)
-    if (!centerObj) {
       return res.status(404).send({ message: 'Center not found.' })
     }
     let ev = new event.Event(
       new location.Location(parseFloat(data.latitude), parseFloat(data.longitude)),
       new Date(data.date),
-      centerObj
+      centerID // Store only the ID
     )
+    // Set optional new fields if provided
+    if (data.description) ev.description = data.description
+    if (data.title) ev.title = data.title
+    if (data.address) ev.address = data.address
+    if (data.pointOfContact) ev.pointOfContact = data.pointOfContact
+    if (data.image) ev.image = data.image
+    if (data.endDate) ev.endDate = new Date(data.endDate)
     let id = ev.assignID()
     for (let i = 0; i < (data.endorsers || []).length; i++) {
       const endorser = data.endorsers[i]
@@ -312,16 +331,9 @@ router.post('/getEventUsers', async (req, res) => {
       return res.status(404).json({ message: 'Event not found' })
     }
 
-    let ev
-    if (doc.eventObject && doc.eventObject.id) {
-      ev = new event.Event()
-      ev.buildFromJSON(doc.eventObject)
-    } else if (doc.eventObject) {
-      ev = new event.Event()
-      ev.buildFromJSON(doc.eventObject)
-    } else {
-      return res.status(500).json({ message: 'Malformed event document' })
-    }
+    // buildFromJSON handles both flat records and legacy nested eventObject
+    const ev = new event.Event()
+    ev.buildFromJSON(doc)
 
     const users = await ev.getAttendingUsers()
     return res.status(200).json({ message: 'Success', users })
@@ -336,6 +348,168 @@ router.post('/fetchEventsByCenter', async (req, res) => {
     return res.status(200).json({ message: 'Success', events: events })
   } catch (err) {
     console.error('Fetch events by center error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+// Center membership routes
+router.post('/joinCenter', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { centerID } = req.body
+    if (!centerID) {
+      return res.status(400).json({ message: 'centerID is required' })
+    }
+    const exists = await authMethods.centerIDExists(centerID)
+    if (!exists) {
+      return res.status(404).json({ message: 'Center not found' })
+    }
+    const userData = await db.getUserById(req.user.id)
+    if (!userData) {
+      return res.status(404).json({ message: 'User not found' })
+    }
+    const memberships = userData.centerMemberships || []
+    if (memberships.includes(centerID)) {
+      return res.status(200).json({ message: 'Already a member' })
+    }
+    memberships.push(centerID)
+    await db.updateUser(req.user.id, { centerMemberships: memberships })
+    // Increment memberCount on the center
+    const centerData = await db.getCenterById(centerID)
+    if (centerData) {
+      await db.updateCenter(centerID, { memberCount: (centerData.memberCount || 0) + 1 })
+    }
+    return res.status(200).json({ message: 'Joined center successfully' })
+  } catch (err) {
+    console.error('Join center error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+router.post('/leaveCenter', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { centerID } = req.body
+    if (!centerID) {
+      return res.status(400).json({ message: 'centerID is required' })
+    }
+    const userData = await db.getUserById(req.user.id)
+    if (!userData) {
+      return res.status(404).json({ message: 'User not found' })
+    }
+    const memberships = (userData.centerMemberships || []).filter(id => id !== centerID)
+    await db.updateUser(req.user.id, { centerMemberships: memberships })
+    // Decrement memberCount on the center
+    const centerData = await db.getCenterById(centerID)
+    if (centerData) {
+      await db.updateCenter(centerID, { memberCount: Math.max(0, (centerData.memberCount || 0) - 1) })
+    }
+    return res.status(200).json({ message: 'Left center successfully' })
+  } catch (err) {
+    console.error('Leave center error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+// Message routes
+router.post('/addMessage', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { eventID, text, image } = req.body
+    if (!eventID || !text) {
+      return res.status(400).json({ message: 'eventID and text are required' })
+    }
+    const result = await db.createMessage({
+      eventID,
+      authorUsername: req.user.username,
+      text,
+      image: image || null,
+    })
+    if (result.success) {
+      return res.status(201).json({ message: 'Message created', messageID: result.messageID })
+    }
+    return res.status(500).json({ message: 'Failed to create message' })
+  } catch (err) {
+    console.error('Add message error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+router.post('/fetchEventMessages', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { eventID } = req.body
+    if (!eventID) {
+      return res.status(400).json({ message: 'eventID is required' })
+    }
+    const messages = await db.getMessagesByEventId(eventID)
+    return res.status(200).json({ message: 'Success', messages })
+  } catch (err) {
+    console.error('Fetch messages error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+router.post('/deleteMessage', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { messageID } = req.body
+    if (!messageID) {
+      return res.status(400).json({ message: 'messageID is required' })
+    }
+    const msg = await db.getMessageById(messageID)
+    if (!msg) {
+      return res.status(404).json({ message: 'Message not found' })
+    }
+    // Only author or admin may delete
+    if (msg.authorUsername !== req.user.username && !authMethods.isUserAdmin(req)) {
+      return res.status(403).json({ message: 'Forbidden' })
+    }
+    const result = await db.deleteMessage(messageID)
+    if (result.success) {
+      return res.status(200).json({ message: 'Message deleted' })
+    }
+    return res.status(500).json({ message: 'Failed to delete message' })
+  } catch (err) {
+    console.error('Delete message error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+// All events (for discover feed)
+router.get('/events', async (req, res) => {
+  try {
+    const events = await db.getAllEvents()
+    return res.status(200).json({ events })
+  } catch (err) {
+    console.error('Get all events error:', err)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+})
+
+// Toggle event attendance (add or remove current user)
+router.post('/attendEvent', authMethods.isAuthenticated, async (req, res) => {
+  try {
+    const { eventID } = req.body
+    if (!eventID) return res.status(400).json({ message: 'eventID is required' })
+
+    const doc = await db.getEventById(String(eventID))
+    if (!doc) return res.status(404).json({ message: 'Event not found' })
+
+    const username = req.user.username
+    const usersAttending = doc.usersAttending || []
+    const isAttending = usersAttending.includes(username)
+    const newUsersAttending = isAttending
+      ? usersAttending.filter((u) => u !== username)
+      : [...usersAttending, username]
+
+    await db.updateEvent(String(eventID), {
+      usersAttending: newUsersAttending,
+      peopleAttending: newUsersAttending.length,
+    })
+
+    return res.status(200).json({
+      message: isAttending ? 'Unregistered' : 'Registered',
+      isRegistered: !isAttending,
+      usersAttending: newUsersAttending,
+    })
+  } catch (err) {
+    console.error('Attend event error:', err)
     return res.status(500).json({ message: 'Internal server error' })
   }
 })

--- a/packages/backend/scripts/create-local-tables.js
+++ b/packages/backend/scripts/create-local-tables.js
@@ -1,0 +1,120 @@
+/**
+ * create-local-tables.js
+ *
+ * One-time script to create all DynamoDB tables in a local DynamoDB instance.
+ * Run this after starting DynamoDB Local:
+ *
+ *   docker run -p 8000:8000 amazon/dynamodb-local
+ *   node -r dotenv/config packages/backend/scripts/create-local-tables.js dotenv_config_path=packages/backend/.env.local
+ *
+ * Or from the backend directory:
+ *   node -r dotenv/config scripts/create-local-tables.js dotenv_config_path=.env.local
+ */
+
+import { DynamoDBClient, CreateTableCommand, ListTablesCommand } from '@aws-sdk/client-dynamodb'
+
+const endpoint = process.env.DYNAMODB_ENDPOINT || 'http://localhost:8000'
+const region = process.env.AWS_REGION || 'us-east-1'
+
+const client = new DynamoDBClient({
+  region,
+  endpoint,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'local',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'local',
+  },
+})
+
+const USERS_TABLE = process.env.USERS_TABLE || 'ChinmayaJanata-Users'
+const CENTERS_TABLE = process.env.CENTERS_TABLE || 'ChinmayaJanata-Centers'
+const EVENTS_TABLE = process.env.EVENTS_TABLE || 'ChinmayaJanata-Events'
+const MESSAGES_TABLE = process.env.MESSAGES_TABLE || 'ChinmayaJanata-Messages'
+
+const tableDefinitions = [
+  {
+    TableName: USERS_TABLE,
+    KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+    AttributeDefinitions: [
+      { AttributeName: 'id', AttributeType: 'S' },
+      { AttributeName: 'username', AttributeType: 'S' },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: 'username-index',
+        KeySchema: [{ AttributeName: 'username', KeyType: 'HASH' }],
+        Projection: { ProjectionType: 'ALL' },
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      },
+    ],
+    BillingMode: 'PROVISIONED',
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+  {
+    TableName: CENTERS_TABLE,
+    KeySchema: [{ AttributeName: 'centerID', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'centerID', AttributeType: 'S' }],
+    BillingMode: 'PROVISIONED',
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+  {
+    TableName: EVENTS_TABLE,
+    KeySchema: [{ AttributeName: 'eventID', KeyType: 'HASH' }],
+    AttributeDefinitions: [
+      { AttributeName: 'eventID', AttributeType: 'S' },
+      { AttributeName: 'centerID', AttributeType: 'S' },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: 'centerID-index',
+        KeySchema: [{ AttributeName: 'centerID', KeyType: 'HASH' }],
+        Projection: { ProjectionType: 'ALL' },
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      },
+    ],
+    BillingMode: 'PROVISIONED',
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+  {
+    TableName: MESSAGES_TABLE,
+    KeySchema: [{ AttributeName: 'messageID', KeyType: 'HASH' }],
+    AttributeDefinitions: [
+      { AttributeName: 'messageID', AttributeType: 'S' },
+      { AttributeName: 'eventID', AttributeType: 'S' },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: 'eventID-index',
+        KeySchema: [{ AttributeName: 'eventID', KeyType: 'HASH' }],
+        Projection: { ProjectionType: 'ALL' },
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      },
+    ],
+    BillingMode: 'PROVISIONED',
+    ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+  },
+]
+
+async function main() {
+  console.log(`Connecting to DynamoDB at ${endpoint}`)
+
+  // List existing tables
+  const existing = await client.send(new ListTablesCommand({}))
+  const existingNames = new Set(existing.TableNames || [])
+
+  for (const def of tableDefinitions) {
+    if (existingNames.has(def.TableName)) {
+      console.log(`  SKIP  ${def.TableName} (already exists)`)
+      continue
+    }
+    try {
+      await client.send(new CreateTableCommand(def))
+      console.log(`  OK    ${def.TableName}`)
+    } catch (err) {
+      console.error(`  FAIL  ${def.TableName}:`, err.message)
+    }
+  }
+
+  console.log('Done.')
+}
+
+main().catch(console.error)

--- a/packages/backend/scripts/migrate-flatten.js
+++ b/packages/backend/scripts/migrate-flatten.js
@@ -1,0 +1,223 @@
+/**
+ * migrate-flatten.js
+ *
+ * One-time migration script to flatten all nested userObject / centerObject / eventObject
+ * fields into top-level DynamoDB attributes.
+ *
+ * Run against LOCAL tables first to verify, then against prod:
+ *
+ *   # Local:
+ *   node -r dotenv/config scripts/migrate-flatten.js dotenv_config_path=.env.local
+ *
+ *   # Prod (real AWS): set real env vars and run without DYNAMODB_ENDPOINT
+ *
+ * Safe to run multiple times — skips records that are already flat.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb'
+
+const clientConfig = {
+  region: process.env.AWS_REGION || 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'local',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'local',
+  },
+}
+if (process.env.DYNAMODB_ENDPOINT) {
+  clientConfig.endpoint = process.env.DYNAMODB_ENDPOINT
+}
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient(clientConfig), {
+  marshallOptions: { removeUndefinedValues: true, convertEmptyValues: false },
+})
+
+const USERS_TABLE = process.env.USERS_TABLE || 'ChinmayaJanata-Users'
+const CENTERS_TABLE = process.env.CENTERS_TABLE || 'ChinmayaJanata-Centers'
+const EVENTS_TABLE = process.env.EVENTS_TABLE || 'ChinmayaJanata-Events'
+
+async function scanAll(tableName) {
+  const items = []
+  let lastKey
+  do {
+    const result = await docClient.send(new ScanCommand({
+      TableName: tableName,
+      ExclusiveStartKey: lastKey,
+    }))
+    items.push(...(result.Items || []))
+    lastKey = result.LastEvaluatedKey
+  } while (lastKey)
+  return items
+}
+
+async function updateItem(tableName, key, updates, removeKeys) {
+  const setExprs = []
+  const removeExprs = []
+  const names = {}
+  const values = {}
+
+  Object.entries(updates).forEach(([k, v], i) => {
+    names[`#f${i}`] = k
+    values[`:v${i}`] = v
+    setExprs.push(`#f${i} = :v${i}`)
+  })
+
+  removeKeys.forEach((k, i) => {
+    names[`#r${i}`] = k
+    removeExprs.push(`#r${i}`)
+  })
+
+  let expr = ''
+  if (setExprs.length > 0) expr += `SET ${setExprs.join(', ')} `
+  if (removeExprs.length > 0) expr += `REMOVE ${removeExprs.join(', ')}`
+
+  await docClient.send(new UpdateCommand({
+    TableName: tableName,
+    Key: key,
+    UpdateExpression: expr.trim(),
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: Object.keys(values).length > 0 ? values : undefined,
+  }))
+}
+
+async function migrateUsers() {
+  console.log('\n--- Migrating Users ---')
+  const users = await scanAll(USERS_TABLE)
+  let migrated = 0
+
+  for (const user of users) {
+    if (!user.userObject) {
+      continue // Already flat
+    }
+    const obj = user.userObject
+    const updates = {}
+
+    // Rename profilePictureURL -> profileImage
+    if (obj.profilePictureURL !== undefined && !user.profileImage) {
+      updates.profileImage = obj.profilePictureURL
+    }
+    // Rename center -> centerID
+    if (obj.center !== undefined && !user.centerID) {
+      updates.centerID = obj.center
+    }
+    // Flatten remaining fields (skip already-set top-level ones)
+    const fieldMap = {
+      username: 'username', firstName: 'firstName', lastName: 'lastName',
+      dateOfBirth: 'dateOfBirth', points: 'points', isVerified: 'isVerified',
+      verificationLevel: 'verificationLevel', exists: 'exists', isActive: 'isActive',
+      id: 'id', events: 'events',
+    }
+    for (const [src, dst] of Object.entries(fieldMap)) {
+      if (obj[src] !== undefined && user[dst] === undefined) {
+        updates[dst] = obj[src]
+      }
+    }
+    // Add new fields with defaults if missing
+    if (user.centerMemberships === undefined) updates.centerMemberships = []
+    if (user.email === undefined && !updates.email) updates.email = ''
+    if (user.profileComplete === undefined) updates.profileComplete = false
+    if (user.phoneNumber === undefined) updates.phoneNumber = ''
+    if (user.interests === undefined) updates.interests = []
+    if (user.bio === undefined) updates.bio = ''
+
+    await updateItem(USERS_TABLE, { id: user.id }, updates, ['userObject'])
+    console.log(`  Migrated user: ${user.id} (${user.username || ''})`)
+    migrated++
+  }
+  console.log(`  Done. ${migrated} records migrated, ${users.length - migrated} already flat.`)
+}
+
+async function migrateCenters() {
+  console.log('\n--- Migrating Centers ---')
+  const centers = await scanAll(CENTERS_TABLE)
+  let migrated = 0
+
+  for (const center of centers) {
+    if (!center.centerObject) {
+      continue // Already flat
+    }
+    const obj = center.centerObject
+    const updates = {}
+
+    const fields = ['location', 'name', 'centerID', 'memberCount', 'isVerified']
+    for (const f of fields) {
+      if (obj[f] !== undefined && center[f] === undefined) {
+        updates[f] = obj[f]
+      }
+    }
+    // Add new fields with defaults if missing
+    if (center.address === undefined) updates.address = ''
+    if (center.website === undefined) updates.website = ''
+    if (center.phone === undefined) updates.phone = ''
+    if (center.image === undefined) updates.image = ''
+    if (center.pointOfContact === undefined) updates.pointOfContact = ''
+    if (center.acharya === undefined) updates.acharya = ''
+
+    await updateItem(CENTERS_TABLE, { centerID: center.centerID }, updates, ['centerObject'])
+    console.log(`  Migrated center: ${center.centerID}`)
+    migrated++
+  }
+  console.log(`  Done. ${migrated} records migrated, ${centers.length - migrated} already flat.`)
+}
+
+async function migrateEvents() {
+  console.log('\n--- Migrating Events ---')
+  const events = await scanAll(EVENTS_TABLE)
+  let migrated = 0
+
+  for (const evt of events) {
+    if (!evt.eventObject) {
+      continue // Already flat
+    }
+    const obj = evt.eventObject
+    const updates = {}
+
+    const fields = [
+      'location', 'date', 'endorsers', 'id', 'tier',
+      'peopleAttending', 'usersAttending', 'description',
+    ]
+    for (const f of fields) {
+      if (obj[f] !== undefined && evt[f] === undefined) {
+        updates[f] = obj[f]
+      }
+    }
+    // Normalize center: extract centerID from embedded object if not already a top-level string
+    if (!evt.centerID) {
+      if (obj.center && typeof obj.center === 'object' && obj.center.centerID) {
+        updates.centerID = obj.center.centerID
+      } else if (obj.center && typeof obj.center === 'string') {
+        updates.centerID = obj.center
+      }
+    }
+    // Add new fields with defaults if missing
+    if (evt.title === undefined) updates.title = ''
+    if (evt.address === undefined) updates.address = ''
+    if (evt.pointOfContact === undefined) updates.pointOfContact = ''
+    if (evt.image === undefined) updates.image = ''
+    if (evt.endDate === undefined) updates.endDate = null
+
+    await updateItem(EVENTS_TABLE, { eventID: evt.eventID }, updates, ['eventObject'])
+    console.log(`  Migrated event: ${evt.eventID}`)
+    migrated++
+  }
+  console.log(`  Done. ${migrated} records migrated, ${events.length - migrated} already flat.`)
+}
+
+async function main() {
+  console.log('Starting migration...')
+  console.log('Tables:', USERS_TABLE, CENTERS_TABLE, EVENTS_TABLE)
+  if (process.env.DYNAMODB_ENDPOINT) {
+    console.log('Endpoint:', process.env.DYNAMODB_ENDPOINT)
+  }
+
+  await migrateUsers()
+  await migrateCenters()
+  await migrateEvents()
+
+  console.log('\nMigration complete.')
+}
+
+main().catch(err => {
+  console.error('Migration failed:', err)
+  process.exit(1)
+})

--- a/packages/backend/scripts/seed-local-data.js
+++ b/packages/backend/scripts/seed-local-data.js
@@ -1,0 +1,443 @@
+/**
+ * seed-local-data.js
+ *
+ * Populates the local DynamoDB instance with realistic dummy data for
+ * development and testing. Safe to run multiple times — skips resources
+ * that already exist.
+ *
+ * Prerequisites:
+ *   1. docker run -p 8000:8000 amazon/dynamodb-local
+ *   2. node --env-file=.env.local ... scripts/create-local-tables.js
+ *   3. Backend running on port 8008 (node --env-file=.env.local centralSequence.js)
+ *
+ * Run:
+ *   node --env-file=packages/backend/.env.local \
+ *     --experimental-vm-modules \
+ *     packages/backend/scripts/seed-local-data.js
+ */
+
+const BASE = 'http://localhost:8008/api'
+
+async function post(path, body, token) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  return res.json()
+}
+
+// ── Users ──────────────────────────────────────────────────────────────────
+
+const USERS = [
+  {
+    username: 'arjun_sharma',
+    password: 'Chinmaya@1',
+    onboarding: {
+      firstName: 'Arjun',
+      lastName: 'Sharma',
+      dateOfBirth: '1988-04-12',
+      phoneNumber: '408-555-1001',
+      interests: ['Bhagavad Gita', 'Meditation', 'Vedanta'],
+      bio: 'Software engineer by day, Gita student by night.',
+      profileImage: 'https://i.pravatar.cc/150?u=arjun',
+    },
+  },
+  {
+    username: 'priya_nair',
+    password: 'Chinmaya@1',
+    onboarding: {
+      firstName: 'Priya',
+      lastName: 'Nair',
+      dateOfBirth: '1993-08-22',
+      phoneNumber: '415-555-2002',
+      interests: ['Bhajans', 'Seva', 'Bala Vihar'],
+      bio: "Devoted to Swamiji's teachings. Bala Vihar teacher.",
+      profileImage: 'https://i.pravatar.cc/150?u=priya',
+    },
+  },
+  {
+    username: 'ravi_krishna',
+    password: 'Chinmaya@1',
+    onboarding: {
+      firstName: 'Ravi',
+      lastName: 'Krishnaswamy',
+      dateOfBirth: '1975-02-14',
+      phoneNumber: '619-555-3003',
+      interests: ['Upanishads', 'Yoga', 'Bhagavatam'],
+      bio: 'Retired teacher. Volunteer at Chinmaya Mission San Diego.',
+      profileImage: 'https://i.pravatar.cc/150?u=ravi',
+    },
+  },
+  {
+    username: 'meera_patel',
+    password: 'Chinmaya@1',
+    onboarding: {
+      firstName: 'Meera',
+      lastName: 'Patel',
+      dateOfBirth: '2000-11-05',
+      phoneNumber: '212-555-4004',
+      interests: ['Devotional Music', 'Vedic Chanting', 'CHYK'],
+      bio: 'CHYK member exploring Vedanta. Love kirtan.',
+      profileImage: 'https://i.pravatar.cc/150?u=meera',
+    },
+  },
+  {
+    username: 'dev_kapoor',
+    password: 'Chinmaya@1',
+    onboarding: {
+      firstName: 'Dev',
+      lastName: 'Kapoor',
+      dateOfBirth: '1965-07-30',
+      phoneNumber: '512-555-5005',
+      interests: ['Karma Yoga', 'Community Service', 'Discourse'],
+      bio: 'Long-time devotee. Center coordinator at Austin.',
+      profileImage: 'https://i.pravatar.cc/150?u=dev',
+    },
+  },
+]
+
+// ── Centers ────────────────────────────────────────────────────────────────
+
+const CENTERS = [
+  {
+    centerName: 'Chinmaya Mission San Jose',
+    latitude: 37.3382,
+    longitude: -121.8863,
+    address: '1 Prem Sagar Lane, San Jose, CA 95129',
+    website: 'https://chinmayasj.org',
+    phone: '408-255-8383',
+    image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
+    pointOfContact: 'Swami Shantananda',
+    acharya: 'Swami Shantananda',
+  },
+  {
+    centerName: 'Chinmaya Mission San Diego',
+    latitude: 32.7157,
+    longitude: -117.1611,
+    address: '8820 Mast Blvd, Santee, CA 92071',
+    website: 'https://chinmayasd.org',
+    phone: '619-448-2465',
+    image: 'https://images.unsplash.com/photo-1570129477492-45c003edd2be?w=800',
+    pointOfContact: 'Br. Ramananda',
+    acharya: 'Swami Sarveshananda',
+  },
+  {
+    centerName: 'Chinmaya Mission Chicago',
+    latitude: 41.8781,
+    longitude: -87.6298,
+    address: '16W673 Mockingbird Ln, Willowbrook, IL 60527',
+    website: 'https://chinmayachicago.org',
+    phone: '630-920-0003',
+    image: 'https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=800',
+    pointOfContact: 'Swami Ishwarananda',
+    acharya: 'Swami Ishwarananda',
+  },
+  {
+    centerName: 'Chinmaya Mission New York',
+    latitude: 40.7128,
+    longitude: -74.006,
+    address: '306 Centerport Rd, Centerport, NY 11721',
+    website: 'https://chinmayany.org',
+    phone: '631-385-2190',
+    image: 'https://images.unsplash.com/photo-1500916434205-0c77489c6cf7?w=800',
+    pointOfContact: 'Swami Sarvananda',
+    acharya: 'Swami Sarvananda',
+  },
+  {
+    centerName: 'Chinmaya Mission Austin',
+    latitude: 30.2672,
+    longitude: -97.7431,
+    address: '1234 Vedanta Dr, Austin, TX 78701',
+    website: 'https://chinmayaaustin.org',
+    phone: '512-555-8800',
+    image: 'https://images.unsplash.com/photo-1531218150217-54595bc2b934?w=800',
+    pointOfContact: 'Dev Kapoor',
+    acharya: 'Swami Bodhananda',
+  },
+]
+
+// ── Events (defined after centers are created, centerID filled in) ──────────
+
+function buildEvents(centers) {
+  const sj = centers['Chinmaya Mission San Jose']
+  const sd = centers['Chinmaya Mission San Diego']
+  const chi = centers['Chinmaya Mission Chicago']
+  const ny = centers['Chinmaya Mission New York']
+  const aus = centers['Chinmaya Mission Austin']
+
+  const now = new Date()
+  const d = (offsetDays, h = 9) => {
+    const dt = new Date(now)
+    dt.setDate(dt.getDate() + offsetDays)
+    dt.setHours(h, 0, 0, 0)
+    return dt.toISOString()
+  }
+
+  return [
+    // San Jose
+    {
+      centerID: sj,
+      title: 'Bhagavad Gita Study Circle',
+      description:
+        "Weekly verse-by-verse study of the Bhagavad Gita with commentary based on Swami Chinmayananda's teachings. All levels welcome.",
+      date: d(3, 19),
+      endDate: d(3, 21),
+      latitude: 37.3382, longitude: -121.8863,
+      address: '1 Prem Sagar Lane, San Jose, CA 95129',
+      pointOfContact: 'Arjun Sharma',
+      image: 'https://images.unsplash.com/photo-1548610435-4b73a7a07bde?w=800',
+    },
+    {
+      centerID: sj,
+      title: 'Weekend Silent Retreat',
+      description:
+        'A two-day retreat focusing on meditation, yoga, and Vedantic inquiry. Meals and accommodation included. Limited spots.',
+      date: d(14, 8),
+      endDate: d(16, 17),
+      latitude: 37.4, longitude: -122.1,
+      address: '450 Retreat Way, Los Altos Hills, CA 94022',
+      pointOfContact: 'Swami Shantananda',
+      image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
+    },
+    {
+      centerID: sj,
+      title: 'Bala Vihar — Spring Semester',
+      description:
+        'Monthly Bala Vihar class for children ages 5–12. Students learn slokas, stories from the Mahabharata, and values-based activities.',
+      date: d(7, 10),
+      endDate: d(7, 12),
+      latitude: 37.3382, longitude: -121.8863,
+      address: '1 Prem Sagar Lane, San Jose, CA 95129',
+      pointOfContact: 'Priya Nair',
+      image: 'https://images.unsplash.com/photo-1503676260728-1c00da094a0b?w=800',
+    },
+    // San Diego
+    {
+      centerID: sd,
+      title: 'Srimad Bhagavatam Discourse',
+      description:
+        "Evening discourse on the Srimad Bhagavatam — stories of Lord Vishnu's avatars and their deeper significance for spiritual seekers.",
+      date: d(5, 18),
+      endDate: d(5, 20),
+      latitude: 32.7157, longitude: -117.1611,
+      address: '8820 Mast Blvd, Santee, CA 92071',
+      pointOfContact: 'Ravi Krishnaswamy',
+      image: 'https://images.unsplash.com/photo-1621609764180-2ca554a9d6f2?w=800',
+    },
+    {
+      centerID: sd,
+      title: 'Yoga & Pranayama Workshop',
+      description:
+        'Half-day workshop on classical yoga asanas and pranayama breathing techniques, rooted in the Hatha Yoga Pradipika.',
+      date: d(10, 7),
+      endDate: d(10, 12),
+      latitude: 32.7157, longitude: -117.1611,
+      address: '8820 Mast Blvd, Santee, CA 92071',
+      pointOfContact: 'Ravi Krishnaswamy',
+      image: 'https://images.unsplash.com/photo-1544367567-0f2fcb009e0b?w=800',
+    },
+    // Chicago
+    {
+      centerID: chi,
+      title: 'Annual Vedanta Camp',
+      description:
+        'Five-day residential camp with morning discourses, workshops, and evening bhajans. Theme: "Karma Yoga — The Path of Action".',
+      date: d(21, 7),
+      endDate: d(26, 21),
+      latitude: 42.1, longitude: -88.0,
+      address: '450 Camp Vedanta Rd, Lake Geneva, WI 53147',
+      pointOfContact: 'Swami Ishwarananda',
+      image: 'https://images.unsplash.com/photo-1519331379826-f10be5486c6f?w=800',
+    },
+    {
+      centerID: chi,
+      title: 'Thursday Satsang & Bhajans',
+      description:
+        'Weekly satsang: 30 minutes of communal bhajans followed by a short Vedanta talk and Q&A. Prasad served afterward.',
+      date: d(2, 19),
+      endDate: d(2, 21),
+      latitude: 41.8781, longitude: -87.6298,
+      address: '16W673 Mockingbird Ln, Willowbrook, IL 60527',
+      pointOfContact: 'Swami Ishwarananda',
+      image: 'https://images.unsplash.com/photo-1520637836862-4d197d17c93a?w=800',
+    },
+    // New York
+    {
+      centerID: ny,
+      title: 'Diwali Celebration & Lakshmi Puja',
+      description:
+        'Grand Diwali celebration with Lakshmi Puja, cultural performances, and community dinner. All are welcome.',
+      date: d(30, 17),
+      endDate: d(30, 22),
+      latitude: 40.7128, longitude: -74.006,
+      address: '306 Centerport Rd, Centerport, NY 11721',
+      pointOfContact: 'Meera Patel',
+      image: 'https://images.unsplash.com/photo-1605870445919-838d190e8e1b?w=800',
+    },
+    {
+      centerID: ny,
+      title: 'CHYK Youth Retreat',
+      description:
+        'Chinmaya Yuva Kendra retreat for young adults 18–35. Focus on Vedanta for modern life — career, relationships, purpose.',
+      date: d(18, 8),
+      endDate: d(19, 18),
+      latitude: 41.0, longitude: -74.3,
+      address: '789 Retreat Lane, Mahwah, NJ 07430',
+      pointOfContact: 'Meera Patel',
+      image: 'https://images.unsplash.com/photo-1529156069898-49953e39b3ac?w=800',
+    },
+    // Austin
+    {
+      centerID: aus,
+      title: 'Upanishad Study Group',
+      description:
+        'Bi-weekly study of the Mandukya Upanishad with Gaudapada Karika. Text and commentary provided.',
+      date: d(4, 18),
+      endDate: d(4, 20),
+      latitude: 30.2672, longitude: -97.7431,
+      address: '1234 Vedanta Dr, Austin, TX 78701',
+      pointOfContact: 'Dev Kapoor',
+      image: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800',
+    },
+  ]
+}
+
+// ── Messages (eventTitle → array of {author, text}) ─────────────────────────
+
+const MESSAGES = {
+  'Bhagavad Gita Study Circle': [
+    { author: 'priya_nair', text: 'Looking forward to Chapter 3 this week. Karma Yoga is so relevant to daily life.' },
+    { author: 'ravi_krishna', text: 'Does anyone have the Swami Chinmayananda commentary PDF? Happy to share mine.' },
+    { author: 'arjun_sharma', text: "I'll bring printed copies for everyone. See you Thursday!" },
+  ],
+  'Weekend Silent Retreat': [
+    { author: 'meera_patel', text: "Is there a carpool being organized from San Jose? I don't have a car." },
+    { author: 'arjun_sharma', text: "Yes! I have 2 seats. DM me your location and I'll pick you up." },
+    { author: 'priya_nair', text: 'Please bring warm layers — the hills get cold at night.' },
+  ],
+  'Srimad Bhagavatam Discourse': [
+    { author: 'ravi_krishna', text: 'Tonight we cover the story of Prahlad. One of my favorites in the Bhagavatam.' },
+    { author: 'dev_kapoor', text: "Swamiji's explanation of Narasimha avatara last week was incredible. Looking forward to this." },
+  ],
+  'Thursday Satsang & Bhajans': [
+    { author: 'meera_patel', text: "Can we sing Hare Rama tonight? It's been a while." },
+    { author: 'priya_nair', text: "Yes please! I'll bring my tabla." },
+    { author: 'dev_kapoor', text: 'Prasad is sponsored by the Kapoor family this week. 🙏' },
+  ],
+  'Diwali Celebration & Lakshmi Puja': [
+    { author: 'meera_patel', text: 'So excited for this. NYC Diwali is always magical.' },
+    { author: 'arjun_sharma', text: "We're driving up from NJ. Can't wait." },
+    { author: 'ravi_krishna', text: 'Will there be a fireworks display this year?' },
+    { author: 'priya_nair', text: 'Please sign up for prasad prep on the shared doc!' },
+  ],
+  'CHYK Youth Retreat': [
+    { author: 'meera_patel', text: "The theme this year sounds perfect. I've been wrestling with career decisions." },
+    { author: 'dev_kapoor', text: "Swamiji's talk on Karma Yoga and work-life balance changed my perspective. Highly recommend." },
+  ],
+}
+
+// ── Membership (username → centerNames to join) ─────────────────────────────
+
+const MEMBERSHIPS = {
+  arjun_sharma: ['Chinmaya Mission San Jose'],
+  priya_nair:   ['Chinmaya Mission San Jose', 'Chinmaya Mission Chicago'],
+  ravi_krishna: ['Chinmaya Mission San Diego'],
+  meera_patel:  ['Chinmaya Mission New York', 'Chinmaya Mission Chicago'],
+  dev_kapoor:   ['Chinmaya Mission Austin'],
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('\n🌸  Seeding local database...\n')
+
+  // 1. Register + onboard users
+  const tokens = {}
+  console.log('── Users ─────────────────────────────')
+  for (const u of USERS) {
+    // Try register (may already exist)
+    await post('/auth/register', { username: u.username, password: u.password })
+    const authResp = await post('/auth/authenticate', { username: u.username, password: u.password })
+    if (!authResp.token) {
+      console.error(`  ✗ Could not authenticate ${u.username}`)
+      continue
+    }
+    tokens[u.username] = authResp.token
+
+    // Complete onboarding
+    await post('/auth/complete-onboarding', { ...u.onboarding, profileComplete: true }, authResp.token)
+    console.log(`  ✓ ${u.username} (${u.onboarding.firstName} ${u.onboarding.lastName})`)
+  }
+
+  // 2. Create centers
+  const centerIDs = {}  // name → UUID
+  console.log('\n── Centers ───────────────────────────')
+  for (const c of CENTERS) {
+    const r = await post('/addCenter', c)
+    if (r.id) {
+      centerIDs[c.centerName] = r.id
+      console.log(`  ✓ ${c.centerName} → ${r.id}`)
+    } else {
+      console.error(`  ✗ Failed to create ${c.centerName}:`, JSON.stringify(r))
+    }
+  }
+
+  // 3. Join centers
+  console.log('\n── Memberships ───────────────────────')
+  for (const [uname, centerNames] of Object.entries(MEMBERSHIPS)) {
+    const token = tokens[uname]
+    if (!token) continue
+    for (const cname of centerNames) {
+      const cid = centerIDs[cname]
+      if (!cid) continue
+      const r = await post('/joinCenter', { centerID: cid }, token)
+      console.log(`  ✓ ${uname} joined ${cname}`)
+    }
+  }
+
+  // 4. Create events
+  const eventIDs = {}  // title → id
+  const events = buildEvents(centerIDs)
+  console.log('\n── Events ────────────────────────────')
+  for (const ev of events) {
+    if (!ev.centerID) {
+      console.log(`  ✗ Skipping "${ev.title}" — center not found`)
+      continue
+    }
+    const r = await post('/addevent', ev)
+    if (r.id) {
+      eventIDs[ev.title] = r.id
+      console.log(`  ✓ ${ev.title}`)
+    } else {
+      console.error(`  ✗ Failed "${ev.title}":`, JSON.stringify(r))
+    }
+  }
+
+  // 5. Add messages
+  console.log('\n── Messages ──────────────────────────')
+  for (const [eventTitle, msgs] of Object.entries(MESSAGES)) {
+    const eid = eventIDs[eventTitle]
+    if (!eid) {
+      console.log(`  ✗ No event ID for "${eventTitle}" — skipping messages`)
+      continue
+    }
+    for (const msg of msgs) {
+      const token = tokens[msg.author]
+      if (!token) continue
+      await post('/addMessage', { eventID: String(eid), text: msg.text }, token)
+    }
+    console.log(`  ✓ ${msgs.length} messages → ${eventTitle}`)
+  }
+
+  console.log('\n✅  Seed complete.\n')
+  console.log(`   ${USERS.length} users | ${CENTERS.length} centers | ${events.length} events`)
+  console.log(`   All users: password is "Chinmaya@1"`)
+}
+
+main().catch((err) => {
+  console.error('Seed failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Overview

This PR retires the dual-storage pattern where model classes wrapped data in nested DynamoDB attributes (`userObject`, `centerObject`, `eventObject`) while auth routes wrote fields directly at the top level. The result was silent data drift between the two write paths.

All three tables are now flat. Two new features (event messages, multi-center membership) are fully implemented on the backend.

> **Frontend compatibility PR will follow.** The frontend currently reads both flat and nested formats via fallback helpers, so it stays backward-compatible until the frontend PR lands.

---

## Changes by area

### DynamoDB schema (flat fields)

| Table | Old format | New format |
|-------|-----------|-----------|
| Users | `userObject.firstName`, `userObject.profilePictureURL` | `firstName`, `profileImage` |
| Centers | `centerObject.centerName`, `centerObject.location` | `name`, `location` |
| Events | `eventObject.title`, `eventObject.date` | `title`, `date` |

**New user fields:** `email`, `profileComplete`, `profileImage`, `phoneNumber`, `interests`, `bio`, `centerMemberships`

**New center fields:** `address`, `website`, `phone`, `image`, `pointOfContact`, `acharya`

**New event fields:** `title`, `address`, `pointOfContact`, `image`, `endDate`

### New table: `ChinmayaJanata-Messages`

- Partition key: `messageID` (UUID)
- GSI: `eventID-index` for querying messages by event

### New & changed endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/events` | No | List all events |
| `POST` | `/attendEvent` | Yes | Toggle attend/unattend (server-side, safe) |
| `POST` | `/addMessage` | Yes | Post message on an event |
| `POST` | `/fetchEventMessages` | Yes | Get messages for an event |
| `POST` | `/deleteMessage` | Yes | Delete own message |
| `POST` | `/joinCenter` | Yes | Join a center (adds to centerMemberships) |
| `POST` | `/leaveCenter` | Yes | Leave a center |
| `POST` | `/fetchAllCenters` | No | Now accepts `username`; returns `isMember` per center |
| `POST` | `/fetchCenter` | No | Now accepts `username`; returns `isMember` |

### Bug fixes

- `event.js`: `for(i in ...)` → `for (let i in ...)` (i was an implicit global)
- `event.js`: `this.endorsers.verificationLevel` → `this.endorsers[i].verificationLevel`
- `eventStorage.js`: removed leftover `eventObject` wrapper in the toJSON write path
- `user.js` `setCenter()`: `center = centerId` → `this.centerID = centerId` (was writing to a local variable, not `this`)
- `dynamoConfig.js`: respects `DYNAMODB_ENDPOINT` env var so local dev doesn't touch AWS
- CORS: added `CORS_ALLOW_NO_ORIGIN` env flag for native iOS/Android clients (they send no `Origin` header)

---

## ⚠️ Migration required before deploying

Run the scripts **in this order** against the production tables:

```bash
# 1. Set your prod AWS env vars (no DYNAMODB_ENDPOINT override)
export AWS_REGION=us-east-1
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export USERS_TABLE=ChinmayaJanata-Users
export CENTERS_TABLE=ChinmayaJanata-Centers
export EVENTS_TABLE=ChinmayaJanata-Events
export MESSAGES_TABLE=ChinmayaJanata-Messages   # create first

# 2. Create the Messages table in prod (CloudFormation / aws cli / console)
#    Key schema: messageID (S, PK), GSI: eventID-index on eventID (S)

# 3. Run the flattening migration (idempotent — skips already-flat records)
node packages/backend/scripts/migrate-flatten.js

# 4. Deploy new backend code
```

The migration is **non-destructive and idempotent** — it reads each record, flattens it, writes it back. Records that are already flat are skipped. Rollback: the old code still reads nested format, so reverting the deploy before running the migration is safe.

---

## Local dev setup

```bash
# 1. Start local DynamoDB
docker run -p 8000:8000 amazon/dynamodb-local

# 2. Create tables (one-time)
node --env-file=packages/backend/.env.local --experimental-vm-modules \
  packages/backend/scripts/create-local-tables.js

# 3. Seed test data (5 users / 5 centers / 10 events / messages)
node --env-file=packages/backend/.env.local --experimental-vm-modules \
  packages/backend/scripts/seed-local-data.js

# 4. Run backend
node --env-file=packages/backend/.env.local --experimental-vm-modules \
  packages/backend/centralSequence.js
```

All test users share password `Chinmaya@1`.

---

## Test plan

- [ ] `POST /auth/login` returns JWT for seeded users
- [ ] `GET /events` returns all events (no auth required)
- [ ] `POST /fetchAllCenters` with `username` returns `isMember: true` for joined centers
- [ ] `POST /fetchCenter` with `username` returns `isMember` correctly
- [ ] `POST /attendEvent` toggles attendance; re-calling toggles back
- [ ] `POST /addMessage` + `POST /fetchEventMessages` round-trip
- [ ] `POST /joinCenter` → `POST /leaveCenter` round-trip; `memberCount` increments/decrements
- [ ] `node scripts/migrate-flatten.js` against local tables logs each record; no nested wrappers remain after run