### PR TITLE
fix: hide Developer Mode button in production builds

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -16,8 +16,8 @@ import { useUser, useThemeContext } from '../components/contexts'
 import { validateEmail, validatePassword } from '../utils'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
-// @ts-ignore -- __DEV__ is a React Native global
-const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production'
+// __DEV__ is a React Native/Expo global — always false in production builds
+const isDev = typeof __DEV__ !== 'undefined' && __DEV__
 
 type AuthStep = 'initial' | 'login' | 'signup'
 


### PR DESCRIPTION
## Summary

The Developer Mode button on `/auth` was visible in production (Cloudflare Pages). 

**Root cause:** The `isDev` check had a fallback that leaked in prod:

```ts
// Before — broken in prod
const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production'
```

On Cloudflare Pages, `__DEV__` is `undefined` and `process.env.NODE_ENV` is also not set to `'production'`, so the fallback evaluated to `true`.

**Fix:**

```ts
// After — strict check, no fallback
const isDev = typeof __DEV__ !== 'undefined' && __DEV__
```

Now if `__DEV__` doesn't exist (as in production web builds), `isDev` is `false`. The Dev Panel button and component are only rendered in local development.

## Changes

| File | What changed |
|------|-------------|
| `app/auth.tsx` | Changed `isDev` from ternary with `NODE_ENV` fallback to strict `__DEV__` check |

**1 file, 2 lines changed**

## Test plan

- [ ] Deploy to staging — confirm no Developer Mode button on `/auth`
- [ ] Run locally with `npx expo start` — confirm Developer Mode button still appears
- [ ] Click Developer Mode locally — confirm Dev Panel still works (Go to Home, Go to Onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)