### PR TITLE
fix: auth signup mode skipping email step

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -36,7 +36,6 @@ export default function AuthScreen() {
   const [authStep, setAuthStep] = useState<AuthStep>(
     params.mode === 'login' ? 'login'
       : params.mode === 'signup' && urlInviteCode ? 'signup'
-      : params.mode === 'signup' ? 'invite-code'
       : 'initial'
   )
   const [username, setUsername] = useState('')

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -57,7 +57,6 @@ export default function AuthScreen() {
   const [authStep, setAuthStep] = useState<AuthStep>(
     initialMode === 'login' ? 'login'
       : initialMode === 'signup' && urlInviteCode ? 'signup'
-      : initialMode === 'signup' ? 'invite-code'
       : 'initial'
   )
   const [username, setUsername] = useState('')


### PR DESCRIPTION
## Summary
- Navigating to `/auth?mode=signup` without an invite code was dropping users into the invite-code step with no email field visible
- Now correctly starts at the initial (email) step unless an invite code is provided via URL param

## Test plan
- [ ] Navigate to `/auth?mode=signup` — should show email field first
- [ ] Navigate to `/auth?mode=signup&inviteCode=PUBLIC-EXPLORE` — should skip to signup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)