### PR TITLE
feat(events): hero thumbnail + center byline on list, on-Janata label, refer all scraped signups out

### DIFF
--- a/migrations/0013_disable_native_signup_for_scraped_events.sql
+++ b/migrations/0013_disable_native_signup_for_scraped_events.sql
@@ -1,0 +1,16 @@
+-- 0013_disable_native_signup_for_scraped_events.sql
+-- For the 41 events seeded in 0010 from scraped chapter websites, signup
+-- happens on those external sites, not on Janata. Set signup_url = external_url
+-- so the event detail page swaps the native "Attend Event" button for a
+-- "Sign up at <hostname>" CTA. Janata acts as a referrer.
+--
+-- This intentionally only touches rows where external_url was populated by
+-- 0012, which scopes the change to the 41 scraped events. The 13 pre-existing
+-- prod events (test/sample) have external_url = NULL and keep native RSVP.
+--
+-- Idempotent; safe to re-run.
+
+UPDATE events
+SET signup_url = external_url, updated_at = datetime('now')
+WHERE external_url IS NOT NULL
+  AND signup_url IS NULL;

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -108,7 +108,15 @@ function AttendeeAvatars({ count, attendees }: { count: number; attendees?: Atte
 
 // ─── Event Item ─────────────────────────────────────────
 
-function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => void }) {
+function EventItem({
+  event,
+  onPress,
+  centerName,
+}: {
+  event: EventDisplay
+  onPress: () => void
+  centerName?: string
+}) {
   const { month, day } = event.date ? formatDatePill(event.date) : { month: '', day: '' }
   const todayLabel = event.date ? isToday(event.date) : false
 
@@ -142,14 +150,28 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
           {todayLabel ? 'Today · ' : ''}{event.time || ''}
         </Text>
+        {centerName && (
+          <Text className="text-stone-500 dark:text-stone-400 font-inter text-xs" numberOfLines={1}>
+            By {centerName}
+          </Text>
+        )}
         <View className="flex-row items-center gap-1 mt-0.5">
           <MapPin size={12} color="#E8862A" />
           <Text className="text-stone-500 dark:text-stone-400 font-inter text-xs flex-1" numberOfLines={1}>
             {event.location}
           </Text>
         </View>
-        <AttendeeAvatars count={event.attendees} attendees={event.attendeesList} />
+        {event.attendees > 0 && <AttendeeAvatars count={event.attendees} attendees={event.attendeesList} />}
       </View>
+
+      {/* Hero thumbnail */}
+      {event.image && (
+        <Image
+          source={{ uri: event.image }}
+          style={{ width: 72, height: 72, borderRadius: 10 }}
+          resizeMode="cover"
+        />
+      )}
     </Pressable>
   )
 }
@@ -214,6 +236,7 @@ export default function DiscoverScreen() {
     filteredPoints,
     loading,
     allEvents,
+    allCenters,
     refresh,
   } = useDiscoverData(activeFilter, searchQuery, user?.id, showPastEvents, showGoingOnly, user?.interests ?? undefined, user?.centerID)
 
@@ -499,6 +522,7 @@ export default function DiscoverScreen() {
                   <EventItem
                     key={`event-${item.data.id}`}
                     event={item.data as EventDisplay}
+                    centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
                     onPress={() => {
                       posthog?.capture('event_list_item_pressed', { eventId: item.data.id, source: 'discover' })
                       router.push(`/events/${item.data.id}`)

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -141,7 +141,15 @@ function AttendeeAvatars({ count, attendees }: { count: number; attendees?: Atte
 
 // ─── Event Item (Desktop) ───────────────────────────────
 
-function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => void }) {
+function EventItem({
+  event,
+  onPress,
+  centerName,
+}: {
+  event: EventDisplay
+  onPress: () => void
+  centerName?: string
+}) {
   const { month, day } = event.date ? formatDatePill(event.date) : { month: '', day: '' }
 
   return (
@@ -176,6 +184,14 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
         <Text className="text-stone-500 dark:text-stone-400 font-inter text-sm">
           {event.date && isToday(event.date) ? 'Today · ' : ''}{event.time || ''}
         </Text>
+        {centerName && (
+          <Text
+            className="text-stone-500 dark:text-stone-400 font-inter text-sm"
+            numberOfLines={1}
+          >
+            By {centerName}
+          </Text>
+        )}
         <View className="flex-row items-center gap-1.5">
           <MapPin size={12} color="#E8862A" />
           <Text
@@ -185,10 +201,21 @@ function EventItem({ event, onPress }: { event: EventDisplay; onPress: () => voi
             {event.location}
           </Text>
         </View>
-        <View style={{ marginTop: 4 }}>
-          <AttendeeAvatars count={event.attendees} attendees={event.attendeesList} />
-        </View>
+        {event.attendees > 0 && (
+          <View style={{ marginTop: 4 }}>
+            <AttendeeAvatars count={event.attendees} attendees={event.attendeesList} />
+          </View>
+        )}
       </View>
+
+      {/* Hero thumbnail */}
+      {event.image && (
+        <Image
+          source={{ uri: event.image }}
+          style={{ width: 84, height: 84, borderRadius: 12 }}
+          resizeMode="cover"
+        />
+      )}
     </Pressable>
   )
 }
@@ -761,6 +788,7 @@ function MobileDiscoverFallback() {
                   <EventItem
                     key={`event-${item.data.id}`}
                     event={item.data as EventDisplay}
+                    centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
                     onPress={() => router.push(`/events/${item.data.id}`)}
                   />
                 )
@@ -1169,6 +1197,7 @@ export default function DiscoverScreenWeb() {
                     <EventItem
                       key={`event-${item.data.id}`}
                       event={item.data as EventDisplay}
+                      centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
                       onPress={() => setSelectedItem({ type: 'event', id: item.data.id })}
                     />
                   )

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -264,7 +264,7 @@ function MetaSection({
   colors: DetailColors
 }) {
   const iconColor = isPast ? colors.textMuted : '#E8862A'
-  const attendLabel = isPast ? `${event.attendees} attended` : `${event.attendees} attending`
+  const attendLabel = `${event.attendees} on Janata`
 
   return (
     <View style={{ gap: 16 }}>
@@ -597,7 +597,7 @@ export default function EventDetailPage() {
                   marginBottom: 12,
                 }}
               >
-                {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
+                {event.attendees} {event.attendees === 1 ? 'person' : 'people'} on Janata
               </Text>
               {attendees.length > 0 ? (
                 attendees.map((attendee, index) => (

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -312,9 +312,7 @@ function MetaSection({
   colors: DetailColors
 }) {
   const iconColor = isPast ? colors.textMuted : '#E8862A'
-  const attendLabel = isPast
-    ? `${event.attendees} attended`
-    : `${event.attendees} attending`
+  const attendLabel = `${event.attendees} on Janata`
 
   return (
     <View style={{ gap: 16 }}>
@@ -492,7 +490,7 @@ function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: Detai
           marginBottom: 12,
         }}
       >
-        {attendees.length} {attendees.length === 1 ? 'person' : 'people'} attending
+        {attendees.length} {attendees.length === 1 ? 'person' : 'people'} on Janata
       </Text>
 
       {attendees.length === 0 ? (


### PR DESCRIPTION
## Summary

Three coupled tweaks for the events surface, inspired by the Luma list-view layout.

### 1. List view richer

- **Hero thumbnail** on the right of each event card (84×84 web, 72×72 native) when `event.image` is set. Closer to the Luma pattern.
- **"By <center name>"** line under the time row, looked up at the call site via `allCenters.find(c => c.id === event.centerId)?.name`. Makes ownership obvious without needing to open the card.
- **Hide the attendee row when 0** — no more empty space for events nobody's marked yet.

### 2. Event detail wording

- `# attending` / `# attended` → `# on Janata` everywhere on the detail surface (web side panel + native page).
- Reflects what the count actually means: people on *this* app who marked attending, not absolute attendance. Important now that we're a referrer for most events.
- Both the summary line ("147 on Janata") and the People tab ("147 people on Janata") updated.

### 3. Native signup off for scraped events

- New migration `0013_disable_native_signup_for_scraped_events.sql`: for all 41 events seeded in 0010, signup happens on the chapter's official site, not on Janata.
- Sets `signup_url = external_url`, which triggers the "Sign up at <hostname>" CTA from PR #141 and hides native RSVP.
- **Scope-safe:** only touches rows where `external_url` is set and `signup_url` is null — the 13 pre-existing prod events keep native RSVP because they have no `external_url`.
- Idempotent.

## Why "on Janata" instead of "attending"

We're not actually the registrar for most events anymore — we redirect users to the chapter's site. Saying "5 attending" is misleading because it conflates the count of Janata users marking interest with the actual event attendance. "5 on Janata" is honest: this is just our side of the data.

## Tests

- [x] Backend 267/267, frontend 153/153
- [x] Local: 0013 applied, all 41 scraped events have `signup_url = external_url`, the 13 sample events untouched
- [ ] Visual: pull this branch, reload the discover Events tab — hero thumbnails on the right, "By Chinmaya Prabha" / etc. bylines visible. Open any scraped event detail → "Sign up at chinmayamission.com" replaces native Attend.

## Deploy notes

After merge, apply `0013` to prod:

```
npx wrangler d1 execute chinmaya-janata-db --remote \
  --file=migrations/0013_disable_native_signup_for_scraped_events.sql \
  --config packages/backend/wrangler.toml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)