### PR TITLE
feat(centers): add 4 missing Chinmaya centers (CMNY, CCMT, Sidhbari, Mangalam)

### DIFF
--- a/migrations/0008_add_chinmaya_centers.sql
+++ b/migrations/0008_add_chinmaya_centers.sql
@@ -1,0 +1,79 @@
+-- 0008_add_chinmaya_centers.sql
+-- Add 4 Chinmaya centers missing from production, identified while ingesting
+-- Chinmaya Mission events (Mar–Jul 2026) for app import:
+--
+--   098  Chinmaya Mission New York (Chinmaya Upavan)  — Woodbury, NY
+--                                                       (inaugurated 2026-07-26)
+--   099  Central Chinmaya Mission Trust              — Powai, Mumbai, India
+--                                                       (umbrella anchor for the
+--                                                        2026 Chinmaya Amrit Yatra
+--                                                        national pilgrimage)
+--   100  Sandeepany Himalayas (Sidhbari)             — Kangra, HP, India
+--                                                       (Chinmaya Jayanti Camp,
+--                                                        Vedanta Course conclusion)
+--   101  Chinmaya Mangalam                            — Barry, TX
+--                                                       (CMDFW 143-acre camp;
+--                                                        High School Retreat,
+--                                                        GCC State Finals)
+--
+-- New IDs continue the c0000001-0000-0000-0000-… sequence used in production
+-- (max existing = 097). All entries are is_verified = 1, matching the prod
+-- convention (all 91 existing centers are verified).
+
+INSERT INTO centers (
+  id, name, latitude, longitude, address, member_count, is_verified,
+  website, phone, image, acharya, point_of_contact,
+  created_at, updated_at
+) VALUES
+(
+  'c0000001-0000-0000-0000-000000000098',
+  'Chinmaya Mission New York',
+  40.8203, -73.4684,
+  '129 Woodbury Rd, Woodbury, NY - 11797, US',
+  0, 1,
+  'https://chinmayanewyork.org/',
+  NULL,
+  'https://chinmayanewyork.org/wp-content/uploads/2026/04/Final-CMNY-Upavan-Hanuman-Havan.png',
+  NULL,
+  'info@chinmayanewyork.org',
+  datetime('now'), datetime('now')
+),
+(
+  'c0000001-0000-0000-0000-000000000099',
+  'Central Chinmaya Mission Trust',
+  19.1197, 72.9053,
+  'Saki Vihar Rd, Powai, Mumbai - 400072, IN',
+  0, 1,
+  'https://www.chinmayamission.com/',
+  '+91-22-2803-4900',
+  'https://images.chinmayamission.com/uploads/YATRA_BANNER_9320f94db2.jpeg',
+  NULL,
+  'ccmt@chinmayamission.com',
+  datetime('now'), datetime('now')
+),
+(
+  'c0000001-0000-0000-0000-000000000100',
+  'Sandeepany Himalayas (Sidhbari)',
+  32.1879, 76.3175,
+  'Tapovan Rd, Sidhbari, Dharamshala, Distt. Kangra, HP - 176057, IN',
+  0, 1,
+  'https://www.chinmayamission.com/sidhbari',
+  '+91-1892-236199',
+  'https://images.chinmayamission.com/uploads/2_d81b0572fb.webp',
+  NULL,
+  'sidhbari@chinmayamission.com',
+  datetime('now'), datetime('now')
+),
+(
+  'c0000001-0000-0000-0000-000000000101',
+  'Chinmaya Mangalam',
+  31.9938, -96.6394,
+  '10470 W FM 744, Barry, TX - 75102, US',
+  0, 1,
+  'https://chinmayamissionwest.com/chinmaya-mangalam/',
+  '(972) 250-2470',
+  NULL,
+  NULL,
+  NULL,
+  datetime('now'), datetime('now')
+);


### PR DESCRIPTION
## Summary

Adds 4 Chinmaya centers to production that were identified as missing while ingesting Chinmaya Mission event listings for Mar–Jul 2026 (past month + next 3 months). Of 40 events scraped from official Chinmaya sources, 13 anchored to chapters that had no row in the \`centers\` table — these 4 entries cover all of them.

| ID | Center | Why |
|----|--------|-----|
| `c0000001-…-098` | **Chinmaya Mission New York** (Chinmaya Upavan, Woodbury NY) | Anchors Hanuman Chalisa Havan (Jul 25) + Upavan Inauguration (Jul 26) — the building is itself being inaugurated this window |
| `c0000001-…-099` | **Central Chinmaya Mission Trust** (Powai, Mumbai) | First India entry. Serves as the umbrella anchor for the 2026 Chinmaya Amrit Yatra national pilgrimage (1 umbrella event + 7 city stops, all attached here per "one anchor for tour-style events") |
| `c0000001-…-100` | **Sandeepany Himalayas (Sidhbari)** | Fixed Himalayan retreat venue. Anchors May 1–8 Chinmaya Jayanti Camp + Hindi Vedanta Conclusion |
| `c0000001-…-101` | **Chinmaya Mangalam** (Barry, TX) | CMDFW's 143-acre regional camp facility ~80 mi south of Dallas. Anchors High School Retreat (Apr 4) + GCC State Finals (May 16) |

Coordinates were sourced from the published street addresses; images and contact details from each chapter's official site (CCMT image is the official Amrit Yatra banner, reused per "just one image for amrit yatra and similar things"). Mangalam image left NULL — no canonical photo found.

## Notes

- Production currently has **0 / 91** centers with an \`image\` set. This PR adds the first 3 with images.
- IDs continue the prod sequence (max existing = \`…-097\`).
- The \`acharya\` column is left NULL on all 4; can be filled in later by the chapters.
- This PR adds **centers only**. The events themselves (the JSON inventory that surfaced this gap) will land in a separate PR.

## Test plan

- [ ] \`wrangler d1 execute chinmaya-janata-db --local --file=migrations/0008_add_chinmaya_centers.sql\` runs without error
- [ ] After local apply, \`SELECT COUNT(*) FROM centers\` returns 95
- [ ] Spot-check one of the new centers in the app's center detail view (image renders, address is correct)
- [ ] When ready: apply to \`--remote\` (production) and re-verify count

🤖 Generated with [Claude Code](https://claude.com/claude-code)