### PR TITLE
fix: show 'My Center' badge on user's selected center

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -151,12 +151,12 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
 
 // ─── Center Item ────────────────────────────────────────
 
-function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () => void }) {
+function CenterItem({ center, onPress, isMyCenter }: { center: DiscoverCenter; onPress: () => void; isMyCenter?: boolean }) {
   return (
     <Pressable
       onPress={onPress}
       className={`flex-row gap-3 p-3 rounded-2xl active:opacity-70 ${
-        center.isMember
+        center.isMember || isMyCenter
           ? 'bg-orange-50 dark:bg-orange-950/20'
           : 'bg-white dark:bg-neutral-900'
       }`}
@@ -172,7 +172,8 @@ function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () =
           <Text className="text-content dark:text-content-dark font-inter-semibold text-base leading-tight flex-1" numberOfLines={1}>
             {center.name}
           </Text>
-          {center.isMember && <Badge label="Member" variant="member" />}
+          {isMyCenter && <Badge label="My Center" variant="going" />}
+          {!isMyCenter && center.isMember && <Badge label="Member" variant="member" />}
         </View>
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
           Center{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
@@ -432,6 +433,7 @@ export default function DiscoverScreen() {
                 <CenterItem
                   key={`center-${item.data.id}`}
                   center={item.data as DiscoverCenter}
+                  isMyCenter={!!user?.centerID && item.data.id === user.centerID}
                   onPress={() => router.push(`/center/${item.data.id}`)}
                 />
               )

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -160,12 +160,12 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
 
 // ─── Center Item (Desktop) ──────────────────────────────
 
-function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () => void }) {
+function CenterItem({ center, onPress, isMyCenter }: { center: DiscoverCenter; onPress: () => void; isMyCenter?: boolean }) {
   return (
     <Pressable
       onPress={onPress}
       className={`flex-row gap-4 p-4 rounded-2xl active:opacity-80 border border-transparent hover:border-stone-200 dark:hover:border-neutral-700 ${
-        center.isMember ? 'bg-orange-50/80 dark:bg-orange-950/20' : 'bg-white dark:bg-neutral-900'
+        center.isMember || isMyCenter ? 'bg-orange-50/80 dark:bg-orange-950/20' : 'bg-white dark:bg-neutral-900'
       }`}
       style={{ minHeight: 72 }}
     >
@@ -183,7 +183,8 @@ function CenterItem({ center, onPress }: { center: DiscoverCenter; onPress: () =
           >
             {center.name}
           </Text>
-          {center.isMember && <Badge label="Member" variant="member" />}
+          {isMyCenter && <Badge label="My Center" variant="going" />}
+          {!isMyCenter && center.isMember && <Badge label="Member" variant="member" />}
         </View>
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
           Center{center.distanceMi != null ? ` · ${center.distanceMi} mi` : ''}
@@ -653,6 +654,7 @@ function MobileDiscoverFallback() {
                 <CenterItem
                   key={`center-${item.data.id}`}
                   center={item.data as DiscoverCenter}
+                  isMyCenter={!!user?.centerID && item.data.id === user.centerID}
                   onPress={() => router.push(`/center/${item.data.id}`)}
                 />
               )
@@ -987,6 +989,7 @@ export default function DiscoverScreenWeb() {
                   <CenterItem
                     key={`center-${item.data.id}`}
                     center={item.data as DiscoverCenter}
+                    isMyCenter={!!user?.centerID && item.data.id === user.centerID}
                     onPress={() => setSelectedItem({ type: 'center', id: item.data.id })}
                   />
                 )


### PR DESCRIPTION
## Summary

- Added a **"My Center"** badge that appears on the user's primary/home center in the discover list
- The badge replaces the generic "Member" badge when the center matches the user's `centerID`
- Uses an orange "going" variant badge to visually distinguish the user's home center from other centers they may be a member of
- Applied to both **web** (`index.web.tsx`) and **native** (`index.tsx`) discover screens

## How it works

Each `CenterItem` component receives an `isMyCenter` prop:
```tsx
isMyCenter={!!user?.centerID && center.id === user.centerID}
```

When `isMyCenter` is true, the badge shows "My Center" (orange). Otherwise, it falls back to "Member" if the user is a member.

## Changes

| File | What changed |
|------|-------------|
| `app/(tabs)/index.web.tsx` | Added `isMyCenter` prop to `CenterItem`, updated badge logic, passed prop from list rendering |
| `app/(tabs)/index.tsx` | Same changes for native discover screen |

## Test plan

- [ ] Log in with a user who has a `centerID` set — confirm "My Center" badge (orange) appears on that center
- [ ] Confirm other centers the user is a member of still show "Member" badge
- [ ] Confirm centers the user is not a member of show no badge
- [ ] Verify on both web and native discover screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)