### PR TITLE
feat(events): admin opt-in for Janata signup alongside external

### DIFF
--- a/migrations/0014_add_event_allow_janata_signup.sql
+++ b/migrations/0014_add_event_allow_janata_signup.sql
@@ -1,0 +1,17 @@
+-- 0014_add_event_allow_janata_signup.sql
+-- Adds allow_janata_signup to events: a per-event opt-in for native RSVP
+-- when an external signup_url is also set.
+--
+-- Default behavior (allow_janata_signup = 0):
+--   - signup_url null  → native "Attend Event" button
+--   - signup_url set   → external "Sign up at <hostname>" button only;
+--                         native RSVP hidden, attendee count hidden
+--
+-- When admin sets allow_janata_signup = 1 on an event with signup_url:
+--   - Two buttons: "Attend on Janata" (primary) + "Sign up at <hostname>"
+--     (secondary). Janata acts as an alternate, official site stays canonical.
+--   - Attendee count visible again ("X on Janata").
+--
+-- Default 0 so existing behavior is preserved everywhere.
+
+ALTER TABLE events ADD COLUMN allow_janata_signup INTEGER NOT NULL DEFAULT 0;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1192,6 +1192,9 @@ app.put('/admin/events/:id', adminMiddleware, async (c) => {
     pointOfContact?: string
     image?: string
     category?: number
+    externalUrl?: string | null
+    signupUrl?: string | null
+    allowJanataSignup?: boolean
   }>()
 
   const updates: Partial<EventRow> = {}
@@ -1202,6 +1205,9 @@ app.put('/admin/events/:id', adminMiddleware, async (c) => {
   if (body.pointOfContact !== undefined) updates.point_of_contact = body.pointOfContact
   if (body.image !== undefined) updates.image = body.image
   if (body.category !== undefined) updates.category = body.category
+  if (body.externalUrl !== undefined) updates.external_url = body.externalUrl
+  if (body.signupUrl !== undefined) updates.signup_url = body.signupUrl
+  if (body.allowJanataSignup !== undefined) updates.allow_janata_signup = body.allowJanataSignup ? 1 : 0
 
   const result = await db.updateEvent(c.env.DB, eventId, updates)
   if (result.success) {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -83,6 +83,7 @@ export interface EventRow {
   created_by: string | null
   external_url: string | null
   signup_url: string | null
+  allow_janata_signup: number // 0 | 1
   created_at: string
   updated_at: string
 }
@@ -168,6 +169,7 @@ export interface EventApiResponse {
   createdBy: string | null
   externalUrl: string | null
   signupUrl: string | null
+  allowJanataSignup: boolean
   createdAt: string
   updatedAt: string
 }
@@ -248,6 +250,7 @@ export function eventRowToApi(row: EventRow): EventApiResponse {
     createdBy: row.created_by,
     externalUrl: row.external_url,
     signupUrl: row.signup_url,
+    allowJanataSignup: row.allow_janata_signup === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Alert, Share } from 'react-native'
+import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Alert, Share, Linking } from 'react-native'
 import { DetailSkeleton } from '../../components/ui/Skeleton'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
@@ -258,7 +258,7 @@ function MetaSection({
   isPast,
   colors,
 }: {
-  event: { location: string; address?: string; attendees: number; pointOfContact?: string }
+  event: { location: string; address?: string; attendees: number; pointOfContact?: string; signupUrl?: string | null; allowJanataSignup?: boolean }
   attendees: { image?: string; initials?: string; name: string; subtitle: string }[]
   isPast?: boolean
   colors: DetailColors
@@ -285,14 +285,16 @@ function MetaSection({
         </View>
       </View>
 
-      {/* Attendees */}
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-        <MetaIcon icon={Users} color={iconColor} colors={colors} />
-        <Text style={{ fontFamily: 'Inter-Medium', fontSize: 14, color: colors.text }}>
-          {attendLabel}
-        </Text>
-        <AvatarStack attendees={attendees} colors={colors} />
-      </View>
+      {/* Attendees — hidden when external signup is exclusive (no native RSVP) */}
+      {!(event.signupUrl && !event.allowJanataSignup) && (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <MetaIcon icon={Users} color={iconColor} colors={colors} />
+          <Text style={{ fontFamily: 'Inter-Medium', fontSize: 14, color: colors.text }}>
+            {attendLabel}
+          </Text>
+          <AvatarStack attendees={attendees} colors={colors} />
+        </View>
+      )}
 
       {/* Point of contact */}
       {event.pointOfContact ? (
@@ -370,38 +372,95 @@ function AttendedBanner({ count, colors }: { count: number; colors: DetailColors
 
 // ── Action bar ───────────────────────────────────────────────────────────
 
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return 'official site'
+  }
+}
+
 function ActionBar({
   isRegistered,
   isPast,
   onToggle,
   isToggling,
+  signupUrl,
+  allowJanataSignup,
   colors,
 }: {
   isRegistered?: boolean
   isPast?: boolean
   onToggle: () => void
   isToggling: boolean
+  signupUrl?: string | null
+  allowJanataSignup?: boolean
   colors: DetailColors
 }) {
   if (isPast) return null
 
+  const wrapperStyle = {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 28,
+    backgroundColor: colors.panelBg,
+  } as const
+
+  // External signup + admin opted into Janata as alternate. Janata primary,
+  // external secondary.
+  if (signupUrl && allowJanataSignup) {
+    return (
+      <View style={{ ...wrapperStyle, gap: 8 }}>
+        {isRegistered ? (
+          <DestructiveButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
+            Cancel Registration
+          </DestructiveButton>
+        ) : (
+          <PrimaryButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
+            Attend on Janata
+          </PrimaryButton>
+        )}
+        <Pressable
+          onPress={() => Linking.openURL(signupUrl)}
+          style={{ paddingVertical: 12, alignItems: 'center', justifyContent: 'center' }}
+          accessibilityLabel={`Sign up at ${hostnameOf(signupUrl)}`}
+        >
+          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 14, color: '#E8862A' }}>
+            Or sign up at {hostnameOf(signupUrl)}
+          </Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  // External signup is exclusive.
+  if (signupUrl) {
+    return (
+      <View style={wrapperStyle}>
+        <PrimaryButton onPress={() => Linking.openURL(signupUrl)}>
+          Sign up at {hostnameOf(signupUrl)}
+        </PrimaryButton>
+        <Text
+          style={{
+            fontFamily: 'Inter-Regular',
+            fontSize: 12,
+            color: colors.textMuted,
+            textAlign: 'center',
+            marginTop: 8,
+          }}
+        >
+          Registration handled on the official site
+        </Text>
+      </View>
+    )
+  }
+
   if (isRegistered) {
     return (
-      <View
-        style={{
-          borderTopWidth: 1,
-          borderTopColor: colors.border,
-          paddingHorizontal: 16,
-          paddingTop: 12,
-          paddingBottom: 28,
-          backgroundColor: colors.panelBg,
-        }}
-      >
-        <DestructiveButton
-          onPress={onToggle}
-          disabled={isToggling}
-          loading={isToggling}
-        >
+      <View style={wrapperStyle}>
+        <DestructiveButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
           Cancel Registration
         </DestructiveButton>
       </View>
@@ -409,21 +468,8 @@ function ActionBar({
   }
 
   return (
-    <View
-      style={{
-        borderTopWidth: 1,
-        borderTopColor: colors.border,
-        paddingHorizontal: 16,
-        paddingTop: 12,
-        paddingBottom: 28,
-        backgroundColor: colors.panelBg,
-      }}
-    >
-      <PrimaryButton
-        onPress={onToggle}
-        disabled={isToggling}
-        loading={isToggling}
-      >
+    <View style={wrapperStyle}>
+      <PrimaryButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
         Attend Event
       </PrimaryButton>
       <Text
@@ -661,6 +707,8 @@ export default function EventDetailPage() {
           isRegistered
           onToggle={handleToggleRegistration}
           isToggling={isToggling}
+          signupUrl={event.signupUrl}
+          allowJanataSignup={event.allowJanataSignup}
           colors={colors}
         />
       </SafeAreaView>
@@ -743,6 +791,8 @@ export default function EventDetailPage() {
         isPast={isPast}
         onToggle={handleToggleRegistration}
         isToggling={isToggling}
+        signupUrl={event.signupUrl}
+        allowJanataSignup={event.allowJanataSignup}
         colors={colors}
       />
     </SafeAreaView>

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -95,6 +95,7 @@ type EventDetailPanelProps = {
     isRegistered?: boolean
     externalUrl?: string | null
     signupUrl?: string | null
+    allowJanataSignup?: boolean
   }
   attendees: Attendee[]
   isPast?: boolean
@@ -343,20 +344,23 @@ function MetaSection({
         </View>
       </View>
 
-      {/* Attendees row */}
-      <View className="flex-row items-center" style={{ gap: 12 }}>
-        <MetaIcon icon={Users} color={iconColor} colors={colors} />
-        <Text
-          style={{
-            fontFamily: 'Inter-Medium',
-            fontSize: 14,
-            color: colors.text,
-          }}
-        >
-          {attendLabel}
-        </Text>
-        <AvatarStack attendees={attendees} colors={colors} />
-      </View>
+      {/* Attendees row — hidden when external signup is exclusive (no native
+          RSVP allowed), since the on-Janata count would always be 0. */}
+      {!(event.signupUrl && !event.allowJanataSignup) && (
+        <View className="flex-row items-center" style={{ gap: 12 }}>
+          <MetaIcon icon={Users} color={iconColor} colors={colors} />
+          <Text
+            style={{
+              fontFamily: 'Inter-Medium',
+              fontSize: 14,
+              color: colors.text,
+            }}
+          >
+            {attendLabel}
+          </Text>
+          <AvatarStack attendees={attendees} colors={colors} />
+        </View>
+      )}
 
       {/* Point of contact row */}
       {event.pointOfContact && (
@@ -687,6 +691,7 @@ function ActionBar({
   onToggleRegistration,
   isToggling,
   signupUrl,
+  allowJanataSignup,
   colors,
 }: {
   isRegistered?: boolean
@@ -694,11 +699,65 @@ function ActionBar({
   onToggleRegistration: () => void
   isToggling: boolean
   signupUrl?: string | null
+  allowJanataSignup?: boolean
   colors: DetailColors
 }) {
   if (isPast) return null
 
-  // External signup wins over native RSVP. We're a referrer, not the registrar.
+  // External signup is set + admin opted into letting users RSVP on Janata
+  // too. Janata is primary, external is the alternate.
+  if (signupUrl && allowJanataSignup) {
+    return (
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+          padding: 16,
+          backgroundColor: colors.panelBg,
+          gap: 8,
+        }}
+      >
+        {isRegistered ? (
+          <DestructiveButton
+            onPress={onToggleRegistration}
+            disabled={isToggling}
+            loading={isToggling}
+          >
+            Cancel Registration
+          </DestructiveButton>
+        ) : (
+          <PrimaryButton
+            onPress={onToggleRegistration}
+            disabled={isToggling}
+            loading={isToggling}
+          >
+            Attend on Janata
+          </PrimaryButton>
+        )}
+        <Pressable
+          onPress={() => Linking.openURL(signupUrl)}
+          style={{
+            paddingVertical: 12,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          accessibilityLabel={`Sign up at ${hostnameOf(signupUrl)}`}
+        >
+          <Text
+            style={{
+              fontFamily: 'Inter-SemiBold',
+              fontSize: 14,
+              color: '#E8862A',
+            }}
+          >
+            Or sign up at {hostnameOf(signupUrl)}
+          </Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  // External signup is exclusive. We're just a referrer.
   if (signupUrl) {
     return (
       <View
@@ -843,6 +902,7 @@ export default function EventDetailPanel({
         onToggleRegistration={onToggleRegistration}
         isToggling={isToggling}
         signupUrl={event.signupUrl}
+        allowJanataSignup={event.allowJanataSignup}
         colors={colors}
       />
     </View>

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -77,6 +77,7 @@ function apiEventToDisplay(e: EventData, _username?: string): EventDisplay {
     category: e.category,
     externalUrl: e.externalUrl ?? null,
     signupUrl: e.signupUrl ?? null,
+    allowJanataSignup: e.allowJanataSignup ?? false,
   }
 
   // If we have an image URL for the event, ensure it's absolute

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -41,6 +41,7 @@ export interface EventData {
   createdBy: string | null
   externalUrl?: string | null
   signupUrl?: string | null
+  allowJanataSignup?: boolean
   createdAt?: string
   updatedAt?: string
 }
@@ -104,6 +105,7 @@ export interface EventDisplay {
   category?: number | null
   externalUrl?: string | null
   signupUrl?: string | null
+  allowJanataSignup?: boolean
 }
 
 export interface DiscoverCenter {


### PR DESCRIPTION
## Summary

Adds `allow_janata_signup` (default `0`) to events so an admin can elect to enable native Janata RSVP even when an external `signup_url` is set. Production behavior is preserved — every existing event keeps its current UX until the flag is flipped.

## Three signup states on the event detail page

| `signup_url` | `allow_janata_signup` | UI |
|---|---|---|
| null | — | Native **"Attend Event"** / "Cancel Registration" (existing) |
| set | `0` (default) | Only **"Sign up at <hostname>"** — native hidden. Attendees count row also hidden (the on-Janata tally is always ~0 when nobody can RSVP here). |
| set | `1` (admin opt-in) | **"Attend on Janata"** primary + "Or sign up at <hostname>" secondary link. Attendees count visible. |

## Migration

- `0014_add_event_allow_janata_signup.sql` — `ALTER TABLE events ADD COLUMN allow_janata_signup INTEGER NOT NULL DEFAULT 0;`

## Changes

**Backend**
- `EventRow` / `EventApiResponse` / `eventRowToApi` extended with `allow_janata_signup` (boolean in API).
- `PUT /admin/events/:id` now accepts `externalUrl`, `signupUrl`, `allowJanataSignup`. Admins can flip the toggle via the API today; the admin events tab is still view-only (filed as follow-up — would mirror the centers edit form from #138).

**Frontend**
- `EventData` / `EventDisplay` / `apiEventToDisplay` extended.
- Web `ActionBar` handles all three states; `MetaSection` conditionally hides the attendees row.
- Native `ActionBar` mirrors the web logic. This PR also brings external-signup support to the native event page, which #141 had scoped to web only.
- Native `MetaSection` matches the web hide rule.

## Tests

- [x] Backend typecheck clean, 267/267 pass
- [x] Frontend 153/153 pass
- [x] Local: 0014 applied, Mahasamadhi event has `signup_url` set + `allow_janata_signup = 0` → external CTA only, count hidden
- [ ] Visual: pull this branch, reload an event. Toggle one event's `allow_janata_signup` to 1 via wrangler — should see two buttons + count return.

## How an admin enables Janata-as-alternate today

Until the admin events form ships, this works:

```bash
curl -X PUT "https://api.chinmayajanata.org/api/admin/events/<event-id>" \\
  -H "Authorization: Bearer <admin-jwt>" \\
  -H "Content-Type: application/json" \\
  -d '{"allowJanataSignup": true}'
```

Or directly:
```bash
npx wrangler d1 execute chinmaya-janata-db --remote \\
  --command "UPDATE events SET allow_janata_signup = 1 WHERE id = '<event-id>';" \\
  --config packages/backend/wrangler.toml
```

## Deploy notes

After merge, apply 0014 to prod:
```
npx wrangler d1 execute chinmaya-janata-db --remote \\
  --file=migrations/0014_add_event_allow_janata_signup.sql \\
  --config packages/backend/wrangler.toml
```

## Follow-ups (not in this PR)

- Admin events tab inline edit form (mirror what #138 did for centers; expose `external_url`, `signup_url`, `allow_janata_signup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)