### PR TITLE
feat: add ErrorBoundary to prevent white-screen crashes

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -18,6 +18,7 @@ import {
   ThemeProvider as CustomThemeProvider,
   useThemeContext,
 } from '../components/contexts'
+import { ErrorBoundary } from '../components/ui/ErrorBoundary'
 import '../globals.css'
 
 export const unstable_settings = {
@@ -73,11 +74,13 @@ export default function RootLayout() {
         host: 'https://us.i.posthog.com',
       }}
     >
-      <CustomThemeProvider>
-        <UserProvider>
-          <RootLayoutNav />
-        </UserProvider>
-      </CustomThemeProvider>
+      <ErrorBoundary>
+        <CustomThemeProvider>
+          <UserProvider>
+            <RootLayoutNav />
+          </UserProvider>
+        </CustomThemeProvider>
+      </ErrorBoundary>
     </PostHogProvider>
   )
 }

--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import React, { Component, type ErrorInfo, type ReactNode } from 'react'
+import { View, Text, Pressable } from 'react-native'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (__DEV__) {
+      console.error('ErrorBoundary caught:', error, info.componentStack)
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: 24,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 20,
+              fontWeight: '600',
+              color: '#1a1a1a',
+              marginBottom: 8,
+            }}
+          >
+            Something went wrong
+          </Text>
+          <Text
+            style={{
+              fontSize: 14,
+              color: '#666',
+              textAlign: 'center',
+              marginBottom: 24,
+            }}
+          >
+            An unexpected error occurred. Please try again.
+          </Text>
+          <Pressable
+            onPress={this.handleRetry}
+            style={{
+              backgroundColor: '#ea580c',
+              paddingHorizontal: 24,
+              paddingVertical: 12,
+              borderRadius: 9999,
+            }}
+          >
+            <Text style={{ color: '#fff', fontWeight: '600', fontSize: 16 }}>
+              Try Again
+            </Text>
+          </Pressable>
+        </View>
+      )
+    }
+
+    return this.props.children
+  }
+}


### PR DESCRIPTION
## Summary
- Create `ErrorBoundary` component with retry button and fallback UI
- Wrap root layout with ErrorBoundary to catch unhandled component errors
- Shows user-friendly "Something went wrong" screen with "Try Again" button instead of blank white page
- Logs errors in development mode for debugging

## Test plan
- [ ] Force a component error and verify the fallback UI appears
- [ ] Verify "Try Again" button recovers the app
- [ ] Verify normal app flow is unaffected

https://claude.ai/code/session_016z9ksWnLDSqDpsnMxAuVPE