### PR TITLE
fix: enable pinch-to-zoom on mobile web map

### DIFF
--- a/packages/frontend/components/Map.web.tsx
+++ b/packages/frontend/components/Map.web.tsx
@@ -9,7 +9,7 @@
  * Web-only map component using react-map-gl with OpenStreetMap tiles.
  * Native platforms (iOS/Android) use Map.tsx with react-native-maps.
  */
-import React, { useState, useCallback, memo, useRef, useMemo } from 'react'
+import React, { useState, useCallback, memo, useRef, useMemo, useEffect } from 'react'
 import Map, { Marker, MapRef, AttributionControl } from 'react-map-gl/maplibre'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { useThemeContext } from './contexts'
@@ -181,6 +181,9 @@ const MapComponent = memo<MapProps>(
     const { isDark } = useThemeContext()
     const mapRef = useRef<MapRef>(null)
 
+    // Disable cooperative gestures on mobile so pinch-to-zoom works
+    const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
+
     const center = initialCenter
       ? { longitude: initialCenter[1], latitude: initialCenter[0] }
       : { longitude: DEFAULT_CENTER.longitude, latitude: DEFAULT_CENTER.latitude }
@@ -284,7 +287,7 @@ const MapComponent = memo<MapProps>(
           style={{ width: '100%', height: '100%' }}
           reuseMaps
           attributionControl={false}
-          cooperativeGestures={true}
+          cooperativeGestures={!isMobile}
         >
           {markers}
           <AttributionControl


### PR DESCRIPTION
## Summary

- Fixed map pinch-to-zoom not working on mobile web browsers
- The `cooperativeGestures` prop on MapLibre GL was set to `true` unconditionally, which requires Ctrl+scroll (desktop) or two-finger drag (mobile) to zoom — preventing natural pinch-to-zoom on mobile
- Now conditionally set based on viewport width: disabled on mobile (< 768px), enabled on desktop

## Changes

| File | What changed |
|------|-------------|
| `components/Map.web.tsx` | Added `isMobile` detection via `window.innerWidth < 768`; changed `cooperativeGestures={true}` → `cooperativeGestures={!isMobile}` |

## Behavior

| Platform | Before | After |
|----------|--------|-------|
| **Mobile web** | Pinch-to-zoom blocked, shows "Use two fingers" overlay | Pinch-to-zoom works freely |
| **Desktop web** | Ctrl+scroll required (prevents accidental zoom while scrolling) | Same — no change |

## Test plan

- [ ] Open the app on a mobile device or resize browser to < 768px — confirm pinch-to-zoom works on the map without any overlay message
- [ ] Open on desktop (> 768px) — confirm Ctrl+scroll is still required to zoom (cooperative gestures still active)
- [ ] Verify map markers are still clickable on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)