### PR TITLE
feat(centers): show member count + verified, prominent Get Directions

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Share2, MapPin, Globe, Phone, User } from 'lucide-react-native'
+import { ChevronLeft, Share2, MapPin, Globe, Phone, User, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useCenterDetail } from '../../hooks/useApiData'
 import { Badge } from '../../components/ui'
@@ -66,11 +66,15 @@ function HeaderBar({
   onBack,
   onShare,
   colors,
+  memberCount = 0,
+  isVerified = false,
 }: {
   title: string
   onBack: () => void
   onShare: () => void
   colors: DetailColors
+  memberCount?: number
+  isVerified?: boolean
 }) {
   return (
     <View
@@ -117,6 +121,43 @@ function HeaderBar({
       >
         {title}
       </Text>
+
+      {/* Stats row */}
+      {(memberCount > 0 || isVerified) && (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          {memberCount > 0 && (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <Users size={13} color={colors.textSecondary} />
+              <Text
+                style={{
+                  fontFamily: 'Inter-Medium',
+                  fontSize: 13,
+                  color: colors.textSecondary,
+                }}
+              >
+                {memberCount} {memberCount === 1 ? 'member' : 'members'}
+              </Text>
+            </View>
+          )}
+          {memberCount > 0 && isVerified && (
+            <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>
+          )}
+          {isVerified && (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <BadgeCheck size={13} color="#E8862A" />
+              <Text
+                style={{
+                  fontFamily: 'Inter-Medium',
+                  fontSize: 13,
+                  color: '#E8862A',
+                }}
+              >
+                Verified
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
     </View>
   )
 }
@@ -211,6 +252,8 @@ export default function CenterDetailPage() {
         onBack={() => router.back()}
         onShare={handleShare}
         colors={colors}
+        memberCount={center.memberCount}
+        isVerified={center.isVerified}
       />
 
       <ScrollView
@@ -247,12 +290,9 @@ export default function CenterDetailPage() {
           <View style={{ gap: 16 }}>
             {/* Address */}
             {center.address ? (
-              <Pressable
-                onPress={handleAddressPress}
-                style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12, minHeight: 44 }}
-              >
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
                 <MetaIcon icon={MapPin} color="#E8862A" colors={colors} />
-                <View style={{ flex: 1, justifyContent: 'center' }}>
+                <View style={{ flex: 1, gap: 8 }}>
                   <Text
                     style={{
                       fontFamily: 'Inter-Medium',
@@ -263,8 +303,35 @@ export default function CenterDetailPage() {
                   >
                     {center.address}
                   </Text>
+                  <Pressable
+                    onPress={handleAddressPress}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 6,
+                      backgroundColor: '#E8862A',
+                      paddingVertical: 9,
+                      paddingHorizontal: 14,
+                      borderRadius: 8,
+                      alignSelf: 'flex-start',
+                      minHeight: 36,
+                    }}
+                    accessibilityLabel="Get directions"
+                  >
+                    <Navigation size={14} color="#fff" />
+                    <Text
+                      style={{
+                        fontFamily: 'Inter-SemiBold',
+                        fontSize: 13,
+                        color: '#fff',
+                      }}
+                    >
+                      Get Directions
+                    </Text>
+                  </Pressable>
                 </View>
-              </Pressable>
+              </View>
             ) : null}
 
             {/* Website */}

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Linking, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Share2, MapPin, Globe, Phone, User } from 'lucide-react-native'
+import { ChevronLeft, Share2, MapPin, Globe, Phone, User, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import { useCenterDetail } from '../../hooks/useApiData'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import type { EventDisplay } from '../../utils/api'
@@ -110,6 +110,27 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
           </Pressable>
         </View>
         <Text style={{ fontSize: 22, fontWeight: 'bold', color: colors.text }}>{center.name}</Text>
+        {(center.memberCount > 0 || center.isVerified) && (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            {center.memberCount > 0 && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <Users size={13} color={colors.textSecondary} />
+                <Text style={{ fontSize: 13, color: colors.textSecondary }}>
+                  {center.memberCount} {center.memberCount === 1 ? 'member' : 'members'}
+                </Text>
+              </View>
+            )}
+            {center.memberCount > 0 && center.isVerified && (
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>
+            )}
+            {center.isVerified && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <BadgeCheck size={13} color="#E8862A" />
+                <Text style={{ fontSize: 13, color: '#E8862A' }}>Verified</Text>
+              </View>
+            )}
+          </View>
+        )}
       </View>
 
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 40 }}>
@@ -128,10 +149,30 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
 
           {/* Address */}
           {center.address ? (
-            <Pressable onPress={handleAddressPress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <MapPin size={18} color="#E8862A" />
-              <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{center.address}</Text>
-            </Pressable>
+            <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>
+              <MapPin size={18} color="#E8862A" style={{ marginTop: 2 }} />
+              <View style={{ flex: 1, gap: 8 }}>
+                <Text style={{ color: colors.text, fontSize: 15 }}>{center.address}</Text>
+                <Pressable
+                  onPress={handleAddressPress}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 6,
+                    backgroundColor: '#E8862A',
+                    paddingVertical: 9,
+                    paddingHorizontal: 14,
+                    borderRadius: 8,
+                    alignSelf: 'flex-start',
+                  }}
+                  accessibilityLabel="Get directions"
+                >
+                  <Navigation size={14} color="#fff" />
+                  <Text style={{ color: '#fff', fontSize: 13, fontWeight: '600' }}>Get Directions</Text>
+                </Pressable>
+              </View>
+            </View>
           ) : null}
 
           {/* Website */}

--- a/packages/frontend/components/web/CenterDetailPanel.tsx
+++ b/packages/frontend/components/web/CenterDetailPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { View, Text, Image, ScrollView, Pressable, Linking } from 'react-native'
-import { MapPin, Globe, Phone, User, ChevronLeft } from 'lucide-react-native'
+import { MapPin, Globe, Phone, User, ChevronLeft, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import type { CenterDisplay } from '../../hooks/useApiData'
 import type { EventDisplay } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
@@ -110,6 +110,43 @@ export default function CenterDetailPanel({
         >
           {center.name}
         </Text>
+
+        {/* Stats row */}
+        {(center.memberCount > 0 || center.isVerified) && (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            {center.memberCount > 0 && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <Users size={13} color={colors.textSecondary} />
+                <Text
+                  style={{
+                    fontFamily: 'Inter-Medium',
+                    fontSize: 13,
+                    color: colors.textSecondary,
+                  }}
+                >
+                  {center.memberCount} {center.memberCount === 1 ? 'member' : 'members'}
+                </Text>
+              </View>
+            )}
+            {center.memberCount > 0 && center.isVerified && (
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>
+            )}
+            {center.isVerified && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <BadgeCheck size={13} color="#E8862A" />
+                <Text
+                  style={{
+                    fontFamily: 'Inter-Medium',
+                    fontSize: 13,
+                    color: '#E8862A',
+                  }}
+                >
+                  Verified
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
       </View>
 
       {/* ── Scrollable content ──────────────────────────────────── */}
@@ -141,10 +178,7 @@ export default function CenterDetailPanel({
           <View style={{ gap: 16 }}>
             {/* Address */}
             {center.address ? (
-              <Pressable
-                onPress={handleAddressPress}
-                style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12, minHeight: 44 }}
-              >
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
                 <View
                   style={{
                     width: 32,
@@ -158,7 +192,7 @@ export default function CenterDetailPanel({
                 >
                   <MapPin size={16} color="#E8862A" />
                 </View>
-                <View style={{ flex: 1, justifyContent: 'center' }}>
+                <View style={{ flex: 1, gap: 8 }}>
                   <Text
                     style={{
                       fontFamily: 'Inter-Medium',
@@ -169,8 +203,35 @@ export default function CenterDetailPanel({
                   >
                     {center.address}
                   </Text>
+                  <Pressable
+                    onPress={handleAddressPress}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 6,
+                      backgroundColor: '#E8862A',
+                      paddingVertical: 9,
+                      paddingHorizontal: 14,
+                      borderRadius: 8,
+                      alignSelf: 'flex-start',
+                      minHeight: 36,
+                    }}
+                    accessibilityLabel="Get directions"
+                  >
+                    <Navigation size={14} color="#fff" />
+                    <Text
+                      style={{
+                        fontFamily: 'Inter-SemiBold',
+                        fontSize: 13,
+                        color: '#fff',
+                      }}
+                    >
+                      Get Directions
+                    </Text>
+                  </Pressable>
                 </View>
-              </Pressable>
+              </View>
             ) : null}
 
             {/* Website */}

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -392,6 +392,8 @@ export interface CenterDisplay {
   acharya: string
   latitude?: number
   longitude?: number
+  memberCount: number
+  isVerified: boolean
 }
 
 const SAMPLE_CENTER_DETAILS: Record<string, CenterDisplay> = {}
@@ -437,6 +439,8 @@ export function useCenterDetail(centerId: string) {
             acharya: apiCenter.acharya || '',
             latitude: apiCenter.latitude,
             longitude: apiCenter.longitude,
+            memberCount: apiCenter.memberCount ?? 0,
+            isVerified: apiCenter.isVerified ?? false,
           })
           setIsLive(true)
         }


### PR DESCRIPTION
## Summary

Two cheap detail-page upgrades using data already in the schema:

1. **Stats line under the title** — "147 members · Verified" (or just one, or hidden if neither applies)
2. **Prominent Get Directions button** — orange CTA right under the address, replacing the implicit-clickable address row that had no visual affordance.

Both render across all three surfaces: web side panel, native page, mobile-web standalone page.

## Screenshots (local)

**With both stats:**
- Title: Chinmaya Mission Phoenix
- "147 members · Verified" (Users icon · BadgeCheck icon)
- Hero image
- Address + Get Directions button
- Phone

**Verified-only (memberCount = 0):**
- Title: Chinmaya Giridhar
- "Verified"
- Hero, address + button, phone

## Changes
- \`packages/frontend/hooks/useApiData.ts\` — \`CenterDisplay\` gains \`memberCount\` and \`isVerified\`; passed through from \`CenterApiResponse\`.
- \`packages/frontend/components/web/CenterDetailPanel.tsx\` — stats row in the header; address row restructured so address text stays as a label and the Get Directions button sits below.
- \`packages/frontend/app/center/[id].tsx\` — \`HeaderBar\` gets optional \`memberCount\` / \`isVerified\` props; same address+button restructure.
- \`packages/frontend/app/center/[id].web.tsx\` — same treatment.

## Test plan
- [x] \`npm run test:frontend\` clean (153/153)
- [x] Backend typecheck clean
- [x] Visual: Phoenix shows both stats; Calgary shows only Verified; centers with neither don't render an empty row
- [x] Get Directions still opens Google Maps with the encoded address
- [ ] Mobile: smoke test on iOS/Android

## Note on stacking
Builds on top of #135 cleanly (no overlapping files). Either order should merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)