### PR TITLE
feat(nav): replace Log In + Sign Up with user-icon circle

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -2,10 +2,10 @@ import { Link, Tabs, useRouter } from 'expo-router'
 import { Platform, View, Text, Pressable, Image, StatusBar } from 'react-native'
 import { useState, useEffect } from 'react'
 import { useUser, useTheme } from '../../components/contexts'
-import { Plus } from 'lucide-react-native'
+import { Plus, User } from 'lucide-react-native'
 import SettingsPanel from '../../components/SettingsPanel'
 import Logo from '../../components/ui/Logo'
-import { Avatar, PrimaryButton, SecondaryButton } from '../../components/ui'
+import { Avatar } from '../../components/ui'
 import { usePostHog } from 'posthog-react-native'
 import { isSuperAdmin } from '../../utils/admin'
 
@@ -57,10 +57,25 @@ export default function TabLayout() {
         )
       }
       return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginRight: 16 }}>
-          <SecondaryButton onPress={() => router.push('/auth?mode=login')}>Log In</SecondaryButton>
-          <PrimaryButton onPress={() => router.push('/auth?mode=signup')}>Sign Up</PrimaryButton>
-        </View>
+        <Pressable
+          accessibilityLabel="Sign in or sign up"
+          onPress={() => {
+            posthog?.capture('nav_signin_icon')
+            router.push('/auth')
+          }}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: isDark ? '#404040' : '#D6D3D1',
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginRight: 16,
+          }}
+        >
+          <User size={18} color={isDark ? '#FAFAFA' : '#1C1917'} />
+        </Pressable>
       )
     }
     if (Platform.OS === 'web') {

--- a/packages/frontend/components/landing/NavBar.tsx
+++ b/packages/frontend/components/landing/NavBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { View, Text, Pressable, useWindowDimensions, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
+import { User } from 'lucide-react-native'
 import Logo from '../ui/Logo'
 
 // Inject hamburger animation CSS (web only)
@@ -73,55 +74,20 @@ export function NavBar() {
               </Pressable>
             ))}
 
-          {/* Log In */}
           <Pressable
-            onPress={() => router.push('/auth?mode=login')}
+            accessibilityLabel="Sign in or sign up"
+            onPress={() => router.push('/auth')}
             style={{
-              paddingHorizontal: 16,
-              paddingVertical: 12,
-              borderRadius: 100,
-              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 18,
               borderWidth: 1,
               borderColor: '#D6D3D1',
-            }}
-          >
-            <Text
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontWeight: '400',
-                fontSize: 16,
-                lineHeight: 16,
-                color: '#1C1917',
-                textAlign: 'center',
-              }}
-            >
-              Log In
-            </Text>
-          </Pressable>
-
-          {/* Sign Up */}
-          <Pressable
-            onPress={() => router.push('/auth?mode=signup')}
-            className="bg-primary active:bg-primary-press"
-            style={{
-              paddingHorizontal: 16,
-              paddingVertical: 12,
-              borderRadius: 100,
+              alignItems: 'center',
               justifyContent: 'center',
             }}
           >
-            <Text
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontWeight: '400',
-                fontSize: 16,
-                lineHeight: 16,
-                color: '#FFFFFF',
-                textAlign: 'center',
-              }}
-            >
-              Sign Up
-            </Text>
+            <User size={18} color="#1C1917" />
           </Pressable>
 
         </View>


### PR DESCRIPTION
## Summary
- Collapses the **Log In** + **Sign Up** buttons into a single 36×36 bordered circle with a lucide `User` icon in two places:
  - `packages/frontend/app/(tabs)/_layout.tsx` — web tab header (logged-out branch)
  - `packages/frontend/components/landing/NavBar.tsx` — landing page navbar
- Both route to `/auth` (no mode), letting the auth screen pick the default — consistent with how the native tab header already works (it shows an `Avatar name="Sign In"` circle).
- Tab-header version honors dark mode (border/icon swap on `isDark`). Adds a `nav_signin_icon` PostHog event.

## Test plan
- [ ] Web (light): visit landing while logged out → see icon circle in top-right; click navigates to `/auth`
- [ ] Web (dark): icon + border colors flip appropriately on the in-app header
- [ ] Web (in-app, logged out): the tab header shows the icon circle (no Log In / Sign Up text buttons)
- [ ] Native: unchanged — still shows the existing `Avatar name="Sign In"` circle in the tab header
- [ ] Logged-in state on web is unchanged — profile avatar + Create Event button still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)