### PR TITLE
fix: improve password strength bar legibility

### DIFF
--- a/packages/frontend/components/PasswordStrength.tsx
+++ b/packages/frontend/components/PasswordStrength.tsx
@@ -183,17 +183,17 @@ export default function PasswordStrength({ password, show }: PasswordStrengthPro
   const getStrengthColor = () => {
     if (score < 20) return 'bg-red-500'
     if (score < 40) return 'bg-orange-500'
-    if (score < 60) return 'bg-yellow-500'
+    if (score < 60) return 'bg-amber-500'
     if (score < 80) return 'bg-lime-500'
     return 'bg-green-500'
   }
 
   const getStrengthTextColor = () => {
-    if (score < 20) return 'text-red-500'
-    if (score < 40) return 'text-orange-500'
-    if (score < 60) return 'text-yellow-500'
-    if (score < 80) return 'text-lime-500'
-    return 'text-green-500'
+    if (score < 20) return 'text-red-600 dark:text-red-400'
+    if (score < 40) return 'text-orange-600 dark:text-orange-400'
+    if (score < 60) return 'text-amber-700 dark:text-amber-400'
+    if (score < 80) return 'text-lime-700 dark:text-lime-400'
+    return 'text-green-600 dark:text-green-400'
   }
 
   return (
@@ -201,18 +201,18 @@ export default function PasswordStrength({ password, show }: PasswordStrengthPro
       {/* Strength Bar */}
       <View className="gap-2">
         <View className="flex-row justify-between items-center">
-          <Text className="text-xs font-inter font-medium text-content dark:text-content-dark">
+          <Text className="text-sm font-inter font-medium text-content dark:text-content-dark">
             Password Strength
           </Text>
           <View className="flex-row items-center gap-2">
-            <Text className={`text-xs font-inter font-semibold ${getStrengthTextColor()}`}>
+            <Text className={`text-sm font-inter font-semibold ${getStrengthTextColor()}`}>
               {strength}
             </Text>
           </View>
         </View>
 
         {/* Progress Bar */}
-        <View className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+        <View className="h-2.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
           <View
             className={`h-full ${getStrengthColor()} transition-all duration-300`}
             style={{ width: `${percent}%` }}


### PR DESCRIPTION
## Summary

- Increase progress bar height from `h-2` to `h-2.5` for better visibility
- Add dark mode variants to strength text colors for proper contrast in both themes
- Change "Fair" tier from yellow to amber (both bar and text) for better contrast against light backgrounds
- Increase label text size from `text-xs` to `text-sm` for readability

## Why

The password strength indicator had legibility issues:
- Yellow text (`text-yellow-500`) was hard to read on light backgrounds
- The thin `h-2` bar was easy to miss
- Small `text-xs` labels were hard to read on mobile
- No dark mode text color variants meant poor contrast in dark theme

## Changes

| File | Change |
|------|--------|
| `packages/frontend/components/PasswordStrength.tsx` | Update bar height, text colors, bar colors, label sizes |

## Test plan

- [ ] Go to signup screen, type a password — verify strength bar is visible and thicker
- [ ] Trigger "Fair" strength level — verify amber color (not yellow) on both bar and label
- [ ] Toggle dark mode — verify text colors have good contrast in both themes
- [ ] Verify requirements checklist is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)