### PR TITLE
fix: update D1 database ID to new production instance

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,7 +22,7 @@ pages_build_output_dir = "dist"
 [[d1_databases]]
 binding = "DB"
 database_name = "chinmaya-janata-db"
-database_id = "289ca84c-bae5-4d15-baeb-d76406fe0ea3"
+database_id = "d38b4cd2-963b-45eb-9f83-1e72f9d3aa5d"
 
 # ── Preview environment ────────────────────────────────────────────────
 # Uncomment and set database_id after creating the preview database:


### PR DESCRIPTION
## Summary
- Updates the Cloudflare D1 `database_id` in `wrangler.toml` to point at the correct production database instance.

## Test plan
- [ ] Verify `wrangler dev` connects to the new D1 database
- [ ] Confirm production deployment reads/writes to the correct database

Made with [Cursor](https://cursor.com)