### PR TITLE
fix: unify buttons to shared components with consistent styles

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -5,7 +5,7 @@ import { useUser, useThemeContext } from '../../components/contexts'
 import { User, Settings, LogOut, Plus } from 'lucide-react-native'
 import SettingsPanel from '../../components/SettingsPanel'
 import Logo from '../../components/ui/Logo'
-import { Avatar } from '../../components/ui'
+import { Avatar, PrimaryButton, SecondaryButton } from '../../components/ui'
 import { usePostHog } from 'posthog-react-native'
 
 /**
@@ -45,14 +45,11 @@ export default function TabLayout() {
   const HeaderRight = () => {
     if (!user) {
       return (
-        <Link href="/auth" asChild>
-          <Pressable
-            className="mr-4 px-3 py-2 bg-primary rounded-full"
-            onPress={() => router.push('/auth')}
-          >
-            <Text className="text-white text-base font-inter">Log In</Text>
-          </Pressable>
-        </Link>
+        <View style={{ marginRight: 16 }}>
+          <PrimaryButton onPress={() => router.push('/auth')} style={{ paddingHorizontal: 12, paddingVertical: 8 }}>
+            Log In
+          </PrimaryButton>
+        </View>
       )
     }
 if (Platform.OS === 'web') {
@@ -68,7 +65,7 @@ if (Platform.OS === 'web') {
         <View className="flex-row items-center" style={{ gap: 8 }}>
           {canCreate && (
             <Pressable
-              className="px-3 py-2 rounded-lg flex-row items-center"
+              className="px-3 py-2 rounded-full flex-row items-center"
               style={{ borderWidth: 1.5, borderColor: '#E8862A', backgroundColor: 'transparent', gap: 6 }}
               onPress={() => {
                 posthog?.capture('nav_create_event')

--- a/packages/frontend/app/admin.tsx
+++ b/packages/frontend/app/admin.tsx
@@ -1,0 +1,17 @@
+import { View, Text } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useEffect } from 'react'
+
+export default function AdminFallback() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.replace('/(tabs)')
+  }, [router])
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Admin is only available on web.</Text>
+    </View>
+  )
+}

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -12,7 +12,7 @@ import {
 import { useRouter } from 'expo-router'
 import { Code, ArrowLeft } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
-import { AuthInput, Logo } from '../components/ui'
+import { AuthInput, Logo, PrimaryButton } from '../components/ui'
 import { useUser, useThemeContext } from '../components/contexts'
 import { validateEmail, validatePassword } from '../utils'
 import { PasswordStrength } from '../components'
@@ -297,26 +297,18 @@ export default function AuthScreen() {
               )}
 
               {/* Submit Button */}
-              <Pressable
+              <PrimaryButton
                 onPress={handleSubmit}
                 disabled={isButtonDisabled}
-                className={`items-center justify-center mt-2 rounded-lg ${
-                  isButtonDisabled
-                    ? 'bg-primary/40 dark:bg-primary/30'
-                    : 'bg-primary active:bg-primary-press'
-                } px-8`}
-                style={{ height: 48 }}
+                loading={loading}
+                style={{ marginTop: 8 }}
               >
-                <Text className="text-white font-inter font-bold text-md">
-                  {loading
-                    ? 'Please wait...'
-                    : authStep === 'login'
-                    ? 'Log In'
-                    : authStep === 'signup'
-                    ? 'Sign Up'
-                    : 'Continue'}
-                </Text>
-              </Pressable>
+                {authStep === 'login'
+                  ? 'Log In'
+                  : authStep === 'signup'
+                  ? 'Sign Up'
+                  : 'Continue'}
+              </PrimaryButton>
 
               {/* Forgot Password (only on login) */}
               {authStep === 'login' && (

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -15,7 +15,7 @@ import {
 import { usePostHog } from 'posthog-react-native'
 import { useEventDetail } from '../../hooks/useApiData'
 import { useUser } from '../../components/contexts'
-import { Badge, UnderlineTabBar, Avatar } from '../../components/ui'
+import { Badge, UnderlineTabBar, Avatar, PrimaryButton, DestructiveButton } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
@@ -396,26 +396,13 @@ function ActionBar({
           backgroundColor: colors.panelBg,
         }}
       >
-        <Pressable
+        <DestructiveButton
           onPress={onToggle}
           disabled={isToggling}
-          style={{
-            height: 48,
-            borderRadius: 10,
-            backgroundColor: 'rgba(239,68,68,0.1)',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: isToggling ? 0.6 : 1,
-          }}
+          loading={isToggling}
         >
-          {isToggling ? (
-            <ActivityIndicator size="small" color="#EF4444" />
-          ) : (
-            <Text style={{ fontFamily: 'Inter-Medium', fontSize: 15, color: '#EF4444' }}>
-              Cancel Registration
-            </Text>
-          )}
-        </Pressable>
+          Cancel Registration
+        </DestructiveButton>
       </View>
     )
   }
@@ -431,26 +418,13 @@ function ActionBar({
         backgroundColor: colors.panelBg,
       }}
     >
-      <Pressable
+      <PrimaryButton
         onPress={onToggle}
         disabled={isToggling}
-        style={{
-          height: 48,
-          borderRadius: 10,
-          backgroundColor: '#E8862A',
-          alignItems: 'center',
-          justifyContent: 'center',
-          opacity: isToggling ? 0.6 : 1,
-        }}
+        loading={isToggling}
       >
-        {isToggling ? (
-          <ActivityIndicator size="small" color="#FFFFFF" />
-        ) : (
-          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 15, color: '#FFFFFF' }}>
-            Attend Event
-          </Text>
-        )}
-      </Pressable>
+        Attend Event
+      </PrimaryButton>
       <Text
         style={{
           fontFamily: 'Inter-Regular',

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -7,6 +7,8 @@ import { useEventDetail } from '../../hooks/useApiData'
 import Avatar from '../../components/ui/Avatar'
 import Badge from '../../components/ui/Badge'
 import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
+import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
+import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import { useDetailColors } from '../../hooks/useDetailColors'
 
 export default function EventDetailWeb() {
@@ -168,20 +170,23 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
       {/* Action button */}
       {!isPast && (
         <View style={{ padding: 16 }}>
-          <Pressable
-            onPress={() => user?.username && toggleRegistration(user.username)}
-            disabled={isToggling}
-            style={{
-              backgroundColor: event.isRegistered ? '#FEE2E2' : '#E8862A',
-              paddingVertical: 14,
-              borderRadius: 12,
-              alignItems: 'center',
-            }}
-          >
-            <Text style={{ color: event.isRegistered ? '#DC2626' : '#FFFFFF', fontWeight: '600', fontSize: 16 }}>
-              {isToggling ? 'Updating...' : event.isRegistered ? 'Cancel Registration' : 'Register'}
-            </Text>
-          </Pressable>
+          {event.isRegistered ? (
+            <DestructiveButton
+              onPress={() => user?.username && toggleRegistration(user.username)}
+              disabled={isToggling}
+              loading={isToggling}
+            >
+              Cancel Registration
+            </DestructiveButton>
+          ) : (
+            <PrimaryButton
+              onPress={() => user?.username && toggleRegistration(user.username)}
+              disabled={isToggling}
+              loading={isToggling}
+            >
+              Register
+            </PrimaryButton>
+          )}
         </View>
       )}
     </View>

--- a/packages/frontend/app/events/form.tsx
+++ b/packages/frontend/app/events/form.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useUser } from '../../components/contexts'
+import { PrimaryButton } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import {
   fetchEvent,
@@ -660,26 +661,13 @@ export default function EventFormPage() {
           backgroundColor: colors.panelBg,
         }}
       >
-        <Pressable
+        <PrimaryButton
           onPress={handleSave}
           disabled={saving}
-          style={{
-            height: 48,
-            borderRadius: 10,
-            backgroundColor: '#E8862A',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: saving ? 0.6 : 1,
-          }}
+          loading={saving}
         >
-          {saving ? (
-            <ActivityIndicator size="small" color="#FFFFFF" />
-          ) : (
-            <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 15, color: '#FFFFFF' }}>
-              {isEdit ? 'Save Changes' : 'Create Event'}
-            </Text>
-          )}
-        </Pressable>
+          {isEdit ? 'Save Changes' : 'Create Event'}
+        </PrimaryButton>
       </View>
     </SafeAreaView>
   )

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import { PrimaryButton, SecondaryButton } from '../../components/ui'
 import {
   fetchEvent,
   fetchCenters,
@@ -629,42 +630,20 @@ export default function EventFormPage() {
           alignSelf: 'center',
         }}
       >
-        <Pressable
+        <SecondaryButton
           onPress={() => router.back()}
-          style={{
-            paddingHorizontal: 24,
-            paddingVertical: 12,
-            borderRadius: 10,
-            minHeight: 44,
-            backgroundColor: colors.iconBoxBg,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          style={{ paddingHorizontal: 24, paddingVertical: 12 }}
         >
-          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 14, color: colors.text }}>Cancel</Text>
-        </Pressable>
-        <Pressable
+          Cancel
+        </SecondaryButton>
+        <PrimaryButton
           onPress={handleSave}
           disabled={saving}
-          style={{
-            paddingHorizontal: 32,
-            paddingVertical: 12,
-            borderRadius: 10,
-            minHeight: 44,
-            backgroundColor: '#E8862A',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: saving ? 0.6 : 1,
-          }}
+          loading={saving}
+          style={{ paddingHorizontal: 32, paddingVertical: 12 }}
         >
-          {saving ? (
-            <ActivityIndicator size="small" color="#FFFFFF" />
-          ) : (
-            <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 14, color: '#FFFFFF' }}>
-              {isEdit ? 'Save Changes' : 'Create Event'}
-            </Text>
-          )}
-        </Pressable>
+          {isEdit ? 'Save Changes' : 'Create Event'}
+        </PrimaryButton>
       </View>
     </View>
   )

--- a/packages/frontend/app/settings/settings.tsx
+++ b/packages/frontend/app/settings/settings.tsx
@@ -14,7 +14,7 @@ import {
 import { Eye, Shield, Info, ExternalLink, AlertTriangle } from 'lucide-react-native'
 import { useUser, useThemeContext } from '../../components/contexts'
 import { useRouter } from 'expo-router'
-import { DestructiveButton } from '../../components/ui'
+import { DestructiveButton, SecondaryButton } from '../../components/ui'
 import ThemeSelector from '../../components/ThemeSelector'
 import { usePostHog } from 'posthog-react-native'
 
@@ -192,24 +192,23 @@ export default function Settings() {
               </Text>
             </View>
             <View style={{ flexDirection: 'row', gap: 12, marginTop: 8 }}>
-              <Pressable
-                onPress={() => setShowDeleteModal(false)}
-                disabled={isDeleting}
-                style={{ flex: 1, paddingVertical: 14, borderRadius: 12, backgroundColor: isDark ? '#262626' : '#F3F0ED', alignItems: 'center' }}
-              >
-                <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 15, color: textColor }}>Cancel</Text>
-              </Pressable>
-              <Pressable
-                onPress={handleDeleteAccount}
-                disabled={isDeleting}
-                style={{ flex: 1, paddingVertical: 14, borderRadius: 12, backgroundColor: '#DC2626', alignItems: 'center' }}
-              >
-                {isDeleting ? (
-                  <ActivityIndicator size="small" color="#fff" />
-                ) : (
-                  <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 15, color: '#FFFFFF' }}>Delete Forever</Text>
-                )}
-              </Pressable>
+              <View style={{ flex: 1 }}>
+                <SecondaryButton
+                  onPress={() => setShowDeleteModal(false)}
+                  disabled={isDeleting}
+                >
+                  Cancel
+                </SecondaryButton>
+              </View>
+              <View style={{ flex: 1 }}>
+                <DestructiveButton
+                  onPress={handleDeleteAccount}
+                  disabled={isDeleting}
+                  loading={isDeleting}
+                >
+                  Delete Forever
+                </DestructiveButton>
+              </View>
             </View>
           </View>
         </View>

--- a/packages/frontend/components/MapPopover.tsx
+++ b/packages/frontend/components/MapPopover.tsx
@@ -113,7 +113,7 @@ export default function MapPopover({
         {/* CTA */}
         <button
           onClick={onViewPress}
-          className="w-full py-2 rounded-lg text-xs font-semibold text-white border-none cursor-pointer transition-opacity hover:opacity-90"
+          className="w-full py-2 rounded-full text-xs font-semibold text-white border-none cursor-pointer transition-opacity hover:opacity-90"
           style={{ backgroundColor: accent }}
         >
           View {isCenter ? 'Center' : 'Event'}

--- a/packages/frontend/components/landing/FinalCTA.tsx
+++ b/packages/frontend/components/landing/FinalCTA.tsx
@@ -71,11 +71,10 @@ export function FinalCTA() {
 
         <Pressable
           onPress={() => router.push('/auth')}
+          className="bg-primary active:bg-primary-press rounded-full"
           style={{
-            backgroundColor: '#EA580C',
             paddingHorizontal: 32,
             paddingVertical: 16,
-            borderRadius: 100,
             marginBottom: 16,
           }}
         >

--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -493,11 +493,10 @@ export function Hero() {
         >
           <Pressable
             onPress={() => router.push('/auth')}
+            className="bg-primary active:bg-primary-press rounded-full"
             style={{
-              backgroundColor: '#EA580C',
               paddingHorizontal: 28,
               paddingVertical: 14,
-              borderRadius: 100,
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'center',

--- a/packages/frontend/components/onboarding/complete.tsx
+++ b/packages/frontend/components/onboarding/complete.tsx
@@ -1,8 +1,9 @@
-import { View, Text, Pressable, Image, ActivityIndicator } from 'react-native'
+import { View, Text, Image } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import React, { useEffect, useState } from 'react'
 import { useOnboarding } from '../contexts'
 import { useThemeContext } from '../contexts'
+import { PrimaryButton } from '../ui'
 
 export default function Complete() {
   const { completeOnboarding, isSubmitting, submitError } = useOnboarding()
@@ -82,19 +83,14 @@ export default function Complete() {
 
         {/* Button */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             onPress={handleGetStarted}
             disabled={isSubmitting}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8 bg-primary active:bg-primary-press shadow-lg ${
-              isSubmitting ? 'opacity-70' : ''
-            }`}
+            loading={isSubmitting}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            {isSubmitting ? (
-              <ActivityIndicator color="#ffffff" />
-            ) : (
-              <Text className="text-white font-inter font-semibold text-base">Get Started</Text>
-            )}
-          </Pressable>
+            Get Started
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/onboarding/step1.tsx
+++ b/packages/frontend/components/onboarding/step1.tsx
@@ -1,7 +1,8 @@
-import { View, Text, Pressable, TextInput } from 'react-native'
+import { View, Text, TextInput } from 'react-native'
 import { useOnboarding } from '../contexts'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useState } from 'react'
+import { PrimaryButton } from '../ui'
 
 export default function StepOne() {
   const { goToNextStep, firstName, setFirstName, lastName, setLastName } = useOnboarding()
@@ -99,19 +100,13 @@ export default function StepOne() {
 
         {/* Button Area */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             onPress={handleContinue}
             disabled={!firstName.trim() || !lastName.trim()}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8
-              ${
-                !firstName.trim() || !lastName.trim()
-                  ? 'bg-orange-300'
-                  : 'bg-primary active:bg-primary-press'
-              }
-            `}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            <Text className="text-white font-inter font-semibold text-base">Continue</Text>
-          </Pressable>
+            Continue
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/onboarding/step2.tsx
+++ b/packages/frontend/components/onboarding/step2.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { View, Text, Pressable, Platform } from 'react-native'
+import { View, Text, Platform } from 'react-native'
 import { useOnboarding } from '../contexts'
 import BirthdatePicker from '../BirthdatePicker'
+import { PrimaryButton } from '../ui'
 
 export default function Step2() {
   const { goToNextStep, birthdate, setBirthdate } = useOnboarding()
@@ -32,19 +33,13 @@ export default function Step2() {
 
         {/* --- Continue Button --- */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             disabled={!isDateSelected}
             onPress={goToNextStep}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8
-              ${
-                !isDateSelected
-                  ? 'bg-orange-300'
-                  : 'bg-primary active:bg-primary-press'
-              }
-            `}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            <Text className="text-white font-inter font-semibold text-base">Continue</Text>
-          </Pressable>
+            Continue
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/onboarding/step3.tsx
+++ b/packages/frontend/components/onboarding/step3.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useRef } from 'react'
 import { calculateDistance } from '../../utils/distance'
 import { fetchCenters, CenterData } from '../../utils/api'
 import { Check } from 'lucide-react-native'
+import { PrimaryButton } from '../ui'
 
 interface CenterWithDistance {
   id: string
@@ -259,17 +260,13 @@ export default function Step3() {
 
         {/* Button */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             onPress={handleContinue}
             disabled={!selectedCenter}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8 ${
-              selectedCenter
-                ? 'bg-primary active:bg-primary-press'
-                : 'bg-orange-300'
-            }`}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            <Text className="text-white font-inter font-semibold text-base">Continue</Text>
-          </Pressable>
+            Continue
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/onboarding/step4.tsx
+++ b/packages/frontend/components/onboarding/step4.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import React, { useState } from 'react'
 import { useOnboarding } from '../contexts'
+import { PrimaryButton } from '../ui'
 
 export default function Step4() {
   const { goToNextStep, interests, setInterests } = useOnboarding()
@@ -85,17 +86,13 @@ export default function Step4() {
 
         {/* Button */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             onPress={handleContinue}
             disabled={interests.length === 0}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8 ${
-              interests.length > 0
-                ? 'bg-primary active:bg-primary-press'
-                : 'bg-orange-300'
-            }`}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            <Text className="text-white font-inter font-semibold text-base">Continue</Text>
-          </Pressable>
+            Continue
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/onboarding/step5.tsx
+++ b/packages/frontend/components/onboarding/step5.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import React, { useState } from 'react'
 import { useOnboarding } from '../contexts'
+import { PrimaryButton } from '../ui'
 
 export default function Step4() {
   const { goToNextStep } = useOnboarding()
@@ -83,17 +84,13 @@ export default function Step4() {
 
         {/* Button */}
         <View className="pb-6">
-          <Pressable
+          <PrimaryButton
             onPress={handleContinue}
             disabled={!memberType}
-            className={`w-full max-w-md self-center items-center justify-center rounded-xl py-4 px-8 ${
-              memberType
-                ? 'bg-primary active:bg-primary-press'
-                : 'bg-orange-300'
-            }`}
+            style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
-            <Text className="text-white font-inter font-semibold text-base">Continue</Text>
-          </Pressable>
+            Continue
+          </PrimaryButton>
         </View>
       </View>
     </SafeAreaView>

--- a/packages/frontend/components/ui/buttons/DestructiveButton.tsx
+++ b/packages/frontend/components/ui/buttons/DestructiveButton.tsx
@@ -1,27 +1,33 @@
-/**
- * AuthInput.tsx
- *
- * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
- * @author Abhiram Ramachandran
- * @date October 13, 2025
- * @description A Pressable component styled for destructive actions.
- * @requires react-native
- *
- */
-import { Pressable, Text } from 'react-native'
+import { Pressable, Text, ActivityIndicator } from 'react-native'
+import React from 'react'
 
-/**
- * Renders DestructiveButton component.
- * @param children - The content to be displayed inside the button.
- * @param props - Additional props to be passed to the Pressable component.
- * @returns TSX.Element
- */
-export default function DestructiveButton({ children, ...props }) {
+interface DestructiveButtonProps {
+  children: React.ReactNode
+  onPress?: () => void
+  disabled?: boolean
+  loading?: boolean
+  style?: any
+  [key: string]: any
+}
+
+export default function DestructiveButton({ children, onPress, disabled, loading, style, ...props }: DestructiveButtonProps) {
+  const isDisabled = disabled || loading
+
   return (
-    <Pressable className="bg-red-600 px-4 py-3 rounded-full active:bg-red-700" {...props}>
-      <Text className="text-backgroundStrong font-inter text-bold text-gray-100 text-center">
-        {children}
-      </Text>
+    <Pressable
+      onPress={!isDisabled ? onPress : undefined}
+      disabled={isDisabled}
+      className="bg-red-600 px-4 py-3 rounded-full active:bg-red-700 disabled:opacity-50"
+      style={style}
+      {...props}
+    >
+      {loading ? (
+        <ActivityIndicator size="small" color="#FFFFFF" />
+      ) : (
+        <Text className="text-backgroundStrong font-inter text-bold text-gray-100 leading-4 text-center">
+          {children}
+        </Text>
+      )}
     </Pressable>
   )
 }

--- a/packages/frontend/components/ui/buttons/GhostButton.tsx
+++ b/packages/frontend/components/ui/buttons/GhostButton.tsx
@@ -1,28 +1,24 @@
-/**
- * GhostButton.tsx
- *
- * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
- * @author Abhiram Ramachandran
- * @date October 13, 2025
- * @description A Pressable component styled for ghost buttons.
- * @requires module:react-native
- *
- */
 import { Pressable, Text } from 'react-native'
+import React from 'react'
 
-/**
- * Renders GhostButton component.
- * @param children - The content to be displayed inside the button.
- * @param props - Additional props to be passed to the Pressable component.
- * @returns TSX.Element
- */
-export default function GhostButton({ children, ...props }) {
+interface GhostButtonProps {
+  children: React.ReactNode
+  onPress?: () => void
+  disabled?: boolean
+  style?: any
+  [key: string]: any
+}
+
+export default function GhostButton({ children, onPress, disabled, style, ...props }: GhostButtonProps) {
   return (
     <Pressable
-      className="bg-transparent px-4 py-3 rounded-lg active:bg-gray-200 dark:active:bg-gray-700"
+      onPress={!disabled ? onPress : undefined}
+      disabled={disabled}
+      className="bg-transparent px-4 py-3 rounded-full active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
+      style={style}
       {...props}
     >
-      <Text className="text-content dark:text-content-dark text-base text-center">{children}</Text>
+      <Text className="text-content dark:text-content-dark text-base leading-4 text-center">{children}</Text>
     </Pressable>
   )
 }

--- a/packages/frontend/components/ui/buttons/IconButton.tsx
+++ b/packages/frontend/components/ui/buttons/IconButton.tsx
@@ -1,29 +1,28 @@
-/**
- * IconButton.tsx
- *
- * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
- * @author Abhiram Ramachandran
- * @date October 13, 2025
- * @description A Pressable component styled for icon buttons.
- * @requires module:react-native
- *
- */
 import { Pressable } from 'react-native'
+import React from 'react'
 
-/**
- * Renders IconButton component.
- * @param children - The content to be displayed inside the button.
- * @param variant - The variant of the button (solid or outlined).
- * @param props - Additional props to be passed to the Pressable component.
- * @returns TSX.Element
- */
-export default function IconButton({ children, variant = 'solid', ...props }) {
+interface IconButtonProps {
+  children: React.ReactNode
+  variant?: 'solid' | 'outlined'
+  onPress?: () => void
+  disabled?: boolean
+  style?: any
+  [key: string]: any
+}
+
+export default function IconButton({ children, variant = 'solid', onPress, disabled, style, ...props }: IconButtonProps) {
   const baseClass =
     variant === 'outlined'
-      ? 'border border-borderColor bg-transparent px-2 py-2 rounded-lg active:bg-gray-200'
-      : 'bg-gray-200 px-2 py-2 rounded-lg active:bg-gray-400'
+      ? 'border border-borderColor bg-transparent px-2 py-2 rounded-full active:bg-gray-200 disabled:opacity-50'
+      : 'bg-gray-200 px-2 py-2 rounded-full active:bg-gray-400 disabled:opacity-50'
   return (
-    <Pressable className={baseClass} {...props}>
+    <Pressable
+      onPress={!disabled ? onPress : undefined}
+      disabled={disabled}
+      className={baseClass}
+      style={style}
+      {...props}
+    >
       {children}
     </Pressable>
   )

--- a/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
+++ b/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { Pressable, Text } from 'react-native'
+import { Pressable, Text, ActivityIndicator } from 'react-native'
 
 interface PrimaryButtonProps {
   children: React.ReactNode
   onPress?: () => void
   disabled?: boolean
+  loading?: boolean
   style?: any
   className?: string
 }
@@ -13,11 +14,14 @@ export default function PrimaryButton({
   children,
   onPress,
   disabled,
+  loading,
   style,
   ...props
 }: PrimaryButtonProps) {
+  const isDisabled = disabled || loading
+
   const handlePress = () => {
-    if (!disabled && onPress) {
+    if (!isDisabled && onPress) {
       onPress()
     }
   }
@@ -25,12 +29,16 @@ export default function PrimaryButton({
   return (
     <Pressable
       onPress={handlePress}
-      disabled={disabled}
+      disabled={isDisabled}
       className="bg-primary px-4 py-3 rounded-full active:bg-primary-press disabled:opacity-50"
       style={style}
       {...props}
     >
-      <Text className="text-backgroundStrong font-inter text-base text-center">{children}</Text>
+      {loading ? (
+        <ActivityIndicator size="small" color="#FFFFFF" />
+      ) : (
+        <Text className="text-backgroundStrong font-inter text-base leading-4 text-center">{children}</Text>
+      )}
     </Pressable>
   )
 }

--- a/packages/frontend/components/ui/buttons/PrimaryButton.web.tsx
+++ b/packages/frontend/components/ui/buttons/PrimaryButton.web.tsx
@@ -4,6 +4,7 @@ interface PrimaryButtonProps {
   children: React.ReactNode
   onPress?: () => void
   disabled?: boolean
+  loading?: boolean
   style?: any
   className?: string
 }
@@ -12,14 +13,17 @@ export default function PrimaryButton({
   children,
   onPress,
   disabled,
+  loading,
   style,
 }: PrimaryButtonProps) {
+  const isDisabled = disabled || loading
+
   const handleClick = (e: any) => {
     if (e) {
       e.preventDefault()
       e.stopPropagation()
     }
-    if (!disabled && onPress) {
+    if (!isDisabled && onPress) {
       onPress()
     }
   }
@@ -28,13 +32,22 @@ export default function PrimaryButton({
     <button
       type="button"
       onClick={handleClick}
-      disabled={disabled}
+      disabled={isDisabled}
       className="bg-primary px-4 py-3 rounded-full active:bg-primary-press disabled:opacity-50 cursor-pointer w-full"
       style={{ border: 'none', outline: 'none', ...style }}
     >
-      <span className="text-backgroundStrong font-inter text-base text-center block">
-        {children}
-      </span>
+      {loading ? (
+        <span className="flex items-center justify-center">
+          <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+        </span>
+      ) : (
+        <span className="text-backgroundStrong font-inter text-base leading-4 text-center block">
+          {children}
+        </span>
+      )}
     </button>
   )
 }

--- a/packages/frontend/components/ui/buttons/SecondaryButton.tsx
+++ b/packages/frontend/components/ui/buttons/SecondaryButton.tsx
@@ -1,29 +1,33 @@
-/**
- * SecondaryButton.tsx
- *
- * Om Sri Cinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
- * @author Abhiram Ramachandran
- * @date October 13, 2025
- * @description A Pressable component styled for secondary actions.
- * @requires module:react-native
- */
-import { Pressable, Text } from 'react-native'
+import { Pressable, Text, ActivityIndicator } from 'react-native'
+import React from 'react'
 
-/**
- * Renders a secondary button.
- * @param children - The content to be displayed inside the button.
- * @param props - Additional props to be passed to the Pressable component.
- * @returns TSX.Element
- */
-export default function SecondaryButton({ children, ...props }) {
+interface SecondaryButtonProps {
+  children: React.ReactNode
+  onPress?: () => void
+  disabled?: boolean
+  loading?: boolean
+  style?: any
+  [key: string]: any
+}
+
+export default function SecondaryButton({ children, onPress, disabled, loading, style, ...props }: SecondaryButtonProps) {
+  const isDisabled = disabled || loading
+
   return (
     <Pressable
-      className="border border-borderColor dark:border-borderColor-dark bg-transparent text-content dark:text-content-dark px-4 py-3 rounded-full active:bg-gray-4"
+      onPress={!isDisabled ? onPress : undefined}
+      disabled={isDisabled}
+      className="border border-borderColor dark:border-borderColor-dark bg-transparent text-content dark:text-content-dark px-4 py-3 rounded-full active:bg-gray-4 disabled:opacity-50"
+      style={style}
       {...props}
     >
-      <Text className="font-inter text-content dark:text-content-dark text-base text-center">
-        {children}
-      </Text>
+      {loading ? (
+        <ActivityIndicator size="small" color="#78716C" />
+      ) : (
+        <Text className="font-inter text-content dark:text-content-dark text-base leading-4 text-center">
+          {children}
+        </Text>
+      )}
     </Pressable>
   )
 }

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -4,6 +4,8 @@ import { MapPin, Users, User, Clock, CheckCircle, ChevronLeft, Pencil } from 'lu
 import Badge from '../ui/Badge'
 import UnderlineTabBar from '../ui/UnderlineTabBar'
 import Avatar from '../ui/Avatar'
+import PrimaryButton from '../ui/buttons/PrimaryButton'
+import DestructiveButton from '../ui/buttons/DestructiveButton'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 
 // ---------------------------------------------------------------------------
@@ -674,32 +676,13 @@ function ActionBar({
           backgroundColor: colors.panelBg,
         }}
       >
-        <Pressable
+        <DestructiveButton
           onPress={onToggleRegistration}
           disabled={isToggling}
-          style={{
-            height: 48,
-            borderRadius: 10,
-            backgroundColor: 'rgba(239,68,68,0.1)',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: isToggling ? 0.6 : 1,
-          }}
+          loading={isToggling}
         >
-          {isToggling ? (
-            <ActivityIndicator size="small" color="#EF4444" />
-          ) : (
-            <Text
-              style={{
-                fontFamily: 'Inter-Medium',
-                fontSize: 15,
-                color: '#EF4444',
-              }}
-            >
-              Cancel Registration
-            </Text>
-          )}
-        </Pressable>
+          Cancel Registration
+        </DestructiveButton>
       </View>
     )
   }
@@ -713,32 +696,13 @@ function ActionBar({
         backgroundColor: colors.panelBg,
       }}
     >
-      <Pressable
+      <PrimaryButton
         onPress={onToggleRegistration}
         disabled={isToggling}
-        style={{
-          height: 48,
-          borderRadius: 10,
-          backgroundColor: '#E8862A',
-          alignItems: 'center',
-          justifyContent: 'center',
-          opacity: isToggling ? 0.6 : 1,
-        }}
+        loading={isToggling}
       >
-        {isToggling ? (
-          <ActivityIndicator size="small" color="#FFFFFF" />
-        ) : (
-          <Text
-            style={{
-              fontFamily: 'Inter-SemiBold',
-              fontSize: 15,
-              color: '#FFFFFF',
-            }}
-          >
-            Attend Event
-          </Text>
-        )}
-      </Pressable>
+        Attend Event
+      </PrimaryButton>
       <Text
         style={{
           fontFamily: 'Inter-Regular',

--- a/packages/frontend/components/web/EventFormPanel.tsx
+++ b/packages/frontend/components/web/EventFormPanel.tsx
@@ -11,6 +11,8 @@ import {
   ChevronDown,
 } from 'lucide-react-native'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import PrimaryButton from '../ui/buttons/PrimaryButton'
+import SecondaryButton from '../ui/buttons/SecondaryButton'
 import {
   fetchEvent,
   fetchCenters,
@@ -623,42 +625,20 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
           gap: 10,
         }}
       >
-        <Pressable
+        <SecondaryButton
           onPress={onClose}
-          style={{
-            paddingHorizontal: 20,
-            paddingVertical: 10,
-            borderRadius: 10,
-            backgroundColor: colors.iconBoxBg,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          style={{ paddingHorizontal: 20, paddingVertical: 10 }}
         >
-          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: colors.text }}>
-            Cancel
-          </Text>
-        </Pressable>
-        <Pressable
+          Cancel
+        </SecondaryButton>
+        <PrimaryButton
           onPress={handleSave}
           disabled={saving}
-          style={{
-            paddingHorizontal: 24,
-            paddingVertical: 10,
-            borderRadius: 10,
-            backgroundColor: '#E8862A',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: saving ? 0.6 : 1,
-          }}
+          loading={saving}
+          style={{ paddingHorizontal: 24, paddingVertical: 10 }}
         >
-          {saving ? (
-            <ActivityIndicator size="small" color="#FFFFFF" />
-          ) : (
-            <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#FFFFFF' }}>
-              {isEdit ? 'Save Changes' : 'Create Event'}
-            </Text>
-          )}
-        </Pressable>
+          {isEdit ? 'Save Changes' : 'Create Event'}
+        </PrimaryButton>
       </View>
     </View>
   )


### PR DESCRIPTION
## Summary
- Consolidate all action buttons across the app to use 5 shared components (`PrimaryButton`, `SecondaryButton`, `DestructiveButton`, `GhostButton`, `IconButton`) with consistent `rounded-full` pill shape
- Add `loading` prop with spinner to `PrimaryButton`, `SecondaryButton`, and `DestructiveButton`
- Fix `leading-4` (1rem) line-height on all button labels to match NativeWind's native behavior on web
- Replace ~20 inline button implementations with mixed `border-radius` values (8px, 10px, 12px, `rounded-lg`, `rounded-xl`) and inconsistent disabled/loading states
- Add `admin.tsx` native fallback for `admin.web.tsx` to fix expo-router missing sibling file error

## Files changed (25)
**Button components** (source of truth):
- `PrimaryButton.web.tsx` / `PrimaryButton.native.tsx` — added `loading` prop, `leading-4`
- `SecondaryButton.tsx` — added `loading` prop, typed interface, `leading-4`
- `DestructiveButton.tsx` — added `loading` prop, typed interface, `leading-4`
- `GhostButton.tsx` — `rounded-lg` → `rounded-full`, typed interface, `leading-4`
- `IconButton.tsx` — `rounded-lg` → `rounded-full`, typed interface

**Consumers updated**:
- Onboarding steps 1-5 + complete → `PrimaryButton`
- Auth page → `PrimaryButton` with `loading`
- Event form (native + web) → `PrimaryButton` + `SecondaryButton`
- Event detail (native + web) → `PrimaryButton` + `DestructiveButton`
- Settings delete modal → `SecondaryButton` + `DestructiveButton`
- Landing Hero + FinalCTA → `bg-primary` class with `rounded-full`
- MapPopover → `rounded-full`
- Tab layout header → `PrimaryButton` for login

## Test plan
- [ ] Verify buttons render with pill shape on web (all pages)
- [ ] Verify buttons render correctly on iOS
- [ ] Check loading spinners on auth, event form save, event register/cancel, delete account
- [ ] Confirm no TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)