### PR TITLE
fix: birthday picker date validation and dropdown z-index on web

### DIFF
--- a/packages/frontend/components/BirthdatePicker.web.tsx
+++ b/packages/frontend/components/BirthdatePicker.web.tsx
@@ -1,4 +1,4 @@
-// In BirthdatePicker.web.js
+// BirthdatePicker.web.tsx
 import React, { useState, useEffect } from 'react'
 import { View, Text, Pressable } from 'react-native'
 // --- NEW: Import Headless UI ---
@@ -37,7 +37,7 @@ function Select({ label, value, options, onChange, className }) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-background dark:bg-background-dark py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          <Listbox.Options className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md bg-background dark:bg-background-dark py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
             {options
               .filter((option) => option.value !== null) // <-- filter out placeholder
               .map((option) => (
@@ -60,7 +60,6 @@ function Select({ label, value, options, onChange, className }) {
   )
 }
 
-// --- Main Picker Component (No changes from here down) ---
 export default function BirthdatePicker({ value, onChange }) {
   const [date, setDate] = useState(value || new Date(2000, 0, 1))
 
@@ -97,36 +96,25 @@ export default function BirthdatePicker({ value, onChange }) {
   })
 
   const handlePartChange = (part, newValue) => {
-    setDateParts((prev) => ({ ...prev, [part]: newValue }))
-    // Only call onChange if all parts are selected
-    if (
-      part === 'year' &&
-      dateParts.month !== null &&
-      dateParts.day !== null &&
-      newValue !== null
-    ) {
-      onChange(new Date(newValue, dateParts.month, dateParts.day))
-    }
-    if (
-      part === 'month' &&
-      dateParts.year !== null &&
-      dateParts.day !== null &&
-      newValue !== null
-    ) {
-      onChange(new Date(dateParts.year, newValue, dateParts.day))
-    }
-    if (
-      part === 'day' &&
-      dateParts.year !== null &&
-      dateParts.month !== null &&
-      newValue !== null
-    ) {
-      onChange(new Date(dateParts.year, dateParts.month, newValue))
+    const newParts = { ...dateParts, [part]: newValue }
+    setDateParts(newParts)
+
+    // Only call onChange when all parts are selected
+    if (newParts.year !== null && newParts.month !== null && newParts.day !== null) {
+      const selectedDate = new Date(newParts.year, newParts.month, newParts.day)
+      const minAgeDate = new Date()
+      minAgeDate.setFullYear(minAgeDate.getFullYear() - 18)
+      minAgeDate.setHours(0, 0, 0, 0)
+
+      // Block under-18 (also covers future dates since minAgeDate < today)
+      if (selectedDate <= minAgeDate) {
+        onChange(selectedDate)
+      }
     }
   }
 
   return (
-    <View className="p-4 w-full max-w-[480px]">
+    <View className="p-4 w-full max-w-[480px]" style={{ overflow: 'visible', zIndex: 20 }}>
       <View className="flex-row justify-between space-x-2">
         {/* Month */}
         <Select

--- a/packages/frontend/components/onboarding/step2.tsx
+++ b/packages/frontend/components/onboarding/step2.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { View, Text, Pressable } from 'react-native'
+import { View, Text, Pressable, Platform } from 'react-native'
 import { useOnboarding } from '../contexts'
 import BirthdatePicker from '../BirthdatePicker'
 
@@ -24,7 +24,7 @@ export default function Step2() {
                 We'll use this to personalize your experience.
               </Text>
             </View>
-            <View className="mt-8 w-full flex items-center justify-center">
+            <View className="mt-8 w-full flex items-center justify-center" style={Platform.OS === 'web' ? { overflow: 'visible', zIndex: 20 } : undefined}>
               <BirthdatePicker value={birthdate ?? undefined} onChange={setBirthdate} />
             </View>
           </View>


### PR DESCRIPTION
## Summary

- Fix stale-state bug in `handlePartChange` — original code read `dateParts` after `setDateParts()` which doesn't update synchronously in React
- Add 18+ age validation to block invalid date selections (defense-in-depth alongside year dropdown range)
- Normalize `minAgeDate` to midnight for robust date comparison
- Bump dropdown z-index from `z-10` to `z-50` to prevent rendering behind the Continue button
- Add `overflow: visible` to picker containers on web to prevent clipping of absolute-positioned dropdowns
- Fix stale comment referencing `.js` extension

## Why

The web birthday picker had three issues:
1. A subtle stale-state bug where rapid field selections could produce incorrect dates
2. No explicit validation that the selected date makes the user 18+ (only the year dropdown constrained this)
3. Dropdown menus could render behind the Continue button due to z-index/overflow stacking

## Changes

| File | Change |
|------|--------|
| `packages/frontend/components/BirthdatePicker.web.tsx` | Refactor handlePartChange, fix z-index, add overflow styles |
| `packages/frontend/components/onboarding/step2.tsx` | Add Platform-conditional overflow style (web only) |

## Test plan

- [ ] Open onboarding step 2 on web — verify all three dropdowns (Month, Day, Year) render above the Continue button
- [ ] Select a date that would make the user under 18 — verify Continue button stays disabled
- [ ] Select a valid date (18+ years ago) — verify Continue button becomes enabled
- [ ] Verify native birthday picker is unaffected (uses DateTimePicker with its own constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)