### PR TITLE
fix: show city/state instead of generic 'Center' on center cards

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -149,6 +149,21 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
   )
 }
 
+// ─── Center helpers ─────────────────────────────────────
+
+function extractCityState(address?: string): string | null {
+  if (!address) return null
+  const parts = address.split(',').map((s) => s.trim())
+  if (parts.length >= 2) {
+    const city = parts[parts.length - 2]
+    const stateZip = parts[parts.length - 1]
+    const stateMatch = stateZip.match(/^([A-Za-z\s]+)/)
+    const state = stateMatch ? stateMatch[1].trim() : stateZip
+    return `${city}, ${state}`
+  }
+  return null
+}
+
 // ─── Center Item ────────────────────────────────────────
 
 function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () => void }) {
@@ -175,7 +190,7 @@ function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () =
           {center.isMember && <Badge label="Member" variant="member" />}
         </View>
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
-          Center{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
+          {extractCityState(center.address) || 'Center'}{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
         </Text>
         {center.eventCount != null && center.eventCount > 0 && (
           <Text className="text-primary font-inter text-xs mt-0.5">

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -158,6 +158,24 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
   )
 }
 
+// ─── Center helpers ─────────────────────────────────────
+
+/** Extract "City, ST" from a full address string, or return fallback */
+function extractCityState(address?: string): string | null {
+  if (!address) return null
+  // Try to match "City, State ZIP" or "City, ST" patterns
+  const parts = address.split(',').map((s) => s.trim())
+  if (parts.length >= 2) {
+    const city = parts[parts.length - 2]
+    // State part may include ZIP — extract just the state abbreviation or name
+    const stateZip = parts[parts.length - 1]
+    const stateMatch = stateZip.match(/^([A-Za-z\s]+)/)
+    const state = stateMatch ? stateMatch[1].trim() : stateZip
+    return `${city}, ${state}`
+  }
+  return null
+}
+
 // ─── Center Item (Desktop) ──────────────────────────────
 
 function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () => void }) {
@@ -186,7 +204,7 @@ function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () =
           {center.isMember && <Badge label="Member" variant="member" />}
         </View>
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
-          Center{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
+          {extractCityState(center.address) || 'Center'}{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
         </Text>
         {center.eventCount != null && center.eventCount > 0 && (
           <Text className="text-primary font-inter text-xs">


### PR DESCRIPTION
## Summary

- Center cards in the discover list now display the **city and state** (e.g., "Houston, TX") instead of the generic label "Center"
- Added `extractCityState()` helper function that parses address strings to extract the city and state components
- Falls back to "Center" if no address is available on the center record
- Applied to both **web** (`index.web.tsx`) and **native** (`index.tsx`) discover screens

## How it works

The `extractCityState()` helper splits the address by commas, takes the second-to-last part as the city and the last part as the state (stripping zip codes). For example:

- `"3232 Bal Theatre Dr, San Jose, CA 95111"` → `"San Jose, CA"`
- `"123 Main St, Houston, TX 77001"` → `"Houston, TX"`

## Changes

| File | What changed |
|------|-------------|
| `app/(tabs)/index.web.tsx` | Added `extractCityState()` helper, changed center subtitle from `Center` to city/state |
| `app/(tabs)/index.tsx` | Same changes for native discover screen |

## Test plan

- [ ] Open discover page on web — scroll to centers section and confirm city/state is displayed (e.g., "Bakersfield, CA", "Boston, MA")
- [ ] Verify centers without addresses fall back to "Center"
- [ ] Check distance display still works alongside city/state (e.g., "Houston, TX · 5 mi")
- [ ] Open discover on native — confirm same city/state display

🤖 Generated with [Claude Code](https://claude.com/claude-code)