### PR TITLE
fix: cleanup unused imports, resize redirect bug, and dead code

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Tabs, useRouter } from 'expo-router'
-import { Platform, View, Text, Pressable, Image, useWindowDimensions } from 'react-native'
+import { Platform, View, Text, Pressable, Image } from 'react-native'
 import { useState } from 'react'
 import { useUser, useThemeContext } from '../../components/contexts'
 import { User, Settings, LogOut, Plus } from 'lucide-react-native'

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Linking, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, Share2, MapPin, Globe, Phone, User } from 'lucide-react-native'
@@ -13,13 +13,15 @@ export default function CenterDetailWeb() {
   const { width } = useWindowDimensions()
   const isMobile = width < 768
 
+  const initiallyMobile = useRef(isMobile)
+
   useEffect(() => {
-    if (!isMobile && id) {
+    if (!initiallyMobile.current && id) {
       router.replace(`/?detail=center&id=${id}`)
     } else if (!id) {
       router.replace('/')
     }
-  }, [id, router, isMobile])
+  }, [id, router])
 
   if (!isMobile) {
     return (

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, Share2, MapPin, Users, User, Clock, CheckCircle } from 'lucide-react-native'
@@ -16,13 +16,15 @@ export default function EventDetailWeb() {
   const { width } = useWindowDimensions()
   const isMobile = width < 768
 
+  const initiallyMobile = useRef(isMobile)
+
   useEffect(() => {
-    if (!isMobile && id) {
+    if (!initiallyMobile.current && id) {
       router.replace(`/?detail=event&id=${id}`)
     } else if (!id) {
       router.replace('/')
     }
-  }, [id, router, isMobile])
+  }, [id, router])
 
   // On desktop, show loading while redirecting
   if (!isMobile) {
@@ -151,8 +153,8 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
             <Text style={{ color: colors.textSecondary, fontSize: 14 }}>
               {attendees.length} {attendees.length === 1 ? 'person' : 'people'} attending
             </Text>
-            {attendees.map((a: any, i: number) => (
-              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 }}>
+            {attendees.map((a) => (
+              <View key={a.name} style={{ flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 }}>
                 <Avatar name={a.name} size={40} image={a.image} />
                 <Text style={{ color: colors.text, fontSize: 16, flex: 1 }}>
                   {a.name}

--- a/packages/frontend/components/Map.native.tsx
+++ b/packages/frontend/components/Map.native.tsx
@@ -58,8 +58,6 @@ const Map = memo<MapProps>(function Map({
   bottomPadding = 0,
 }) {
   const mapRef = useRef<MapView>(null)
-  const pointsRef = useRef(points)
-  pointsRef.current = points
 
   // Compute initial region synchronously — user's center > SF default
   const computeInitialRegion = (): Region => {


### PR DESCRIPTION
## Summary
- Remove unused imports (`useWindowDimensions`, `useCallback`, `useState`) across 3 files
- Fix resize-triggered redirect loop in event/center detail pages — captures initial mobile state with `useRef` so resizing across the 768px breakpoint no longer causes unwanted navigation
- Replace array-index `key` with stable `a.name` for attendee list and drop `any` type annotation
- Remove dead `pointsRef` in `Map.native.tsx` (assigned but never read)

## Test plan
- [x] All 133 frontend tests pass
- [x] All 210 backend tests pass
- [ ] Verify event/center detail pages still redirect correctly on desktop
- [ ] Verify resizing browser across 768px doesn't trigger redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)