### PR TITLE
fix: harden iOS/Android config for App Store submission

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -17,37 +17,26 @@
     ],
     "ios": {
       "supportsTablet": true,
+      "buildNumber": "1",
       "infoPlist": {
-        "NSAppTransportSecurity": {
-          "NSAllowsArbitraryLoads": true,
-          "NSExceptionDomains": {
-            "localhost": {
-              "NSExceptionAllowsInsecureHTTPLoads": true
-            },
-            "ec2-3-236-142-145.compute-1.amazonaws.com": {
-              "NSExceptionAllowsInsecureHTTPLoads": true
-            },
-            "3.236.142.145": {
-              "NSExceptionAllowsInsecureHTTPLoads": true
-            }
-          }
-        }
+        "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
+        "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",
+        "NSCameraUsageDescription": "Chinmaya Janata needs access to your camera to take a profile picture."
       },
-      "bundleIdentifier": "com.anonymous.chinmayajanata"
+      "bundleIdentifier": "org.chinmayamission.janata"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/logo.png",
         "backgroundColor": "#ffffff"
       },
-      "usesCleartextTraffic": true,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",
-        "INTERNET",
-        "ACCESS_NETWORK_STATE"
+        "ACCESS_FINE_LOCATION",
+        "ACCESS_COARSE_LOCATION"
       ],
-      "package": "com.anonymous.chinmayajanata"
+      "package": "org.chinmayamission.janata"
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
## Summary
- Remove `NSAllowsArbitraryLoads` and insecure HTTP exceptions (security risk + App Store rejection)
- Remove hardcoded AWS EC2 IP exception from production config
- Remove `usesCleartextTraffic` on Android
- Add `NSLocationWhenInUseUsageDescription` for location permissions
- Add `NSPhotoLibraryUsageDescription` and `NSCameraUsageDescription`
- Add iOS `buildNumber` for version management
- Change bundle ID from `com.anonymous.chinmayajanata` to `org.chinmayamission.janata`
- Fix duplicate Android permissions and add location permissions

## Test plan
- [ ] Verify iOS build succeeds with new bundle ID
- [ ] Verify location permission prompt shows correct description on iOS
- [ ] Verify Android build succeeds
- [ ] Confirm HTTPS-only API calls work correctly

https://claude.ai/code/session_016z9ksWnLDSqDpsnMxAuVPE