### PR TITLE
fix(frontend): UX spacing and touch target audit

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -46,17 +46,6 @@
     "plugins": [
       "expo-router",
       "expo-font",
-      [
-        "expo-build-properties",
-        {
-          "ios": {
-            "newArchEnabled": true
-          },
-          "android": {
-            "newArchEnabled": true
-          }
-        }
-      ],
       "expo-localization"
     ],
     "experiments": {

--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -44,7 +44,7 @@ export default function TabLayout() {
   const HeaderRight = () => {
     if (!user) {
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginRight: 16 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginRight: 12 }}>
           <SecondaryButton onPress={() => router.push('/auth?mode=login')}>
             Log In
           </SecondaryButton>

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -398,9 +398,9 @@ export default function DiscoverScreen() {
 
             {/* Search Input */}
             <View
-              className="flex-row items-center mx-4 mb-2 px-3 rounded-xl"
+              className="flex-row items-center mx-4 mb-3 px-3 rounded-xl"
               style={{
-                minHeight: 40,
+                minHeight: 44,
                 backgroundColor: isDark ? '#262626' : '#F3F4F6',
               }}
             >
@@ -431,24 +431,26 @@ export default function DiscoverScreen() {
 
             {/* Filter checkboxes */}
             {activeFilter !== 'Centers' && (
-              <View className="flex-row items-center px-4 py-1 gap-4">
+              <View className="flex-row items-center px-4 py-2 gap-5">
                 <Pressable
                   onPress={() => setShowGoingOnly((prev) => !prev)}
                   className="flex-row items-center"
+                  style={{ minHeight: 32 }}
                 >
-                  <View className={`w-4 h-4 rounded border mr-2 items-center justify-center ${showGoingOnly ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
+                  <View className={`w-[18px] h-[18px] rounded border mr-2 items-center justify-center ${showGoingOnly ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
                     {showGoingOnly && <Text className="text-white text-xs font-bold">✓</Text>}
                   </View>
-                  <Text className="text-xs text-stone-500 dark:text-stone-400 font-inter">Going</Text>
+                  <Text className="text-[13px] text-stone-500 dark:text-stone-400 font-inter">Going</Text>
                 </Pressable>
                 <Pressable
                   onPress={() => setShowPastEvents((prev) => !prev)}
                   className="flex-row items-center"
+                  style={{ minHeight: 32 }}
                 >
-                  <View className={`w-4 h-4 rounded border mr-2 items-center justify-center ${showPastEvents ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
+                  <View className={`w-[18px] h-[18px] rounded border mr-2 items-center justify-center ${showPastEvents ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
                     {showPastEvents && <Text className="text-white text-xs font-bold">✓</Text>}
                   </View>
-                  <Text className="text-xs text-stone-500 dark:text-stone-400 font-inter">Show past events</Text>
+                  <Text className="text-[13px] text-stone-500 dark:text-stone-400 font-inter">Show past events</Text>
                 </Pressable>
               </View>
             )}
@@ -478,7 +480,7 @@ export default function DiscoverScreen() {
           {/* Unified List */}
           <ScrollView
             style={{ flex: 1 }}
-            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40, gap: 2 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40, gap: 4 }}
             showsVerticalScrollIndicator={false}
             scrollEnabled={isSheetExpanded}
           >
@@ -561,12 +563,12 @@ const styles = StyleSheet.create({
   },
   handleRow: {
     alignItems: 'center',
-    paddingTop: 8,
-    paddingBottom: 6,
+    paddingTop: 10,
+    paddingBottom: 8,
   },
   handle: {
-    width: 40,
-    height: 4,
-    borderRadius: 2,
+    width: 36,
+    height: 5,
+    borderRadius: 2.5,
   },
 })

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -255,11 +255,11 @@ export default function AuthScreen() {
 
             {/* Janata Wordmark */}
             <Pressable onPress={() => router.push('/landing')}>
-              <Logo size={32} style={{ marginBottom: 40 }} />
+              <Logo size={32} style={{ marginBottom: 32 }} />
             </Pressable>
 
             {/* Heading & Subtitle */}
-            <View className="mb-8">
+            <View className="mb-6">
               <Text
                 style={{ fontFamily: '"Inclusive Sans"', fontSize: 36, fontWeight: '400' }}
                 className="text-content dark:text-content-dark"

--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -45,16 +45,16 @@ function MetaIcon({
   return (
     <View
       style={{
-        width: 32,
-        height: 32,
-        borderRadius: 8,
+        width: 36,
+        height: 36,
+        borderRadius: 10,
         backgroundColor: colors.iconBoxBg,
         alignItems: 'center',
         justifyContent: 'center',
         flexShrink: 0,
       }}
     >
-      <Icon size={16} color={color} />
+      <Icon size={18} color={color} />
     </View>
   )
 }

--- a/packages/frontend/components/WeekCalendar.tsx
+++ b/packages/frontend/components/WeekCalendar.tsx
@@ -29,7 +29,7 @@ export default function WeekCalendar({ eventDates, selectedDate, onSelectDate }:
   const weekDays = useMemo(() => getWeekDays(), [])
 
   return (
-    <View className="flex-row justify-around px-2 py-2">
+    <View className="flex-row justify-around px-3 py-2.5">
       {weekDays.map((d) => {
         const isSelected = selectedDate === d.dateStr
         const hasEvents = eventDates.has(d.dateStr)

--- a/packages/frontend/components/ui/EmptyState.tsx
+++ b/packages/frontend/components/ui/EmptyState.tsx
@@ -36,14 +36,15 @@ export function EmptyState({ variant = 'search', message, subtitle }: EmptyState
   const { icon: Icon, title, subtitle: defaultSubtitle } = config[variant]
 
   return (
-    <View style={{ paddingVertical: 48, alignItems: 'center', paddingHorizontal: 24 }}>
-      <Icon size={40} color="#a8a29e" />
+    <View style={{ paddingVertical: 36, alignItems: 'center', paddingHorizontal: 24 }}>
+      <Icon size={36} color="#a8a29e" />
       <Text
         style={{
-          marginTop: 16,
-          fontSize: 16,
+          marginTop: 14,
+          fontSize: 15,
           fontWeight: '600',
           color: '#78716c',
+          fontFamily: 'Inter-SemiBold',
           textAlign: 'center',
         }}
       >
@@ -54,6 +55,7 @@ export function EmptyState({ variant = 'search', message, subtitle }: EmptyState
           marginTop: 6,
           fontSize: 13,
           color: '#a8a29e',
+          fontFamily: 'Inter-Regular',
           textAlign: 'center',
         }}
       >

--- a/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
+++ b/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
@@ -37,7 +37,7 @@ export default function PrimaryButton({
       {loading ? (
         <ActivityIndicator size="small" color="#FFFFFF" />
       ) : (
-        <Text className="text-white font-inter text-base leading-4 text-center">{children}</Text>
+        <Text className="text-white font-inter text-base leading-5 text-center">{children}</Text>
       )}
     </Pressable>
   )

--- a/packages/frontend/components/ui/buttons/SecondaryButton.tsx
+++ b/packages/frontend/components/ui/buttons/SecondaryButton.tsx
@@ -24,7 +24,7 @@ export default function SecondaryButton({ children, onPress, disabled, loading, 
       {loading ? (
         <ActivityIndicator size="small" color="#78716C" />
       ) : (
-        <Text className="font-inter text-content dark:text-content-dark text-base leading-4 text-center">
+        <Text className="font-inter text-content dark:text-content-dark text-base leading-5 text-center">
           {children}
         </Text>
       )}


### PR DESCRIPTION
## Summary
- **Search bar**: increased min height from 40px to 44px (iOS HIG touch target)
- **Filter checkboxes**: enlarged from 16px to 18px with 32px min tap area
- **Week calendar**: added horizontal/vertical breathing room (`px-3 py-2.5`)
- **Button text**: fixed `leading-4` clipping descenders on "Log In", "Sign Up", etc.
- **Auth screen**: tightened logo→heading gap (40→32px) and heading→form gap (mb-8→mb-6)
- **Center detail**: matched MetaIcon size to event detail (32→36px, icon 16→18px)
- **Empty state**: reduced excessive vertical padding (48→36px), added Inter font family
- **Bottom sheet handle**: refined proportions (36x5px, more padding)
- **Header nav buttons**: increased gap between Log In/Sign Up (8→10px)
- **app.json**: removed unused `expo-build-properties` plugin (already removed in #130)

## Test plan
- [ ] Verify home screen bottom sheet spacing on iPhone SE and iPhone Pro Max
- [ ] Verify filter checkboxes are easy to tap
- [ ] Check auth screen layout doesn't feel too cramped
- [ ] Verify button text ("Log In", "Sign Up", "Continue") doesn't clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)