### PR TITLE
feat: add EmptyState component with icons and contextual messaging

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 // Discover tab — mobile / native layout
 import React, { useState, Suspense, useRef, useCallback } from 'react'
+import { EmptyState } from '../../components/ui/EmptyState'
 import {
   View,
   Text,
@@ -444,11 +445,7 @@ export default function DiscoverScreen() {
             scrollEnabled={isSheetExpanded}
           >
             {!loading && displayItems.length === 0 && (
-              <View className="py-12 items-center">
-                <Text className="text-stone-400 dark:text-stone-500 font-inter text-sm">
-                  {selectedDate ? 'No events on this day' : 'No results found'}
-                </Text>
-              </View>
+              <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
             {displayItems.map((item) =>
               item.type === 'event' ? (

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -1,4 +1,5 @@
 // Discover tab — web desktop layout
+import { EmptyState } from '../../components/ui/EmptyState'
 import React, {
   useState,
   useCallback,
@@ -653,11 +654,7 @@ function MobileDiscoverFallback() {
             scrollEnabled={isExpanded}
           >
             {!loading && displayItems.length === 0 && (
-              <View className="py-12 items-center">
-                <Text className="text-stone-400 dark:text-stone-500 font-inter text-sm">
-                  {selectedDate ? 'No events on this day' : 'No results found'}
-                </Text>
-              </View>
+              <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
             {displayItems.map((item) =>
               item.type === 'event' ? (
@@ -974,11 +971,7 @@ export default function DiscoverScreenWeb() {
               showsVerticalScrollIndicator={false}
             >
               {!loading && displayItems.length === 0 && (
-                <View className="py-16 items-center">
-                  <Text className="text-stone-400 dark:text-stone-500 font-inter text-sm">
-                    {selectedDate ? 'No events on this day' : 'No results found'}
-                  </Text>
-                </View>
+                <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
               )}
               {displayItems.map((item) =>
                 item.type === 'event' ? (

--- a/packages/frontend/components/ui/EmptyState.tsx
+++ b/packages/frontend/components/ui/EmptyState.tsx
@@ -1,0 +1,64 @@
+import { View, Text } from 'react-native'
+import { Calendar, MapPin, Search } from 'lucide-react-native'
+
+type EmptyStateVariant = 'events' | 'centers' | 'search' | 'date'
+
+interface EmptyStateProps {
+  variant?: EmptyStateVariant
+  message?: string
+  subtitle?: string
+}
+
+const config: Record<EmptyStateVariant, { icon: typeof Calendar; title: string; subtitle: string }> = {
+  events: {
+    icon: Calendar,
+    title: 'No events yet',
+    subtitle: 'Events you register for will appear here',
+  },
+  centers: {
+    icon: MapPin,
+    title: 'No centers found',
+    subtitle: 'Try adjusting your search or location',
+  },
+  search: {
+    icon: Search,
+    title: 'No results found',
+    subtitle: 'Try a different search term',
+  },
+  date: {
+    icon: Calendar,
+    title: 'No events on this day',
+    subtitle: 'Try selecting a different date',
+  },
+}
+
+export function EmptyState({ variant = 'search', message, subtitle }: EmptyStateProps) {
+  const { icon: Icon, title, subtitle: defaultSubtitle } = config[variant]
+
+  return (
+    <View style={{ paddingVertical: 48, alignItems: 'center', paddingHorizontal: 24 }}>
+      <Icon size={40} color="#a8a29e" />
+      <Text
+        style={{
+          marginTop: 16,
+          fontSize: 16,
+          fontWeight: '600',
+          color: '#78716c',
+          textAlign: 'center',
+        }}
+      >
+        {message || title}
+      </Text>
+      <Text
+        style={{
+          marginTop: 6,
+          fontSize: 13,
+          color: '#a8a29e',
+          textAlign: 'center',
+        }}
+      >
+        {subtitle || defaultSubtitle}
+      </Text>
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- Create reusable `EmptyState` component with icon, title, and subtitle
- Support variants: `events`, `centers`, `search`, `date`
- Replace plain text empty states in discover tab (native + web mobile + web desktop)
- Show contextual messaging based on active filter/search state

## Test plan
- [ ] Filter to a date with no events — verify date empty state shows
- [ ] Search for nonexistent term — verify search empty state shows
- [ ] Verify empty state renders correctly on web and native

https://claude.ai/code/session_016z9ksWnLDSqDpsnMxAuVPE