### PR TITLE
fix: remove share button and messages tab from event detail

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -250,7 +250,7 @@ function EventPanelInner({
   ) => void
 }) {
   const { user } = useUser()
-  const { event, attendees, messages, loading, toggleRegistration, isToggling } = useEventDetail(
+  const { event, attendees, loading, toggleRegistration, isToggling } = useEventDetail(
     eventId,
     user?.username,
     user?.id
@@ -311,7 +311,6 @@ function EventPanelInner({
     <EventDetailPanel
       event={event}
       attendees={attendees}
-      messages={messages}
       isPast={isPast}
       isAdmin={isAdmin}
       onClose={onClose}

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -10,7 +10,6 @@ import {
   User,
   Clock,
   CheckCircle,
-  Info,
   Pencil,
 } from 'lucide-react-native'
 import { useEventDetail } from '../../hooks/useApiData'
@@ -467,7 +466,7 @@ export default function EventDetailPage() {
   const [activeTab, setActiveTab] = useState('Details')
   const username = authStatus === 'authenticated' ? user?.username : undefined
   const userId = authStatus === 'authenticated' ? user?.id : undefined
-  const { event, attendees, messages, loading, toggleRegistration, isToggling, isCreator } =
+  const { event, attendees, loading, toggleRegistration, isToggling, isCreator } =
     useEventDetail(id as string, username, userId)
   const colors = useDetailColors()
 
@@ -555,7 +554,7 @@ export default function EventDetailPage() {
 
         <View style={{ paddingTop: 8 }}>
           <UnderlineTabBar
-            tabs={['Details', 'People', 'Messages']}
+            tabs={['Details', 'People']}
             activeTab={activeTab}
             onTabChange={setActiveTab}
           />
@@ -649,83 +648,6 @@ export default function EventDetailPage() {
             </View>
           )}
 
-          {activeTab === 'Messages' && (
-            <View style={{ paddingTop: 16, paddingHorizontal: 20, gap: 20 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <Info size={16} color="#E8862A" />
-                <Text style={{ fontFamily: 'Inter-Regular', fontSize: 13, color: '#E8862A' }}>
-                  Only the host can post messages
-                </Text>
-              </View>
-              {messages.length > 0 ? (
-                messages.map((message, index) => (
-                  <View key={index} style={{ gap: 8 }}>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                      <Image
-                        source={{ uri: message.image }}
-                        style={{ width: 30, height: 30, borderRadius: 15 }}
-                      />
-                      <Text
-                        style={{
-                          fontFamily: 'Inter-SemiBold',
-                          fontSize: 14,
-                          color: colors.text,
-                          flex: 1,
-                        }}
-                      >
-                        {message.author}
-                      </Text>
-                      <Text
-                        style={{
-                          fontFamily: 'Inter-Regular',
-                          fontSize: 12,
-                          color: colors.textMuted,
-                        }}
-                      >
-                        {message.timestamp}
-                      </Text>
-                    </View>
-                    <View
-                      style={{
-                        backgroundColor: colors.cardBg,
-                        borderTopLeftRadius: 4,
-                        borderTopRightRadius: 16,
-                        borderBottomLeftRadius: 16,
-                        borderBottomRightRadius: 16,
-                        padding: 12,
-                        marginLeft: 38,
-                      }}
-                    >
-                      <Text
-                        style={{
-                          fontFamily: 'Inter-Regular',
-                          fontSize: 14,
-                          color: colors.text,
-                          lineHeight: 20,
-                        }}
-                      >
-                        {message.text}
-                      </Text>
-                    </View>
-                  </View>
-                ))
-              ) : (
-                <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-                  <Info size={48} color={colors.textMuted} />
-                  <Text
-                    style={{
-                      fontFamily: 'Inter-Regular',
-                      fontSize: 14,
-                      color: colors.textSecondary,
-                      marginTop: 12,
-                    }}
-                  >
-                    No messages yet
-                  </Text>
-                </View>
-              )}
-            </View>
-          )}
         </ScrollView>
 
         <ActionBar

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { View, Text, Image, ScrollView, Pressable, ActivityIndicator } from 'react-native'
-import { MapPin, Users, User, Share2, Clock, CheckCircle, Info, ChevronLeft, Pencil } from 'lucide-react-native'
+import { MapPin, Users, User, Clock, CheckCircle, ChevronLeft, Pencil } from 'lucide-react-native'
 import Badge from '../ui/Badge'
 import UnderlineTabBar from '../ui/UnderlineTabBar'
 import Avatar from '../ui/Avatar'
@@ -78,13 +78,6 @@ type Attendee = {
   initials?: string
 }
 
-type Message = {
-  author: string
-  timestamp: string
-  text: string
-  image: string
-}
-
 type EventDetailPanelProps = {
   event: {
     id: string
@@ -100,7 +93,6 @@ type EventDetailPanelProps = {
     isRegistered?: boolean
   }
   attendees: Attendee[]
-  messages: Message[]
   isPast?: boolean
   isAdmin?: boolean
   onClose: () => void
@@ -224,15 +216,6 @@ function HeaderBar({
               accessibilityLabel="Edit event"
             >
               <Pencil size={18} color={colors.iconHeader} />
-            </Pressable>
-          )}
-          {!isPast && (
-            <Pressable
-              onPress={() => {}}
-              style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
-              accessibilityLabel="Share event"
-            >
-              <Share2 size={18} color={colors.iconHeader} />
             </Pressable>
           )}
         </View>
@@ -529,85 +512,6 @@ function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: Detai
   )
 }
 
-// ---------------------------------------------------------------------------
-// Messages tab content
-// ---------------------------------------------------------------------------
-
-function MessagesTab({ messages, colors }: { messages: Message[]; colors: DetailColors }) {
-  return (
-    <View style={{ paddingHorizontal: 24, paddingTop: 16, gap: 20 }}>
-      {/* Notice banner */}
-      <View className="flex-row items-center" style={{ gap: 8 }}>
-        <Info size={16} color="#E8862A" />
-        <Text
-          style={{
-            fontFamily: 'Inter-Regular',
-            fontSize: 13,
-            color: '#E8862A',
-          }}
-        >
-          Only the host can post messages
-        </Text>
-      </View>
-
-      {/* Message list */}
-      {messages.map((m, i) => (
-        <View key={i} style={{ gap: 8 }}>
-          {/* Author row */}
-          <View className="flex-row items-center" style={{ gap: 8 }}>
-            <Image
-              source={{ uri: m.image }}
-              style={{ width: 30, height: 30, borderRadius: 15 }}
-            />
-            <Text
-              style={{
-                fontFamily: 'Inter-SemiBold',
-                fontSize: 14,
-                color: colors.text,
-                flex: 1,
-              }}
-            >
-              {m.author}
-            </Text>
-            <Text
-              style={{
-                fontFamily: 'Inter-Regular',
-                fontSize: 12,
-                color: colors.textMuted,
-              }}
-            >
-              {m.timestamp}
-            </Text>
-          </View>
-
-          {/* Message bubble */}
-          <View
-            style={{
-              backgroundColor: colors.cardBg,
-              borderTopLeftRadius: 4,
-              borderTopRightRadius: 16,
-              borderBottomLeftRadius: 16,
-              borderBottomRightRadius: 16,
-              paddingVertical: 12,
-              paddingHorizontal: 14,
-            }}
-          >
-            <Text
-              style={{
-                fontFamily: 'Inter-Regular',
-                fontSize: 14,
-                color: colors.text,
-                lineHeight: 20,
-              }}
-            >
-              {m.text}
-            </Text>
-          </View>
-        </View>
-      ))}
-    </View>
-  )
-}
 
 // ---------------------------------------------------------------------------
 // Default content (unregistered / past)
@@ -667,12 +571,10 @@ function DefaultContent({
 function RegisteredContent({
   event,
   attendees,
-  messages,
   colors,
 }: {
   event: EventDetailPanelProps['event']
   attendees: Attendee[]
-  messages: Message[]
   colors: DetailColors
 }) {
   const [activeTab, setActiveTab] = useState('Details')
@@ -681,7 +583,7 @@ function RegisteredContent({
     <View style={{ flex: 1 }}>
       <View style={{ paddingTop: 8 }}>
         <UnderlineTabBar
-          tabs={['Details', 'People', 'Messages']}
+          tabs={['Details', 'People']}
           activeTab={activeTab}
           onTabChange={setActiveTab}
         />
@@ -723,9 +625,6 @@ function RegisteredContent({
 
         {activeTab === 'People' && <PeopleTab attendees={attendees} colors={colors} />}
 
-        {activeTab === 'Messages' && (
-          <MessagesTab messages={messages} colors={colors} />
-        )}
       </ScrollView>
     </View>
   )
@@ -847,7 +746,6 @@ function ActionBar({
 export default function EventDetailPanel({
   event,
   attendees,
-  messages,
   isPast,
   isAdmin,
   onClose,
@@ -887,7 +785,6 @@ export default function EventDetailPanel({
         <RegisteredContent
           event={event}
           attendees={attendees}
-          messages={messages}
           colors={colors}
         />
       ) : (


### PR DESCRIPTION
## Summary

- Removed the **Share** button (Share2 icon) from the event detail header bar on web
- Removed the **Messages** tab entirely from event detail — tab bar now shows only "Details" and "People"
- Removed the `MessagesTab` component, `Message` type, and all messages-related imports/props from `EventDetailPanel.tsx`
- Cleaned up the native event detail page (`events/[id].tsx`) to match — removed Messages tab rendering and unused imports
- Removed `messages` prop threading from `index.web.tsx` → `EventDetailPanel`

Messages were removed from MVP scope. Share functionality is deferred to a future release.

## Changes

| File | What changed |
|------|-------------|
| `components/web/EventDetailPanel.tsx` | Removed Share2 button, MessagesTab component (~75 lines), Message type, messages prop from HeaderBar and component |
| `app/(tabs)/index.web.tsx` | Removed `messages` from `useEventDetail` destructuring and `EventDetailPanel` props |
| `app/events/[id].tsx` | Removed Messages tab from tabs array, removed Messages tab render block (~75 lines), removed unused `Info` import |

**Net: -187 lines**

## Test plan

- [ ] Open any event detail on web — confirm only "Details" and "People" tabs appear
- [ ] Confirm no Share button in the event detail header
- [ ] Open event detail on native — confirm same behavior (no Messages tab)
- [ ] Verify "Details" tab shows About section and meta info correctly
- [ ] Verify "People" tab still shows attendees list

🤖 Generated with [Claude Code](https://claude.com/claude-code)