### PR TITLE
fix(map): open popup for the exact event picked from the list

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -832,6 +832,7 @@ export default function DiscoverScreenWeb() {
   const [selectedItem, setSelectedItem] = useState<{ type: 'event' | 'center'; id: string } | null>(
     null
   )
+  const [autoOpenPoint, setAutoOpenPoint] = useState<{ id: string; type: 'event' | 'center'; key: number } | null>(null)
   const [mapFlyTo, setMapFlyTo] = useState<{ latitude: number; longitude: number; key: number } | null>(
     null
   )
@@ -882,6 +883,15 @@ export default function DiscoverScreenWeb() {
     setMapFlyTo((prev) => ({
       latitude: coords.latitude,
       longitude: coords.longitude,
+      key: (prev?.key ?? 0) + 1,
+    }))
+    // Tell the map to auto-open the popover for THIS exact point after the
+    // fly-to settles. Disambiguates overlapping markers (e.g. multiple events
+    // at the same center's coordinates) and serves as the requested
+    // "popup opens after the map moves" UX.
+    setAutoOpenPoint((prev) => ({
+      id: selectedItem.id,
+      type: selectedItem.type,
       key: (prev?.key ?? 0) + 1,
     }))
   }, [selectedItem, filteredPoints, allEvents, allCenters])
@@ -1024,6 +1034,7 @@ export default function DiscoverScreenWeb() {
               onMapMove={handleMapMove}
               userCenterID={user?.centerID}
               flyTo={mapFlyTo}
+              autoOpenPoint={autoOpenPoint}
             />
           </Suspense>
 

--- a/packages/frontend/components/Map.web.tsx
+++ b/packages/frontend/components/Map.web.tsx
@@ -43,6 +43,13 @@ export interface MapProps {
    * including re-selecting the same place.
    */
   flyTo?: { latitude: number; longitude: number; key: number } | null
+  /**
+   * After the next fly-to settles, simulate a click on the matching marker so
+   * the popover opens for THIS specific point. Necessary when several events
+   * share a center's coordinates and the visible top marker may not be the
+   * one the user picked from the list. `key` must change to retrigger.
+   */
+  autoOpenPoint?: { id: string; type: 'center' | 'event'; key: number } | null
 }
 
 // Default center - San Francisco Bay Area
@@ -189,6 +196,7 @@ const MapComponent = memo<MapProps>(
     showUserLocation = false,
     userCenterID,
     flyTo,
+    autoOpenPoint,
   }) => {
     const { isDark } = useTheme()
     const mapRef = useRef<MapRef>(null)
@@ -260,6 +268,59 @@ const MapComponent = memo<MapProps>(
         duration: 1200,
       })
     }, [flyTo?.key, flyTo?.latitude, flyTo?.longitude])
+
+    // After fly-to settles, programmatically open the popover for the
+    // requested point. Solves the "click event A in list, see event B's
+    // popup" overlap bug — the popup is keyed on the specific MapPoint id,
+    // not whichever marker happens to be on top.
+    useEffect(() => {
+      if (!autoOpenPoint) return
+      const map = mapRef.current
+      if (!map) return
+      const point = pointsRef.current.find(
+        (p) => p.id === autoOpenPoint.id && p.type === autoOpenPoint.type
+      )
+      if (!point) return
+
+      const fire = () => {
+        const m = mapRef.current
+        if (!m || !onPointClick) return
+        const projected = m.project([point.longitude, point.latitude])
+        const canvas = m.getCanvas()
+        const rect = canvas.getBoundingClientRect()
+        // Marker pin's tip sits ~8px above the projected coordinate.
+        const x = rect.left + projected.x
+        const y = rect.top + projected.y - 8
+        onPointClick(point, x, y)
+      }
+
+      // Wait for the fly-to animation to finish so the projected coords
+      // reflect the final viewport. moveend fires once when animation ends.
+      let cancelled = false
+      const onMoveEnd = () => {
+        if (cancelled) return
+        cancelled = true
+        map.off('moveend', onMoveEnd)
+        // One frame of breathing room so the marker DOM is in place.
+        requestAnimationFrame(fire)
+      }
+      map.on('moveend', onMoveEnd)
+
+      // Safety net: if no flyTo was scheduled (e.g. the point is already on
+      // screen), moveend won't fire — fire after a short delay.
+      const timer = setTimeout(() => {
+        if (cancelled) return
+        cancelled = true
+        map.off('moveend', onMoveEnd)
+        fire()
+      }, 1500)
+
+      return () => {
+        cancelled = true
+        map.off('moveend', onMoveEnd)
+        clearTimeout(timer)
+      }
+    }, [autoOpenPoint?.key, autoOpenPoint?.id, autoOpenPoint?.type, onPointClick])
 
     const handleMove = useCallback((evt: any) => {
       setViewState(evt.viewState)


### PR DESCRIPTION
## Bug

When the user clicks an event in the list, the side panel opens for that event correctly — but the **map pin** they're navigated to often shows a different event when manually clicked. Most seeded events share their host center's lat/lng (because the migration didn't have venue-level coordinates), so the markers overlap; whichever pin happens to be on top wins the click.

## Fix

`Map.web.tsx` now accepts an `autoOpenPoint` prop. When set:
1. Listens for `moveend` after the fly-to animation completes
2. Projects the point's `lat/lng` to viewport coordinates via `mapRef.project()`
3. Dispatches the same `onPointClick` callback a real marker click would, **keyed on the specific MapPoint `id`**

The popup now matches list selection regardless of pin overlap.

## Bonus (also requested in the same message)

> "if possible make the pin popup show after the map moves and the event details are open"

Same code path delivers this — the popup auto-opens once the fly-to settles. Applies to centers too for consistency.

## Mechanics

- `id + type + key` triple → re-trigger when the user re-selects after dismissing.
- 1500ms safety net fires the popup even if no fly-to was scheduled (point already on screen).
- Cleanup detaches the moveend listener and clears the timer on unmount.

## Test plan
- [x] Backend typecheck clean, frontend 153/153 pass
- [ ] Visual: pull this branch, click an event in the discover list whose center hosts multiple events. Pin popup should match the list selection. Map should fly first, then popup.
- [ ] Click a center: popup should open for that center (not an event sharing its coords).

🤖 Generated with [Claude Code](https://claude.com/claude-code)