### PR TITLE
fix(frontend): dark mode toggle not applying on web

### DIFF
--- a/packages/frontend/components/contexts/ThemeContext.tsx
+++ b/packages/frontend/components/contexts/ThemeContext.tsx
@@ -5,6 +5,15 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const THEME_PREFERENCE_KEY = '@theme_preference'
 
+// Read initial preference synchronously on web, null on native (loaded async)
+function getInitialPreference(): 'light' | 'dark' | 'system' | null {
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    const saved = localStorage.getItem(THEME_PREFERENCE_KEY)
+    if (saved === 'light' || saved === 'dark' || saved === 'system') return saved
+  }
+  return null
+}
+
 // Safe storage wrapper
 const safeStorage = {
   getItem: async (key: string): Promise<string | null> => {
@@ -35,11 +44,22 @@ const safeStorage = {
   },
 }
 
-// Provider that initializes theme from system
+/** Apply dark/light class and colorScheme style on web */
+function applyWebTheme(theme: 'light' | 'dark') {
+  if (Platform.OS !== 'web' || typeof document === 'undefined') return
+  if (theme === 'dark') {
+    document.documentElement.classList.add('dark')
+    document.documentElement.style.colorScheme = 'dark'
+  } else {
+    document.documentElement.classList.remove('dark')
+    document.documentElement.style.colorScheme = 'light'
+  }
+}
+
+// Provider that initializes theme from storage/system
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const systemScheme = useSystemColorScheme()
   const { setColorScheme } = useNativeWindColorScheme()
-  const [initialized, setInitialized] = useState(false)
 
   // Load saved preference on mount and apply once
   useEffect(() => {
@@ -47,33 +67,20 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     const loadPreference = async () => {
       try {
         const saved = await safeStorage.getItem(THEME_PREFERENCE_KEY)
-        if (isMounted) {
-          let themeToApply: 'light' | 'dark'
+        if (!isMounted) return
 
-          if (saved === 'light' || saved === 'dark') {
-            themeToApply = saved
-          } else {
-            // Default to system or light
-            themeToApply = (systemScheme as 'light' | 'dark') || 'light'
-          }
-
-          setColorScheme(themeToApply)
-
-          // For web, set class immediately
-          if (Platform.OS === 'web' && typeof document !== 'undefined') {
-            if (themeToApply === 'dark') {
-              document.documentElement.classList.add('dark')
-            } else {
-              document.documentElement.classList.remove('dark')
-            }
-          }
-
-          setInitialized(true)
+        let themeToApply: 'light' | 'dark'
+        if (saved === 'light' || saved === 'dark') {
+          themeToApply = saved
+        } else {
+          themeToApply = (systemScheme as 'light' | 'dark') || 'light'
         }
+
+        setColorScheme(themeToApply)
+        // Apply after NativeWind processes the change
+        requestAnimationFrame(() => applyWebTheme(themeToApply))
       } catch (error) {
-        if (isMounted) {
-          setInitialized(true)
-        }
+        // ignore
       }
     }
     loadPreference()
@@ -88,11 +95,16 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 // Re-export NativeWind's hook with additional theme preference methods
 export const useThemeContext = () => {
   const { colorScheme, setColorScheme, toggleColorScheme } = useNativeWindColorScheme()
-  const systemScheme = useSystemColorScheme() // MUST be called at top level, not inside callback
-  const [themePreference, setThemePreferenceState] = useState<'light' | 'dark' | 'system'>('system')
+  const systemScheme = useSystemColorScheme() // MUST be called at top level
+  const initialPref = getInitialPreference()
+  const [themePreference, setThemePreferenceState] = useState<'light' | 'dark' | 'system'>(
+    initialPref ?? 'system'
+  )
+  const [loaded, setLoaded] = useState(initialPref !== null)
 
-  // Load saved preference
+  // Load saved preference (async — needed for native, instant on web)
   useEffect(() => {
+    if (loaded) return // Already loaded synchronously on web
     let isMounted = true
     const loadPreference = async () => {
       try {
@@ -102,27 +114,26 @@ export const useThemeContext = () => {
         }
       } catch (error) {
         // Failed to load theme preference
+      } finally {
+        if (isMounted) setLoaded(true)
       }
     }
     loadPreference()
     return () => {
       isMounted = false
     }
-  }, [])
+  }, [loaded])
 
   // React to system appearance changes when in 'system' mode
+  // Only fires after preference is loaded to avoid overriding saved dark/light
   useEffect(() => {
+    if (!loaded) return
     if (themePreference === 'system' && systemScheme) {
-      setColorScheme(systemScheme as 'light' | 'dark')
-      if (Platform.OS === 'web' && typeof document !== 'undefined') {
-        if (systemScheme === 'dark') {
-          document.documentElement.classList.add('dark')
-        } else {
-          document.documentElement.classList.remove('dark')
-        }
-      }
+      const theme = (systemScheme as 'light' | 'dark') || 'light'
+      setColorScheme(theme)
+      requestAnimationFrame(() => applyWebTheme(theme))
     }
-  }, [themePreference, systemScheme, setColorScheme])
+  }, [loaded, themePreference, systemScheme, setColorScheme])
 
   const setThemePreference = useCallback(
     async (mode: 'light' | 'dark' | 'system') => {
@@ -130,25 +141,16 @@ export const useThemeContext = () => {
         await safeStorage.setItem(THEME_PREFERENCE_KEY, mode)
         setThemePreferenceState(mode)
 
-        // Apply theme immediately
         let themeToApply: 'light' | 'dark'
         if (mode === 'system') {
-          // Use system preference (from hook called at top level)
           themeToApply = (systemScheme as 'light' | 'dark') || 'light'
         } else {
           themeToApply = mode
         }
 
         setColorScheme(themeToApply)
-
-        // For web, update class
-        if (Platform.OS === 'web' && typeof document !== 'undefined') {
-          if (themeToApply === 'dark') {
-            document.documentElement.classList.add('dark')
-          } else {
-            document.documentElement.classList.remove('dark')
-          }
-        }
+        // Ensure class is applied after NativeWind side-effects
+        requestAnimationFrame(() => applyWebTheme(themeToApply))
       } catch (error) {
         // Failed to save theme preference
       }


### PR DESCRIPTION
## Summary
- Fixed race condition in `ThemeContext.tsx` where the system-scheme effect overrode the saved dark/light preference on mount
- Added synchronous localStorage read on web to avoid async gap between ThemeProvider and useThemeContext
- Centralized web theme application via `applyWebTheme()` with `requestAnimationFrame` to ensure the `dark` class is applied after NativeWind processes `setColorScheme`

## Test plan
- [x] Toggle Light → Dark → Auto on web settings page
- [x] Verify dark mode persists when navigating to home page
- [x] Verify light mode applies correctly when selected
- [ ] Test on iOS/Android native

🤖 Generated with [Claude Code](https://claude.com/claude-code)