### PR TITLE
feat: mobile web UX — full-screen detail pages and nav fixes

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Tabs, useRouter } from 'expo-router'
-import { Platform, View, Text, Pressable, Image } from 'react-native'
+import { Platform, View, Text, Pressable, Image, useWindowDimensions } from 'react-native'
 import { useState } from 'react'
 import { useUser, useThemeContext } from '../../components/contexts'
 import { User, Settings, LogOut, Plus } from 'lucide-react-native'
@@ -73,7 +73,12 @@ if (Platform.OS === 'web') {
               onPress={() => {
                 posthog?.capture('nav_create_event')
                 if (typeof window !== 'undefined') {
-                  window.dispatchEvent(new CustomEvent('open-event-form'))
+                  const isMobile = window.innerWidth < 768
+                  if (isMobile) {
+                    router.push('/events/form')
+                  } else {
+                    window.dispatchEvent(new CustomEvent('open-event-form'))
+                  }
                 }
               }}
             >

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -1,6 +1,6 @@
 import '@expo/metro-runtime'
 import { useEffect, useState } from 'react'
-import { ActivityIndicator, LogBox, View, Text } from 'react-native'
+import { ActivityIndicator, LogBox, Platform, View, Text } from 'react-native'
 
 // Suppress non-fatal WorkletsTurboModule error in Expo Go (reanimated v4 compat)
 LogBox.ignoreLogs(['Exception in HostFunction: <unknown>'])
@@ -174,15 +174,15 @@ function RootLayoutNav() {
         />
         <Stack.Screen
           name="privacy"
-          options={{ headerShown: true, title: 'Privacy Policy', headerBackTitle: '' }}
+          options={{ headerShown: Platform.OS !== 'web', title: 'Privacy Policy', headerBackTitle: '' }}
         />
         <Stack.Screen
           name="terms"
-          options={{ headerShown: true, title: 'Terms of Service', headerBackTitle: '' }}
+          options={{ headerShown: Platform.OS !== 'web', title: 'Terms of Service', headerBackTitle: '' }}
         />
         <Stack.Screen
           name="cookies"
-          options={{ headerShown: true, title: 'Cookie Policy', headerBackTitle: '' }}
+          options={{ headerShown: Platform.OS !== 'web', title: 'Cookie Policy', headerBackTitle: '' }}
         />
       </Stack>
     </NavigationThemeProvider>

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -1,23 +1,205 @@
-import { useEffect } from 'react'
-import { View, ActivityIndicator } from 'react-native'
+import { useEffect, useState } from 'react'
+import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Linking, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ChevronLeft, Share2, MapPin, Globe, Phone, User } from 'lucide-react-native'
+import { useCenterDetail } from '../../hooks/useApiData'
+import { useDetailColors } from '../../hooks/useDetailColors'
+import type { EventDisplay } from '../../utils/api'
 
 export default function CenterDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
   const id = Array.isArray(rawId) ? rawId[0] : rawId
   const router = useRouter()
+  const { width } = useWindowDimensions()
+  const isMobile = width < 768
 
   useEffect(() => {
-    if (id) {
+    if (!isMobile && id) {
       router.replace(`/?detail=center&id=${id}`)
-    } else {
+    } else if (!id) {
       router.replace('/')
     }
-  }, [id, router])
+  }, [id, router, isMobile])
+
+  if (!isMobile) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color="#E8862A" />
+      </View>
+    )
+  }
+
+  return <MobileCenterDetail centerId={id || ''} />
+}
+
+function formatDateCallout(dateStr: string): { month: string; day: string } {
+  const d = new Date(dateStr + 'T00:00:00')
+  if (isNaN(d.getTime())) return { month: '', day: '' }
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+  const day = String(d.getDate())
+  return { month, day }
+}
+
+function MobileCenterDetail({ centerId }: { centerId: string }) {
+  const router = useRouter()
+  const { center, events, loading } = useCenterDetail(centerId)
+  const colors = useDetailColors()
+
+  const handleShare = () => {
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      navigator.share({ title: center?.name || 'Center', text: `Check out ${center?.name} on Chinmaya Janata!` }).catch(() => {})
+    } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href)
+    }
+  }
+
+  const handleAddressPress = () => {
+    if (!center?.address) return
+    Linking.openURL(`https://maps.google.com/?q=${encodeURIComponent(center.address)}`)
+  }
+
+  const handleWebsitePress = () => {
+    if (!center?.website) return
+    const url = center.website.startsWith('http') ? center.website : `https://${center.website}`
+    Linking.openURL(url)
+  }
+
+  const handlePhonePress = () => {
+    if (!center?.phone) return
+    Linking.openURL(`tel:${center.phone}`)
+  }
+
+  const handleEventPress = (event: EventDisplay) => {
+    router.push(`/events/${event.id}`)
+  }
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.panelBg }}>
+        <ActivityIndicator size="large" color="#E8862A" />
+      </View>
+    )
+  }
+
+  if (!center) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.panelBg }}>
+        <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Center not found</Text>
+        <Pressable onPress={() => router.back()} style={{ marginTop: 16 }}>
+          <Text style={{ color: '#E8862A', fontSize: 16 }}>Go back</Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  const displayWebsite = (center.website ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '')
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ActivityIndicator size="large" color="#E8862A" />
+    <View style={{ flex: 1, backgroundColor: colors.panelBg }}>
+      {/* Header */}
+      <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8, gap: 10 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Pressable onPress={() => router.back()} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            <ChevronLeft size={20} color={colors.textSecondary} />
+            <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Back</Text>
+          </Pressable>
+          <Pressable onPress={handleShare} style={{ padding: 8 }}>
+            <Share2 size={18} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+        <Text style={{ fontSize: 22, fontWeight: 'bold', color: colors.text }}>{center.name}</Text>
+      </View>
+
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 40 }}>
+        {/* Hero image */}
+        {center.image ? (
+          <Image source={{ uri: center.image }} style={{ width: '100%', height: 200 }} resizeMode="cover" />
+        ) : null}
+
+        <View style={{ paddingHorizontal: 16, paddingTop: 20, gap: 16 }}>
+          {/* Point of contact */}
+          {center.pointOfContact ? (
+            <Text style={{ color: colors.textSecondary, fontSize: 13 }}>
+              Point of Contact: {center.pointOfContact}
+            </Text>
+          ) : null}
+
+          {/* Address */}
+          {center.address ? (
+            <Pressable onPress={handleAddressPress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <MapPin size={18} color="#E8862A" />
+              <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{center.address}</Text>
+            </Pressable>
+          ) : null}
+
+          {/* Website */}
+          {center.website ? (
+            <Pressable onPress={handleWebsitePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Globe size={18} color="#E8862A" />
+              <Text style={{ color: '#E8862A', fontSize: 15, flex: 1 }} numberOfLines={1}>{displayWebsite}</Text>
+            </Pressable>
+          ) : null}
+
+          {/* Phone */}
+          {center.phone ? (
+            <Pressable onPress={handlePhonePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Phone size={18} color="#E8862A" />
+              <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{center.phone}</Text>
+            </Pressable>
+          ) : null}
+
+          {/* Acharya */}
+          {center.acharya ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <User size={18} color="#E8862A" />
+              <View style={{ flex: 1 }}>
+                <Text style={{ color: colors.text, fontSize: 15 }}>{center.acharya}</Text>
+                <Text style={{ color: colors.textSecondary, fontSize: 13 }}>Resident Acharya</Text>
+              </View>
+            </View>
+          ) : null}
+
+          {/* Upcoming Events */}
+          {events.length > 0 && (
+            <View style={{ marginTop: 8 }}>
+              <Text style={{ color: colors.textSecondary, fontSize: 12, fontWeight: '600', marginBottom: 12, letterSpacing: 0.5 }}>
+                UPCOMING EVENTS
+              </Text>
+              <View style={{ gap: 8 }}>
+                {events.map((event) => {
+                  const { month, day } = formatDateCallout(event.date)
+                  return (
+                    <Pressable
+                      key={event.id}
+                      onPress={() => handleEventPress(event)}
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        backgroundColor: colors.cardBg,
+                        borderRadius: 8,
+                        paddingVertical: 12,
+                        paddingHorizontal: 14,
+                      }}
+                    >
+                      <View style={{ width: 52, alignItems: 'center' }}>
+                        <Text style={{ fontSize: 11, fontWeight: '600', color: '#E8862A', textTransform: 'uppercase' }}>{month}</Text>
+                        <Text style={{ fontSize: 22, fontWeight: '600', color: colors.text }}>{day}</Text>
+                      </View>
+                      <View style={{ width: 1, backgroundColor: colors.border, alignSelf: 'stretch', marginHorizontal: 12 }} />
+                      <View style={{ flex: 1 }}>
+                        <Text style={{ fontSize: 14, fontWeight: '600', color: colors.text }} numberOfLines={2}>{event.title}</Text>
+                        <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+                          {event.time}{event.attendees > 0 ? ` · ${event.attendees} attending` : ''}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  )
+                })}
+              </View>
+            </View>
+          )}
+        </View>
+      </ScrollView>
     </View>
   )
 }

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -1,23 +1,187 @@
-import { useEffect } from 'react'
-import { View, ActivityIndicator } from 'react-native'
+import { useEffect, useState, useCallback } from 'react'
+import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ChevronLeft, Share2, MapPin, Users, User, Clock, CheckCircle } from 'lucide-react-native'
+import { useUser } from '../../components/contexts'
+import { useEventDetail } from '../../hooks/useApiData'
+import Avatar from '../../components/ui/Avatar'
+import Badge from '../../components/ui/Badge'
+import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
+import { useDetailColors } from '../../hooks/useDetailColors'
 
 export default function EventDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
   const id = Array.isArray(rawId) ? rawId[0] : rawId
   const router = useRouter()
+  const { width } = useWindowDimensions()
+  const isMobile = width < 768
 
   useEffect(() => {
-    if (id) {
+    if (!isMobile && id) {
       router.replace(`/?detail=event&id=${id}`)
-    } else {
+    } else if (!id) {
       router.replace('/')
     }
-  }, [id, router])
+  }, [id, router, isMobile])
+
+  // On desktop, show loading while redirecting
+  if (!isMobile) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color="#E8862A" />
+      </View>
+    )
+  }
+
+  // On mobile web, render full-screen event detail
+  return <MobileEventDetail eventId={id || ''} />
+}
+
+function MobileEventDetail({ eventId }: { eventId: string }) {
+  const router = useRouter()
+  const { user } = useUser()
+  const { event, loading, toggleRegistration, isToggling, attendees } = useEventDetail(eventId, user?.username, user?.id)
+  const colors = useDetailColors()
+  const [activeTab, setActiveTab] = useState('Details')
+
+  const isPast = event?.date ? new Date(event.date + 'T23:59:59') < new Date() : false
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.panelBg }}>
+        <ActivityIndicator size="large" color="#E8862A" />
+      </View>
+    )
+  }
+
+  if (!event) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.panelBg }}>
+        <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Event not found</Text>
+        <Pressable onPress={() => router.back()} style={{ marginTop: 16 }}>
+          <Text style={{ color: '#E8862A', fontSize: 16 }}>Go back</Text>
+        </Pressable>
+      </View>
+    )
+  }
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ActivityIndicator size="large" color="#E8862A" />
+    <View style={{ flex: 1, backgroundColor: colors.panelBg }}>
+      {/* Header */}
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 }}>
+        <Pressable onPress={() => router.back()} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+          <ChevronLeft size={20} color={colors.textSecondary} />
+          <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Back</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => {
+            if (typeof navigator !== 'undefined' && navigator.share) {
+              navigator.share({ title: event.title, text: `Check out ${event.title} on Chinmaya Janata!` }).catch(() => {})
+            } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+              navigator.clipboard.writeText(window.location.href)
+            }
+          }}
+          style={{ padding: 8 }}
+        >
+          <Share2 size={18} color={colors.textSecondary} />
+        </Pressable>
+      </View>
+
+      {/* Title + Badge */}
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingBottom: 8 }}>
+        <Text style={{ fontSize: 22, fontWeight: 'bold', color: colors.text, flex: 1 }}>{event.title}</Text>
+        {event.isRegistered && <Badge label="Going" variant="going" />}
+      </View>
+
+      {/* Tabs */}
+      <UnderlineTabBar
+        tabs={['Details', 'People']}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 16, gap: 16 }}>
+        {activeTab === 'Details' ? (
+          <>
+            {/* Date & Time */}
+            {event.date && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Clock size={18} color={colors.textSecondary} />
+                <Text style={{ color: colors.text, fontSize: 15 }}>
+                  {new Date(event.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })}
+                  {event.time ? ` · ${event.time}` : ''}
+                </Text>
+              </View>
+            )}
+
+            {/* Location */}
+            {event.address && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <MapPin size={18} color="#E8862A" />
+                <Text style={{ color: colors.text, fontSize: 15 }}>{event.address}</Text>
+              </View>
+            )}
+
+            {/* Attendees count */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Users size={18} color={colors.textSecondary} />
+              <Text style={{ color: colors.text, fontSize: 15 }}>
+                {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
+              </Text>
+            </View>
+
+            {/* Contact */}
+            {event.pointOfContact && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <User size={18} color={colors.textSecondary} />
+                <Text style={{ color: colors.text, fontSize: 15 }}>Contact: {event.pointOfContact}</Text>
+              </View>
+            )}
+
+            {/* Description */}
+            {event.description && (
+              <View style={{ marginTop: 8 }}>
+                <Text style={{ color: colors.textSecondary, fontSize: 12, fontWeight: '600', marginBottom: 8 }}>ABOUT</Text>
+                <Text style={{ color: colors.text, fontSize: 15, lineHeight: 22 }}>{event.description}</Text>
+              </View>
+            )}
+          </>
+        ) : (
+          <>
+            <Text style={{ color: colors.textSecondary, fontSize: 14 }}>
+              {attendees.length} {attendees.length === 1 ? 'person' : 'people'} attending
+            </Text>
+            {attendees.map((a: any, i: number) => (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 }}>
+                <Avatar name={a.name} size={40} image={a.image} />
+                <Text style={{ color: colors.text, fontSize: 16, flex: 1 }}>
+                  {a.name}
+                </Text>
+              </View>
+            ))}
+          </>
+        )}
+      </ScrollView>
+
+      {/* Action button */}
+      {!isPast && (
+        <View style={{ padding: 16 }}>
+          <Pressable
+            onPress={() => user?.username && toggleRegistration(user.username)}
+            disabled={isToggling}
+            style={{
+              backgroundColor: event.isRegistered ? '#FEE2E2' : '#E8862A',
+              paddingVertical: 14,
+              borderRadius: 12,
+              alignItems: 'center',
+            }}
+          >
+            <Text style={{ color: event.isRegistered ? '#DC2626' : '#FFFFFF', fontWeight: '600', fontSize: 16 }}>
+              {isToggling ? 'Updating...' : event.isRegistered ? 'Cancel Registration' : 'Register'}
+            </Text>
+          </Pressable>
+        </View>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- Render event and center detail pages inline on mobile web (<768px) instead of redirecting to the desktop overlay route
- Hide native stack headers for Privacy/Terms/Cookie pages on web (they have their own nav)
- Route "Create Event" button to `/events/form` on mobile web instead of dispatching the desktop side-panel event

## Test plan
- [ ] Open an event detail link on mobile-width browser — should render full-screen detail with tabs, registration button
- [ ] Open a center detail link on mobile-width browser — should render full-screen detail with contact info, events list
- [ ] Open same links on desktop-width — should still redirect to overlay route
- [ ] Tap "Create Event" on mobile web — should navigate to /events/form
- [ ] Open Privacy/Terms/Cookie on web — no duplicate native header

🤖 Generated with [Claude Code](https://claude.com/claude-code)