### PR TITLE
fix: auth page logo links to landing page

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -206,7 +206,9 @@ export default function AuthScreen() {
             )}
 
             {/* Janata Wordmark */}
-            <Logo size={32} style={{ marginBottom: 40 }} />
+            <Pressable onPress={() => router.push('/landing')}>
+              <Logo size={32} style={{ marginBottom: 40 }} />
+            </Pressable>
 
             {/* Heading & Subtitle */}
             <View className="mb-8">

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -302,7 +302,11 @@ export default function AuthScreen() {
           )}
 
           {/* Janata logo */}
-          <div style={{ marginBottom: isMobile ? 32 : 48 }}>
+          <div
+            onClick={() => router.push('/landing')}
+            role="link"
+            style={{ marginBottom: isMobile ? 32 : 48, cursor: 'pointer' }}
+          >
             <Logo size={isMobile ? 28 : 32} />
           </div>
 


### PR DESCRIPTION
## Summary
- Clicking the Janata logo on the `/auth` page now navigates back to the landing page
- Works on both web (`auth.web.tsx`) and native (`auth.tsx`)

## Test plan
- [ ] Open `/auth` on web, click the logo — should navigate to `/landing`
- [ ] Open auth screen on native, tap the logo — should navigate to `/landing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)