### PR TITLE
fix: landing page polish — avatar overlap and mobile carousel

### DIFF
--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -328,7 +328,7 @@ function AvatarStack() {
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center' }}>
       {TEAM.map((person, i) => (
-        <div key={person.name} className="avatar-wrap" style={{ marginLeft: i > 0 ? -10 : 0, cursor: 'default' }}>
+        <div key={person.name} className="avatar-wrap" style={{ marginLeft: i > 0 ? -10 : 0, cursor: 'default', zIndex: TEAM.length - i }}>
           <div className="avatar-tooltip">{person.name}</div>
           {person.image ? (
             <Image
@@ -527,8 +527,8 @@ export function Hero() {
           </Text>
         </View>
 
-        {/* Horizontal scrolling card row on mobile */}
-        {isMobile && <HorizontalScrollRow />}
+        {/* Horizontal scrolling card row on mobile — hidden for now */}
+        {/* {isMobile && <HorizontalScrollRow />} */}
       </View>
 
       {/* Infinite scrolling card columns -- rotated (hidden on mobile) */}


### PR DESCRIPTION
## Summary
- **Avatar stack z-index**: Fixed overlap order so the leftmost avatar renders on top (descending `zIndex` based on array position)
- **Hide mobile carousel**: Commented out the `HorizontalScrollRow` on mobile viewports for a cleaner landing experience

## Test plan
- [ ] Verify avatar overlap shows left avatar on top on desktop
- [ ] Verify card carousel is no longer visible on mobile (<768px)
- [ ] Confirm desktop infinite-scroll columns still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)