### PR TITLE
fix(fonts): restore runtime Inter font loading

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, LogBox, Platform, View } from 'react-native'
 
 // Suppress non-fatal WorkletsTurboModule error in Expo Go (reanimated v4 compat)
 LogBox.ignoreLogs(['Exception in HostFunction: <unknown>'])
+import { useFonts } from 'expo-font'
 import {
   DarkTheme,
   DefaultTheme,
@@ -32,11 +33,23 @@ const posthogKey = (process.env.EXPO_PUBLIC_POSTHOG_KEY || '').trim()
 const posthogEnabled = posthogKey.length > 0
 
 export default function RootLayout() {
-  // Fonts are embedded at build time via expo-font config plugin in app.json.
-  // No runtime loading needed — avoids CoreText crash on iOS 26 beta.
+  const [fontsLoaded] = useFonts({
+    'Inter-Regular': require('../assets/fonts/Inter-Regular.ttf'),
+    'Inter-Bold': require('../assets/fonts/Inter-Bold.ttf'),
+    'Inter-SemiBold': require('../assets/fonts/Inter-SemiBold.ttf'),
+    'Inter-Medium': require('../assets/fonts/Inter-Medium.ttf'),
+    'Inter-Light': require('../assets/fonts/Inter-Light.ttf'),
+  })
+
   useEffect(() => {
-    SplashScreen.hideAsync().catch(() => {})
-  }, [])
+    if (fontsLoaded) {
+      SplashScreen.hideAsync().catch(() => {})
+    }
+  }, [fontsLoaded])
+
+  if (!fontsLoaded) {
+    return null
+  }
 
   return (
     <PostHogProvider


### PR DESCRIPTION
## Summary
- Restores `useFonts()` runtime font loading that was removed in `e7f6e5d` to avoid a CoreText crash on iOS 26 beta
- The expo-font config plugin was never configured with font file paths, so removing `useFonts()` caused all Inter fonts to stop loading on native (fell back to system fonts)
- Verified working on iOS simulator

## Test plan
- [x] Tested on iPhone 16 Pro simulator — Inter fonts render correctly
- [x] Splash screen hides after fonts load

🤖 Generated with [Claude Code](https://claude.com/claude-code)