### PR TITLE
feat: add skeleton loaders to replace spinner loading states

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 // Discover tab — mobile / native layout
 import React, { useState, Suspense, useRef, useCallback } from 'react'
 import { EmptyState } from '../../components/ui/EmptyState'
+import { DiscoverListSkeleton } from '../../components/ui/Skeleton'
 import {
   View,
   Text,
@@ -430,10 +431,10 @@ export default function DiscoverScreen() {
             )}
           </View>
 
-          {/* Loading indicator */}
+          {/* Loading skeleton */}
           {loading && (
-            <View className="py-4 items-center">
-              <ActivityIndicator size="small" color="#9A3412" />
+            <View style={{ paddingHorizontal: 16 }}>
+              <DiscoverListSkeleton count={4} />
             </View>
           )}
 

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -1,5 +1,6 @@
 // Discover tab — web desktop layout
 import { EmptyState } from '../../components/ui/EmptyState'
+import { DiscoverListSkeleton } from '../../components/ui/Skeleton'
 import React, {
   useState,
   useCallback,
@@ -639,10 +640,10 @@ function MobileDiscoverFallback() {
             )}
           </div>
 
-          {/* Loading indicator */}
+          {/* Loading skeleton */}
           {loading && (
-            <View className="py-3 items-center">
-              <ActivityIndicator size="small" color="#9A3412" />
+            <View style={{ paddingHorizontal: 12 }}>
+              <DiscoverListSkeleton count={4} />
             </View>
           )}
 
@@ -957,10 +958,10 @@ export default function DiscoverScreenWeb() {
               </View>
             )}
 
-            {/* Loading indicator */}
+            {/* Loading skeleton */}
             {loading && (
-              <View className="py-4 items-center">
-                <ActivityIndicator size="small" color="#9A3412" />
+              <View style={{ paddingHorizontal: 16 }}>
+                <DiscoverListSkeleton count={5} />
               </View>
             )}
 

--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { DetailSkeleton } from '../../components/ui/Skeleton'
 import {
   View,
   Text,
@@ -178,9 +179,7 @@ export default function CenterDetailPage() {
   if (loading) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }} edges={['top']}>
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <ActivityIndicator size="large" color="#E8862A" />
-        </View>
+        <DetailSkeleton />
       </SafeAreaView>
     )
   }

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Alert, Share } from 'react-native'
+import { DetailSkeleton } from '../../components/ui/Skeleton'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import {
@@ -502,9 +503,7 @@ export default function EventDetailPage() {
   if (loading) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <ActivityIndicator size="large" color="#E8862A" />
-        </View>
+        <DetailSkeleton />
       </SafeAreaView>
     )
   }

--- a/packages/frontend/components/ui/Skeleton.tsx
+++ b/packages/frontend/components/ui/Skeleton.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react'
+import { View, Animated, StyleSheet, type ViewStyle } from 'react-native'
+
+interface SkeletonProps {
+  width?: number | string
+  height?: number
+  borderRadius?: number
+  style?: ViewStyle
+}
+
+function SkeletonBox({ width = '100%', height = 16, borderRadius = 8, style }: SkeletonProps) {
+  const opacity = useRef(new Animated.Value(0.3)).current
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+      ])
+    )
+    animation.start()
+    return () => animation.stop()
+  }, [opacity])
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width: width as any,
+          height,
+          borderRadius,
+          backgroundColor: '#d6d3d1',
+          opacity,
+        },
+        style,
+      ]}
+    />
+  )
+}
+
+export function EventCardSkeleton() {
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardBody}>
+        <SkeletonBox width="60%" height={14} />
+        <SkeletonBox width="40%" height={12} style={{ marginTop: 8 }} />
+        <SkeletonBox width="80%" height={12} style={{ marginTop: 8 }} />
+        <View style={{ flexDirection: 'row', gap: 8, marginTop: 12 }}>
+          <SkeletonBox width={28} height={28} borderRadius={14} />
+          <SkeletonBox width={28} height={28} borderRadius={14} />
+          <SkeletonBox width={28} height={28} borderRadius={14} />
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export function CenterCardSkeleton() {
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardBody}>
+        <SkeletonBox width="50%" height={14} />
+        <SkeletonBox width="70%" height={12} style={{ marginTop: 8 }} />
+      </View>
+    </View>
+  )
+}
+
+export function DiscoverListSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <View style={{ gap: 8, paddingTop: 8 }}>
+      {Array.from({ length: count }).map((_, i) => (
+        <View key={i}>{i % 3 === 2 ? <CenterCardSkeleton /> : <EventCardSkeleton />}</View>
+      ))}
+    </View>
+  )
+}
+
+export function DetailSkeleton() {
+  return (
+    <View style={{ padding: 20, gap: 16 }}>
+      <SkeletonBox width="100%" height={200} borderRadius={12} />
+      <SkeletonBox width="70%" height={20} />
+      <SkeletonBox width="40%" height={14} />
+      <SkeletonBox width="90%" height={14} />
+      <SkeletonBox width="85%" height={14} />
+      <SkeletonBox width="60%" height={14} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fafaf9',
+    borderRadius: 12,
+    padding: 16,
+  },
+  cardBody: {
+    gap: 0,
+  },
+})


### PR DESCRIPTION
## Summary
- Create reusable Skeleton components (`SkeletonBox`, `EventCardSkeleton`, `CenterCardSkeleton`, `DiscoverListSkeleton`, `DetailSkeleton`)
- Animated pulse effect for better perceived performance
- Replace ActivityIndicator spinners with skeletons in:
  - Discover tab list (native + web mobile + web desktop)
  - Event detail screen
  - Center detail screen

## Test plan
- [ ] Verify skeleton animation appears during loading on discover tab
- [ ] Verify skeleton appears on event detail page load
- [ ] Verify skeleton appears on center detail page load
- [ ] Verify no layout shift when content replaces skeleton

https://claude.ai/code/session_016z9ksWnLDSqDpsnMxAuVPE