### PR TITLE
fix: restrict event edit button to owners and admins

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -269,14 +269,14 @@ function EventPanelInner({
   ) => void
 }) {
   const { user } = useUser()
-  const { event, attendees, loading, toggleRegistration, isToggling } = useEventDetail(
+  const { event, attendees, loading, toggleRegistration, isToggling, isCreator } = useEventDetail(
     eventId,
     user?.username,
     user?.id
   )
   const colors = useDetailColors()
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
-  const canEdit = isAdmin || isLocal
+  const canEdit = isAdmin || isCreator
 
   // Propogate registration status change back to discover list
   const prevRegisteredRef = useRef<boolean | undefined>(undefined)


### PR DESCRIPTION
## Summary

- Changed the edit button visibility logic on the **web** discover page so only event **creators** and **admins** can see the edit button
- Previously used `isLocal` (always true in dev), now uses `isCreator` from the `useEventDetail` hook which checks `createdBy === userId`
- The native event detail page (`events/[id].tsx`) already had this logic correct — no changes needed there

## Changes

| File | What changed |
|------|-------------|
| `app/(tabs)/index.web.tsx` | Changed `canEdit = isAdmin \|\| isLocal` → `canEdit = isAdmin \|\| isCreator`; added `isCreator` to `useEventDetail` destructuring |

**2 lines changed**

## Context

The `isLocal` flag was a dev convenience that was accidentally left in production code, causing the edit button to appear for all users. The `isCreator` flag properly checks if the current user's ID matches the event's `createdBy` field.

## Test plan

- [ ] Log in and open an event **you created** — confirm Edit button (pencil icon) shows in the header
- [ ] Open an event **someone else created** — confirm no Edit button
- [ ] Log in as admin — confirm Edit button shows on all events
- [ ] Verify events with no `created_by` field don't show the edit button

🤖 Generated with [Claude Code](https://claude.com/claude-code)