### PR TITLE
fix: make Create Event button outline and remove duplicate button

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -66,15 +66,15 @@ if (Platform.OS === 'web') {
           {canCreate && (
             <Pressable
               className="px-3 py-2 rounded-lg flex-row items-center"
-              style={{ backgroundColor: '#E8862A', gap: 6 }}
+              style={{ borderWidth: 1.5, borderColor: '#E8862A', backgroundColor: 'transparent', gap: 6 }}
               onPress={() => {
                 if (typeof window !== 'undefined') {
                   window.dispatchEvent(new CustomEvent('open-event-form'))
                 }
               }}
             >
-              <Plus size={16} color="#fff" />
-              <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#fff' }}>
+              <Plus size={16} color="#E8862A" />
+              <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#E8862A' }}>
                 Create Event
               </Text>
             </Pressable>

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -18,7 +18,7 @@ import {
   TextInput,
   ActivityIndicator,
 } from 'react-native'
-import { MapPin, Search, Building2, Users, ChevronUp, Plus } from 'lucide-react-native'
+import { MapPin, Search, Building2, Users, ChevronUp } from 'lucide-react-native'
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router'
 import { useThemeContext, useUser } from '../../components/contexts'
 import { FilterChip, Badge, UnderlineTabBar, Avatar } from '../../components/ui'
@@ -914,25 +914,6 @@ export default function DiscoverScreenWeb() {
                     style={{ paddingVertical: 8 }}
                   />
                 </View>
-                {canCreate && (
-                  <Pressable
-                    onPress={() => {
-                      setSelectedItem(null)
-                      setFormPanel({})
-                    }}
-                    style={{
-                      width: 40,
-                      height: 40,
-                      borderRadius: 12,
-                      backgroundColor: '#E8862A',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                    accessibilityLabel="Create event"
-                  >
-                    <Plus size={20} color="#FFFFFF" />
-                  </Pressable>
-                )}
               </View>
             </View>
 


### PR DESCRIPTION
## Summary

- Changed the top header **"Create Event"** button from a filled orange style to a **secondary/outline** style (orange border and text on transparent background)
- Removed the **duplicate small orange "+" button** that appeared next to the search bar in the discover panel — redundant since the header already has a Create Event button
- Cleaned up unused `Plus` import from `index.web.tsx`

## Changes

| File | What changed |
|------|-------------|
| `app/(tabs)/_layout.tsx` | Changed Create Event button: `backgroundColor: '#E8862A'` → `borderWidth: 1.5, borderColor: '#E8862A', backgroundColor: 'transparent'`; icon and text color changed from white to `#E8862A` |
| `app/(tabs)/index.web.tsx` | Removed the 40x40 orange "+" `Pressable` button next to search input; removed unused `Plus` import |

## Visual comparison

**Before:** Filled orange "Create Event" button in header + small orange "+" next to search
**After:** Outline orange "Create Event" button in header only — cleaner, less visual clutter

## Test plan

- [ ] Verify "Create Event" button in header is outline style (orange border/text, transparent background)
- [ ] Verify no "+" button appears next to the search bar
- [ ] Click "Create Event" — confirm the event form panel still opens correctly
- [ ] Verify on mobile web viewport — confirm button still looks correct at smaller widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)