### PR TITLE
feat: event form as side panel with role-based access

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -10,11 +10,15 @@ import Logo from '../../components/ui/Logo'
  * TabLayout Component - The main layout for the tab-based navigation.
  * @return {JSX.Element} A TabLayout component that sets up tab navigation with theming.
  */
+const ADMIN_NAME = 'brahman'
+const isLocal = typeof window !== 'undefined' && window.location.hostname === 'localhost'
+
 export default function TabLayout() {
   const router = useRouter()
   const { user, logout } = useUser()
   const { isDark } = useThemeContext()
   const [settingsVisible, setSettingsVisible] = useState(false)
+  const canCreate = user?.username === ADMIN_NAME || isLocal
 
   const handleLogout = async () => {
     await logout()
@@ -50,16 +54,22 @@ export default function TabLayout() {
     if (Platform.OS === 'web') {
       return (
         <View className="flex-row items-center" style={{ gap: 8 }}>
-          <Pressable
-            className="px-3 py-2 rounded-lg flex-row items-center"
-            style={{ backgroundColor: '#E8862A', gap: 6 }}
-            onPress={() => router.push('/events/form')}
-          >
-            <Plus size={16} color="#fff" />
-            <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#fff' }}>
-              Create Event
-            </Text>
-          </Pressable>
+          {canCreate && (
+            <Pressable
+              className="px-3 py-2 rounded-lg flex-row items-center"
+              style={{ backgroundColor: '#E8862A', gap: 6 }}
+              onPress={() => {
+                if (typeof window !== 'undefined') {
+                  window.dispatchEvent(new CustomEvent('open-event-form'))
+                }
+              }}
+            >
+              <Plus size={16} color="#fff" />
+              <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#fff' }}>
+                Create Event
+              </Text>
+            </Pressable>
+          )}
           <Pressable
             className="mr-4 p-2 rounded-full bg-gray-200 dark:bg-gray-700"
             onPress={() => setSettingsVisible(true)}

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -22,10 +22,14 @@ import {
   type DiscoverFilter,
 } from '../../hooks/useApiData'
 import EventDetailPanel from '../../components/web/EventDetailPanel'
+import EventFormPanel from '../../components/web/EventFormPanel'
 import CenterDetailPanel from '../../components/web/CenterDetailPanel'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import type { MapPoint, EventDisplay, DiscoverCenter } from '../../utils/api'
 import { WeekCalendar } from '../../components'
+
+const ADMIN_NAME = 'brahman'
+const isLocal = typeof window !== 'undefined' && window.location.hostname === 'localhost'
 
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'All' },
@@ -176,25 +180,28 @@ function DetailPanelWrapper({
   selectedItem,
   onClose,
   onEventPress,
+  onEditEvent,
 }: {
   selectedItem: { type: 'event' | 'center'; id: string }
   onClose: () => void
   onEventPress: (id: string) => void
+  onEditEvent?: (id: string) => void
 }) {
   if (selectedItem.type === 'event') {
-    return <EventPanelInner eventId={selectedItem.id} onClose={onClose} />
+    return <EventPanelInner eventId={selectedItem.id} onClose={onClose} onEdit={onEditEvent} />
   }
   return (
     <CenterPanelInner centerId={selectedItem.id} onClose={onClose} onEventPress={onEventPress} />
   )
 }
 
-function EventPanelInner({ eventId, onClose }: { eventId: string; onClose: () => void }) {
+function EventPanelInner({ eventId, onClose, onEdit }: { eventId: string; onClose: () => void; onEdit?: (id: string) => void }) {
   const { user } = useUser()
   const { event, attendees, messages, loading, toggleRegistration, isToggling } =
     useEventDetail(eventId)
   const colors = useDetailColors()
-  const isAdmin = user?.username === 'brahman'
+  const isAdmin = user?.username === ADMIN_NAME
+  const canEdit = isAdmin || isLocal
 
   const handleToggleRegistration = async () => {
     if (!user?.username) return
@@ -235,6 +242,7 @@ function EventPanelInner({ eventId, onClose }: { eventId: string; onClose: () =>
       onClose={onClose}
       onToggleRegistration={handleToggleRegistration}
       isToggling={isToggling}
+      onEdit={canEdit ? onEdit : undefined}
     />
   )
 }
@@ -579,19 +587,29 @@ export default function DiscoverScreenWeb() {
   const router = useRouter()
   const { isDark } = useThemeContext()
   const { user } = useUser()
-  const isAdmin = user?.username === 'brahman'
+  const isAdmin = user?.username === ADMIN_NAME
+  const canCreate = isAdmin || isLocal
   const [activeFilter, setActiveFilter] = useState<DiscoverFilter>('All')
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [selectedItem, setSelectedItem] = useState<{ type: 'event' | 'center'; id: string } | null>(
     null
   )
+  // Event form panel: null = hidden, { id?: string } = open (id present = edit, absent = create)
+  const [formPanel, setFormPanel] = useState<{ id?: string } | null>(null)
   const { items, filteredPoints, loading, allEvents, allCenters } = useDiscoverData(
     activeFilter,
     searchQuery
   )
 
-  const params = useLocalSearchParams<{ detail?: string; id?: string }>()
+  const params = useLocalSearchParams<{ detail?: string; id?: string; action?: string }>()
+
+  // Clear query string without navigation
+  const clearParams = useCallback(() => {
+    if (typeof window !== 'undefined' && window.location.search) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [])
 
   // Support direct URL navigation (e.g. ?detail=event&id=123)
   useEffect(() => {
@@ -599,6 +617,14 @@ export default function DiscoverScreenWeb() {
       setSelectedItem({ type: params.detail as 'event' | 'center', id: params.id })
     }
   }, [params.detail, params.id])
+
+  // Listen for create event from header nav button
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handler = () => { setSelectedItem(null); setFormPanel({}) }
+    window.addEventListener('open-event-form', handler)
+    return () => window.removeEventListener('open-event-form', handler)
+  }, [])
 
   // Fixed 440px width for both list and detail panels — no shift on selection
   const rightPanelWidth = 440
@@ -730,12 +756,26 @@ export default function DiscoverScreenWeb() {
           )}
         </View>
 
-        {/* Right Panel — detail view or list */}
-        {selectedItem ? (
+        {/* Right Panel — form, detail view, or list */}
+        {formPanel ? (
+          <EventFormPanel
+            eventId={formPanel.id}
+            onClose={() => {
+              const editId = formPanel.id
+              setFormPanel(null)
+              if (editId) {
+                setSelectedItem({ type: 'event', id: editId })
+              } else {
+                clearParams()
+              }
+            }}
+          />
+        ) : selectedItem ? (
           <DetailPanelWrapper
             selectedItem={selectedItem}
-            onClose={() => setSelectedItem(null)}
+            onClose={() => { setSelectedItem(null); clearParams() }}
             onEventPress={(id) => setSelectedItem({ type: 'event', id })}
+            onEditEvent={(id) => { setSelectedItem(null); setFormPanel({ id }) }}
           />
         ) : (
           <View
@@ -760,9 +800,9 @@ export default function DiscoverScreenWeb() {
                     style={{ paddingVertical: 8 }}
                   />
                 </View>
-                {isAdmin && (
+                {canCreate && (
                   <Pressable
-                    onPress={() => router.push('/events/form')}
+                    onPress={() => { setSelectedItem(null); setFormPanel({}) }}
                     style={{
                       width: 40,
                       height: 40,

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -5,8 +5,6 @@ import { validateEmail, validatePassword } from '../utils'
 import PasswordStrength from '../components/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
 import DevPanel from '../components/DevPanel'
-// @ts-ignore -- __DEV__ is a React Native global
-const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const swamiChinmayanandaJpg = require('../assets/images/landing/Swami Chinmayananda.jpg')
 const swamiChinmayanandaAlt = require('../assets/images/landing/Swami Chinmayananda (1).jpg')
@@ -543,34 +541,32 @@ export default function AuthScreen() {
             By continuing, you agree to our Terms of Service and Privacy Policy
           </p>
 
-          {/* Developer Mode button -- dev only */}
-          {isDev && (
-            <button
-              onClick={() => setShowDevPanel(true)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 8,
-                backgroundColor: '#F5F5F4',
-                padding: '10px 16px',
-                borderRadius: 8,
-                border: 'none',
-                cursor: 'pointer',
-                marginTop: 24,
-                width: '100%',
-                fontSize: 14,
-                fontFamily: 'Inter, sans-serif',
-                color: '#57534E',
-              }}
-            >
-              <span style={{ fontFamily: 'monospace', fontSize: 16 }}>&lt;/&gt;</span>
-              Developer Mode
-            </button>
-          )}
+          {/* Developer Mode button */}
+          <button
+            onClick={() => setShowDevPanel(true)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              backgroundColor: '#F5F5F4',
+              padding: '10px 16px',
+              borderRadius: 8,
+              border: 'none',
+              cursor: 'pointer',
+              marginTop: 24,
+              width: '100%',
+              fontSize: 14,
+              fontFamily: 'Inter, sans-serif',
+              color: '#57534E',
+            }}
+          >
+            <span style={{ fontFamily: 'monospace', fontSize: 16 }}>&lt;/&gt;</span>
+            Developer Mode
+          </button>
 
           {/* DevPanel */}
-          {isDev && showDevPanel && (
+          {showDevPanel && (
             <DevPanel visible={showDevPanel} onClose={() => setShowDevPanel(false)} />
           )}
         </div>

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -104,6 +104,7 @@ type EventDetailPanelProps = {
   onClose: () => void
   onToggleRegistration: () => void
   isToggling: boolean
+  onEdit?: (eventId: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -170,6 +171,7 @@ function HeaderBar({
   isAdmin,
   eventId,
   onClose,
+  onEdit,
   colors,
 }: {
   title: string
@@ -178,6 +180,7 @@ function HeaderBar({
   isAdmin?: boolean
   eventId?: string
   onClose: () => void
+  onEdit?: (eventId: string) => void
   colors: DetailColors
 }) {
   return (
@@ -212,11 +215,9 @@ function HeaderBar({
         </Pressable>
 
         <View className="flex-row items-center" style={{ gap: 4 }}>
-          {eventId && (
+          {eventId && onEdit && (
             <Pressable
-              onPress={() => {
-                window.location.href = `/events/form?id=${eventId}`
-              }}
+              onPress={() => onEdit(eventId)}
               style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
               accessibilityLabel="Edit event"
             >
@@ -848,6 +849,7 @@ export default function EventDetailPanel({
   onClose,
   onToggleRegistration,
   isToggling,
+  onEdit,
 }: EventDetailPanelProps) {
   const colors = useDetailColors()
   const isRegistered = event.isRegistered && !isPast
@@ -865,7 +867,7 @@ export default function EventDetailPanel({
       }}
     >
       {/* Header */}
-      <HeaderBar title={event.title} isPast={isPast} isRegistered={isRegistered} isAdmin={isAdmin} eventId={event.id} onClose={onClose} colors={colors} />
+      <HeaderBar title={event.title} isPast={isPast} isRegistered={isRegistered} isAdmin={isAdmin} eventId={event.id} onClose={onClose} onEdit={onEdit} colors={colors} />
 
       {/* Hero image (non-registered only) */}
       {!isRegistered && (

--- a/packages/frontend/components/web/EventFormPanel.tsx
+++ b/packages/frontend/components/web/EventFormPanel.tsx
@@ -1,0 +1,665 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { View, Text, ScrollView, TextInput, Pressable, ActivityIndicator } from 'react-native'
+import {
+  ChevronLeft,
+  Calendar,
+  Clock,
+  MapPin,
+  User,
+  Tag,
+  Building2,
+  ChevronDown,
+} from 'lucide-react-native'
+import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import {
+  fetchEvent,
+  fetchCenters,
+  createEvent,
+  updateEvent,
+  type CenterData,
+} from '../../utils/api'
+
+const CATEGORY_OPTIONS = [
+  { value: undefined as number | undefined, label: 'None' },
+  { value: 91, label: 'Satsang' },
+  { value: 92, label: 'Bhiksha' },
+]
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+type EventFormPanelProps = {
+  eventId?: string
+  onClose: () => void
+  onSaved?: () => void
+}
+
+// ── Input component ──────────────────────────────────────────────────────
+
+function FormInput({
+  value,
+  onChangeText,
+  placeholder,
+  colors,
+  hasError,
+  multiline,
+  style,
+  ...rest
+}: {
+  value: string
+  onChangeText: (text: string) => void
+  placeholder: string
+  colors: DetailColors
+  hasError?: boolean
+  multiline?: boolean
+  style?: any
+  [key: string]: any
+}) {
+  return (
+    <TextInput
+      value={value}
+      onChangeText={onChangeText}
+      placeholder={placeholder}
+      placeholderTextColor={colors.textMuted}
+      multiline={multiline}
+      textAlignVertical={multiline ? 'top' : undefined}
+      style={{
+        fontFamily: 'Inter-Regular',
+        fontSize: 14,
+        color: colors.text,
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: hasError ? '#DC2626' : colors.border,
+        backgroundColor: colors.cardBg,
+        ...(multiline ? { minHeight: 100 } : {}),
+        ...style,
+      }}
+      {...rest}
+    />
+  )
+}
+
+// ── Section label ────────────────────────────────────────────────────────
+
+function SectionLabel({
+  icon: Icon,
+  label,
+  colors,
+}: {
+  icon: React.ElementType
+  label: string
+  colors: DetailColors
+}) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+      <View
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 7,
+          backgroundColor: colors.iconBoxBg,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Icon size={14} color="#E8862A" />
+      </View>
+      <Text
+        style={{
+          fontFamily: 'Inter-Medium',
+          fontSize: 11,
+          color: colors.textMuted,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────────────
+
+export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormPanelProps) {
+  const isEdit = !!eventId
+  const colors = useDetailColors()
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [centers, setCenters] = useState<CenterData[]>([])
+  const [showCenterPicker, setShowCenterPicker] = useState(false)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  // Form state
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+  const [address, setAddress] = useState('')
+  const [latitude, setLatitude] = useState('')
+  const [longitude, setLongitude] = useState('')
+  const [centerID, setCenterID] = useState('')
+  const [centerName, setCenterName] = useState('')
+  const [pointOfContact, setPointOfContact] = useState('')
+  const [image, setImage] = useState('')
+  const [category, setCategory] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    let mounted = true
+
+    const load = async () => {
+      try {
+        const allCenters = await fetchCenters()
+        if (!mounted) return
+        setCenters(allCenters)
+
+        if (isEdit && eventId) {
+          const event = await fetchEvent(eventId)
+          if (!mounted) return
+
+          if (event) {
+            setTitle(event.title || '')
+            setDescription(event.description || '')
+
+            if (event.date) {
+              const d = new Date(event.date)
+              setDate(d.toISOString().split('T')[0])
+              setTime(
+                d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+              )
+            }
+
+            setAddress(event.address || '')
+            setLatitude(String(event.latitude || ''))
+            setLongitude(String(event.longitude || ''))
+            setCenterID(event.centerID || '')
+            setPointOfContact(event.pointOfContact || '')
+            setImage(event.image || '')
+            setCategory(event.category ?? undefined)
+
+            const matchingCenter = allCenters.find((c) => c.centerID === event.centerID)
+            if (matchingCenter) setCenterName(matchingCenter.name)
+          }
+        }
+      } catch (err) {
+        if (__DEV__) console.warn('[EventFormPanel]', err)
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+
+    load()
+    return () => { mounted = false }
+  }, [eventId, isEdit])
+
+  const validate = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {}
+    if (!title.trim()) newErrors.title = 'Title is required'
+    if (!date.trim()) newErrors.date = 'Date is required'
+    if (!centerID) newErrors.center = 'Center is required'
+
+    const lat = parseFloat(latitude)
+    const lng = parseFloat(longitude)
+    if (!latitude || isNaN(lat) || lat < -90 || lat > 90) {
+      newErrors.latitude = 'Valid latitude required'
+    }
+    if (!longitude || isNaN(lng) || lng < -180 || lng > 180) {
+      newErrors.longitude = 'Valid longitude required'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }, [title, date, centerID, latitude, longitude])
+
+  const buildDateISO = (): string => {
+    if (!time.trim()) return `${date}T12:00:00`
+    const match = time.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
+    if (match) {
+      let hours = parseInt(match[1], 10)
+      const minutes = match[2]
+      const ampm = match[3].toUpperCase()
+      if (ampm === 'PM' && hours !== 12) hours += 12
+      if (ampm === 'AM' && hours === 12) hours = 0
+      return `${date}T${String(hours).padStart(2, '0')}:${minutes}:00`
+    }
+    return `${date}T12:00:00`
+  }
+
+  const handleSave = async () => {
+    if (!validate()) return
+    setSaving(true)
+
+    try {
+      if (isEdit && eventId) {
+        await updateEvent({
+          id: eventId,
+          title: title.trim(),
+          description: description.trim(),
+          date: buildDateISO(),
+          latitude: parseFloat(latitude),
+          longitude: parseFloat(longitude),
+          address: address.trim() || undefined,
+          centerID,
+          pointOfContact: pointOfContact.trim() || undefined,
+          image: image.trim() || undefined,
+          category,
+        })
+      } else {
+        await createEvent({
+          title: title.trim(),
+          description: description.trim(),
+          date: buildDateISO(),
+          latitude: parseFloat(latitude),
+          longitude: parseFloat(longitude),
+          address: address.trim() || undefined,
+          centerID,
+          pointOfContact: pointOfContact.trim() || undefined,
+          image: image.trim() || undefined,
+          category,
+        })
+      }
+      onSaved?.()
+      onClose()
+    } catch (err: any) {
+      alert(err?.message || 'Something went wrong')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const selectCenter = (center: CenterData) => {
+    setCenterID(center.centerID)
+    setCenterName(center.name)
+    if (!latitude && center.latitude) setLatitude(String(center.latitude))
+    if (!longitude && center.longitude) setLongitude(String(center.longitude))
+    if (!address && center.address) setAddress(center.address)
+    setShowCenterPicker(false)
+  }
+
+  const errorText = (key: string) =>
+    errors[key] ? (
+      <Text style={{ fontFamily: 'Inter-Regular', fontSize: 11, color: '#DC2626', marginTop: 4 }}>
+        {errors[key]}
+      </Text>
+    ) : null
+
+  // ── Loading ──────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <View
+        style={{
+          maxWidth: 440,
+          width: '100%',
+          height: '100%',
+          backgroundColor: colors.panelBg,
+          borderLeftWidth: 1,
+          borderLeftColor: colors.border,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <ActivityIndicator size="large" color="#E8862A" />
+      </View>
+    )
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────
+
+  return (
+    <View
+      style={{
+        maxWidth: 440,
+        width: '100%',
+        height: '100%',
+        backgroundColor: colors.panelBg,
+        borderLeftWidth: 1,
+        borderLeftColor: colors.border,
+        flexDirection: 'column',
+      }}
+    >
+      {/* Header */}
+      <View
+        style={{
+          paddingHorizontal: 16,
+          paddingTop: 14,
+          paddingBottom: 12,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+          gap: 10,
+        }}
+      >
+        {/* Top row: back */}
+        <View className="flex-row items-center" style={{ justifyContent: 'space-between' }}>
+          <Pressable
+            onPress={onClose}
+            className="flex-row items-center"
+            style={{ gap: 4, padding: 8, minHeight: 44, minWidth: 44 }}
+            accessibilityLabel="Close panel"
+          >
+            <ChevronLeft size={20} color={colors.iconHeader} />
+            <Text
+              style={{
+                fontFamily: 'Inter-Regular',
+                fontSize: 14,
+                color: colors.iconHeader,
+              }}
+            >
+              Back
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* Title */}
+        <Text
+          style={{
+            fontFamily: 'Inter-Bold',
+            fontSize: 20,
+            color: colors.text,
+            lineHeight: 26,
+          }}
+        >
+          {isEdit ? 'Edit Event' : 'Create Event'}
+        </Text>
+        <Text
+          style={{
+            fontFamily: 'Inter-Regular',
+            fontSize: 13,
+            color: colors.textSecondary,
+          }}
+        >
+          {isEdit ? 'Update event details below' : 'Fill in the details for your new event'}
+        </Text>
+      </View>
+
+      {/* Form body */}
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: 20, gap: 20, paddingBottom: 24 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Title */}
+        <View>
+          <SectionLabel icon={Tag} label="Title" colors={colors} />
+          <FormInput
+            value={title}
+            onChangeText={setTitle}
+            placeholder="Event title"
+            colors={colors}
+            hasError={!!errors.title}
+          />
+          {errorText('title')}
+        </View>
+
+        {/* Description */}
+        <View>
+          <SectionLabel icon={Tag} label="Description" colors={colors} />
+          <FormInput
+            value={description}
+            onChangeText={setDescription}
+            placeholder="Describe the event..."
+            colors={colors}
+            multiline
+          />
+        </View>
+
+        {/* Date & Time row */}
+        <View style={{ flexDirection: 'row', gap: 12 }}>
+          <View style={{ flex: 1 }}>
+            <SectionLabel icon={Calendar} label="Date" colors={colors} />
+            <FormInput
+              value={date}
+              onChangeText={setDate}
+              placeholder="YYYY-MM-DD"
+              colors={colors}
+              hasError={!!errors.date}
+            />
+            {errorText('date')}
+          </View>
+          <View style={{ flex: 1 }}>
+            <SectionLabel icon={Clock} label="Time" colors={colors} />
+            <FormInput
+              value={time}
+              onChangeText={setTime}
+              placeholder="e.g. 10:30 AM"
+              colors={colors}
+            />
+          </View>
+        </View>
+
+        {/* Center */}
+        <View>
+          <SectionLabel icon={Building2} label="Center" colors={colors} />
+          <Pressable
+            onPress={() => setShowCenterPicker(!showCenterPicker)}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingHorizontal: 12,
+              paddingVertical: 10,
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: errors.center ? '#DC2626' : colors.border,
+              backgroundColor: colors.cardBg,
+            }}
+          >
+            <Text
+              style={{
+                fontFamily: 'Inter-Regular',
+                fontSize: 14,
+                color: centerName ? colors.text : colors.textMuted,
+              }}
+            >
+              {centerName || 'Select a center...'}
+            </Text>
+            <ChevronDown
+              size={14}
+              color={colors.textMuted}
+              style={{ transform: [{ rotate: showCenterPicker ? '180deg' : '0deg' }] }}
+            />
+          </Pressable>
+          {errorText('center')}
+
+          {showCenterPicker && (
+            <View
+              style={{
+                marginTop: 4,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: colors.border,
+                backgroundColor: colors.cardBg,
+                maxHeight: 180,
+                overflow: 'hidden',
+              }}
+            >
+              <ScrollView nestedScrollEnabled showsVerticalScrollIndicator>
+                {centers.map((center) => (
+                  <Pressable
+                    key={center.centerID}
+                    onPress={() => selectCenter(center)}
+                    style={{
+                      paddingHorizontal: 12,
+                      paddingVertical: 10,
+                      borderBottomWidth: 1,
+                      borderBottomColor: colors.border,
+                      backgroundColor:
+                        center.centerID === centerID ? 'rgba(232,134,42,0.08)' : 'transparent',
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontFamily: center.centerID === centerID ? 'Inter-Medium' : 'Inter-Regular',
+                        fontSize: 13,
+                        color: center.centerID === centerID ? '#E8862A' : colors.text,
+                      }}
+                    >
+                      {center.name}
+                    </Text>
+                    {center.address ? (
+                      <Text
+                        style={{
+                          fontFamily: 'Inter-Regular',
+                          fontSize: 11,
+                          color: colors.textSecondary,
+                          marginTop: 1,
+                        }}
+                      >
+                        {center.address}
+                      </Text>
+                    ) : null}
+                  </Pressable>
+                ))}
+              </ScrollView>
+            </View>
+          )}
+        </View>
+
+        {/* Address */}
+        <View>
+          <SectionLabel icon={MapPin} label="Address" colors={colors} />
+          <FormInput
+            value={address}
+            onChangeText={setAddress}
+            placeholder="Event address"
+            colors={colors}
+          />
+        </View>
+
+        {/* Coordinates */}
+        <View>
+          <SectionLabel icon={MapPin} label="Coordinates" colors={colors} />
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <View style={{ flex: 1 }}>
+              <FormInput
+                value={latitude}
+                onChangeText={setLatitude}
+                placeholder="Latitude"
+                colors={colors}
+                hasError={!!errors.latitude}
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <FormInput
+                value={longitude}
+                onChangeText={setLongitude}
+                placeholder="Longitude"
+                colors={colors}
+                hasError={!!errors.longitude}
+              />
+            </View>
+          </View>
+          {errorText('latitude')}
+          {errorText('longitude')}
+        </View>
+
+        {/* Point of Contact */}
+        <View>
+          <SectionLabel icon={User} label="Point of Contact" colors={colors} />
+          <FormInput
+            value={pointOfContact}
+            onChangeText={setPointOfContact}
+            placeholder="Contact person"
+            colors={colors}
+          />
+        </View>
+
+        {/* Image URL */}
+        <View>
+          <SectionLabel icon={MapPin} label="Image URL" colors={colors} />
+          <FormInput
+            value={image}
+            onChangeText={setImage}
+            placeholder="https://..."
+            colors={colors}
+            autoCapitalize="none"
+          />
+        </View>
+
+        {/* Category */}
+        <View>
+          <SectionLabel icon={Tag} label="Category" colors={colors} />
+          <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap' }}>
+            {CATEGORY_OPTIONS.map((opt) => {
+              const selected = category === opt.value
+              return (
+                <Pressable
+                  key={opt.label}
+                  onPress={() => setCategory(opt.value)}
+                  style={{
+                    paddingHorizontal: 16,
+                    paddingVertical: 8,
+                    borderRadius: 100,
+                    backgroundColor: selected ? '#E8862A' : colors.iconBoxBg,
+                  }}
+                >
+                  <Text
+                    style={{
+                      fontFamily: selected ? 'Inter-SemiBold' : 'Inter-Regular',
+                      fontSize: 12,
+                      color: selected ? '#FFFFFF' : colors.textSecondary,
+                    }}
+                  >
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              )
+            })}
+          </View>
+        </View>
+      </ScrollView>
+
+      {/* Sticky action bar */}
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+          padding: 16,
+          backgroundColor: colors.panelBg,
+          flexDirection: 'row',
+          justifyContent: 'flex-end',
+          gap: 10,
+        }}
+      >
+        <Pressable
+          onPress={onClose}
+          style={{
+            paddingHorizontal: 20,
+            paddingVertical: 10,
+            borderRadius: 10,
+            backgroundColor: colors.iconBoxBg,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: colors.text }}>
+            Cancel
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={handleSave}
+          disabled={saving}
+          style={{
+            paddingHorizontal: 24,
+            paddingVertical: 10,
+            borderRadius: 10,
+            backgroundColor: '#E8862A',
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: saving ? 0.6 : 1,
+          }}
+        >
+          {saving ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#FFFFFF' }}>
+              {isEdit ? 'Save Changes' : 'Create Event'}
+            </Text>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaces full-page event create/edit form with an inline side panel matching the EventDetailPanel design (440px, same header/colors/layout)
- Create Event button (header nav + "+" in search bar) gated to admin users and localhost
- Edit pencil icon on event detail panel gated to admin/localhost, clicking opens form in side panel
- Back/Cancel on edit form returns to event detail view; on create form returns to list
- Dev login button on auth page always visible (not gated behind `__DEV__`)
- Fixed: Create Event button works reliably on repeated clicks (custom event instead of URL params)

## Test plan
- [ ] Click "Create Event" in header nav — form opens in side panel
- [ ] Click "+" button next to search — form opens in side panel
- [ ] Close form, click create again — form reopens (no stale state)
- [ ] Click edit pencil on event detail — form opens with event data prefilled
- [ ] Cancel/Back on edit form — returns to that event's detail panel
- [ ] Cancel/Back on create form — returns to event list
- [ ] Deploy to production — Create/Edit buttons hidden for non-admin users
- [ ] On localhost — Create/Edit buttons visible for all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)