### PR TITLE
security: move PostHog API key to env variable

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,6 @@
+# PostHog analytics
+EXPO_PUBLIC_POSTHOG_KEY=phc_your_posthog_key_here
+EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# API base URL (optional — defaults to localhost in dev, production URL in prod)
+# EXPO_PUBLIC_API_BASE_URL=https://api.chinmayajanata.org/api

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -68,9 +68,9 @@ export default function RootLayout() {
 
   return (
     <PostHogProvider
-      apiKey="phc_5o67MgFjj113GN0QKduyyIs0BmEQkpWc8D2eDi6ju7Q"
+      apiKey={process.env.EXPO_PUBLIC_POSTHOG_KEY || ''}
       options={{
-        host: 'https://us.i.posthog.com',
+        host: process.env.EXPO_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
       }}
     >
       <CustomThemeProvider>


### PR DESCRIPTION
## Summary
- Replace hardcoded PostHog key with `EXPO_PUBLIC_POSTHOG_KEY` env variable
- Replace hardcoded PostHog host with `EXPO_PUBLIC_POSTHOG_HOST` env variable
- Add `.env.example` with placeholder values for developer setup

**Note:** You'll need to set `EXPO_PUBLIC_POSTHOG_KEY=phc_5o67MgFjj113GN0QKduyyIs0BmEQkpWc8D2eDi6ju7Q` in your `.env` file or CI/CD environment.

## Test plan
- [ ] Verify PostHog events fire with env var set
- [ ] Verify app doesn't crash when env var is missing (empty string fallback)

https://claude.ai/code/session_016z9ksWnLDSqDpsnMxAuVPE