### PR TITLE
feat(ux): show counts on Events / Centers tabs

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -440,6 +440,7 @@ export default function DiscoverScreen() {
                 tabs={FILTERS.map((f) => f.label)}
                 activeTab={selectedDate ? '' : activeFilter}
                 onTabChange={(tab) => handleFilterPress(tab as DiscoverFilter)}
+                counts={{ Events: allEvents.length, Centers: allCenters.length }}
               />
             </View>
 

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -719,6 +719,7 @@ function MobileDiscoverFallback() {
                 tabs={FILTERS.map((f) => f.label)}
                 activeTab={selectedDate ? '' : activeFilter}
                 onTabChange={(tab) => handleFilterPress(tab as DiscoverFilter)}
+                counts={{ Events: allEvents.length, Centers: allCenters.length }}
               />
             </View>
 
@@ -1167,6 +1168,7 @@ export default function DiscoverScreenWeb() {
                 tabs={FILTERS.map((f) => f.label)}
                 activeTab={selectedDate ? '' : activeFilter}
                 onTabChange={(tab) => handleFilterPress(tab as DiscoverFilter)}
+                counts={{ Events: allEvents.length, Centers: allCenters.length }}
               />
             </View>
 

--- a/packages/frontend/components/ui/UnderlineTabBar.tsx
+++ b/packages/frontend/components/ui/UnderlineTabBar.tsx
@@ -6,9 +6,11 @@ export interface UnderlineTabBarProps {
   tabs: string[]
   activeTab: string
   onTabChange: (tab: string) => void
+  /** Optional per-tab count rendered as a subtle inline number after the label. */
+  counts?: Record<string, number | undefined>
 }
 
-export default function UnderlineTabBar({ tabs, activeTab, onTabChange }: UnderlineTabBarProps) {
+export default function UnderlineTabBar({ tabs, activeTab, onTabChange, counts }: UnderlineTabBarProps) {
   const { isDark } = useTheme()
   const borderColor = isDark ? '#404040' : '#E7E5E4'
   const inactiveColor = isDark ? '#6B7280' : '#A8A29E'
@@ -20,6 +22,9 @@ export default function UnderlineTabBar({ tabs, activeTab, onTabChange }: Underl
     >
       {tabs.map((tab) => {
         const isActive = tab === activeTab
+        const count = counts?.[tab]
+        const labelColor = isActive ? '#E8862A' : inactiveColor
+        const countColor = isActive ? '#E8862A99' : (isDark ? '#52525B' : '#D6D3D1')
         return (
           <Pressable
             key={tab}
@@ -31,10 +36,15 @@ export default function UnderlineTabBar({ tabs, activeTab, onTabChange }: Underl
               style={{
                 fontSize: 14,
                 fontFamily: 'Inter-Medium',
-                color: isActive ? '#E8862A' : inactiveColor,
+                color: labelColor,
               }}
             >
               {tab}
+              {count != null && (
+                <Text style={{ fontFamily: 'Inter-Regular', color: countColor }}>
+                  {'  '}{count}
+                </Text>
+              )}
             </Text>
           </Pressable>
         )


### PR DESCRIPTION
First of five sequential UX improvements requested for the discover panel.

## Change
- `UnderlineTabBar` accepts an optional `counts` prop (`Record<string, number>`).
- When provided, renders a subtle inline number after the tab label.
- Wired at all three call sites: web desktop side panel, web mobile bottom sheet, native bottom sheet.

## Visual
- Active tab: orange label, half-opacity orange count.
- Inactive tab: muted grey label, even more muted grey count.
- Backwards compatible — omitting `counts` keeps existing tab bars unchanged.

## Tests
- [x] Frontend 153/153, backend typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)