### PR TITLE
feat(ux): replace checkboxes with filter chips, hide Going for guests

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -24,7 +24,7 @@ import {
 import { useRouter, useFocusEffect } from 'expo-router'
 import { usePostHog } from 'posthog-react-native'
 import { useTheme } from '../../components/contexts'
-import { Badge, UnderlineTabBar, Avatar } from '../../components/ui'
+import { Badge, UnderlineTabBar, Avatar, FilterChip } from '../../components/ui'
 import { useUser } from '../../components/contexts/UserContext'
 import { useDiscoverData, type DiscoverFilter } from '../../hooks/useApiData'
 import type { EventDisplay, DiscoverCenter, AttendeeInfo } from '../../utils/api'
@@ -443,29 +443,23 @@ export default function DiscoverScreen() {
               />
             </View>
 
-            {/* Filter checkboxes */}
+            {/* Filter chips */}
             {activeFilter !== 'Centers' && (
-              <View className="flex-row items-center px-4 py-2 gap-5">
-                <Pressable
-                  onPress={() => setShowGoingOnly((prev) => !prev)}
-                  className="flex-row items-center"
-                  style={{ minHeight: 32 }}
-                >
-                  <View className={`w-[18px] h-[18px] rounded border mr-2 items-center justify-center ${showGoingOnly ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
-                    {showGoingOnly && <Text className="text-white text-xs font-bold">✓</Text>}
-                  </View>
-                  <Text className="text-[13px] text-stone-500 dark:text-stone-400 font-inter">Going</Text>
-                </Pressable>
-                <Pressable
+              <View className="flex-row flex-wrap items-center px-4 py-2 gap-2">
+                {user && (
+                  <FilterChip
+                    label="Going"
+                    variant="outline"
+                    active={showGoingOnly}
+                    onPress={() => setShowGoingOnly((prev) => !prev)}
+                  />
+                )}
+                <FilterChip
+                  label="Show past"
+                  variant="outline"
+                  active={showPastEvents}
                   onPress={() => setShowPastEvents((prev) => !prev)}
-                  className="flex-row items-center"
-                  style={{ minHeight: 32 }}
-                >
-                  <View className={`w-[18px] h-[18px] rounded border mr-2 items-center justify-center ${showPastEvents ? 'bg-orange-600 border-orange-600' : 'border-stone-300 dark:border-stone-600'}`}>
-                    {showPastEvents && <Text className="text-white text-xs font-bold">✓</Text>}
-                  </View>
-                  <Text className="text-[13px] text-stone-500 dark:text-stone-400 font-inter">Show past events</Text>
-                </Pressable>
+                />
               </View>
             )}
 

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -704,37 +704,23 @@ function MobileDiscoverFallback() {
               />
             </View>
 
-            {/* Filter checkboxes */}
+            {/* Filter chips */}
             {activeFilter !== 'Centers' && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 4, gap: 16 }}>
-                <Pressable
-                  onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
-                  style={{ flexDirection: 'row', alignItems: 'center' }}
-                >
-                  <View style={{
-                    width: 16, height: 16, borderRadius: 3, borderWidth: 1,
-                    marginRight: 8, alignItems: 'center', justifyContent: 'center',
-                    backgroundColor: showGoingOnly ? '#ea580c' : 'transparent',
-                    borderColor: showGoingOnly ? '#ea580c' : '#9ca3af',
-                  }}>
-                    {showGoingOnly && <Text style={{ color: '#fff', fontSize: 10, fontWeight: 'bold' }}>✓</Text>}
-                  </View>
-                  <Text style={{ fontSize: 12, color: '#78716c' }}>Going</Text>
-                </Pressable>
-                <Pressable
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 6, gap: 8 }}>
+                {user && (
+                  <FilterChip
+                    label="Going"
+                    variant="outline"
+                    active={showGoingOnly}
+                    onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
+                  />
+                )}
+                <FilterChip
+                  label="Show past"
+                  variant="outline"
+                  active={showPastEvents}
                   onPress={() => setShowPastEvents((prev: boolean) => !prev)}
-                  style={{ flexDirection: 'row', alignItems: 'center' }}
-                >
-                  <View style={{
-                    width: 16, height: 16, borderRadius: 3, borderWidth: 1,
-                    marginRight: 8, alignItems: 'center', justifyContent: 'center',
-                    backgroundColor: showPastEvents ? '#ea580c' : 'transparent',
-                    borderColor: showPastEvents ? '#ea580c' : '#9ca3af',
-                  }}>
-                    {showPastEvents && <Text style={{ color: '#fff', fontSize: 10, fontWeight: 'bold' }}>✓</Text>}
-                  </View>
-                  <Text style={{ fontSize: 12, color: '#78716c' }}>Show past events</Text>
-                </Pressable>
+                />
               </View>
             )}
 
@@ -1126,37 +1112,23 @@ export default function DiscoverScreenWeb() {
               />
             </View>
 
-            {/* Filter checkboxes */}
+            {/* Filter chips */}
             {activeFilter !== 'Centers' && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 20, paddingVertical: 4, gap: 16 }}>
-                <Pressable
-                  onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
-                  style={{ flexDirection: 'row', alignItems: 'center' }}
-                >
-                  <View style={{
-                    width: 16, height: 16, borderRadius: 3, borderWidth: 1,
-                    marginRight: 8, alignItems: 'center', justifyContent: 'center',
-                    backgroundColor: showGoingOnly ? '#ea580c' : 'transparent',
-                    borderColor: showGoingOnly ? '#ea580c' : '#9ca3af',
-                  }}>
-                    {showGoingOnly && <Text style={{ color: '#fff', fontSize: 10, fontWeight: 'bold' }}>✓</Text>}
-                  </View>
-                  <Text style={{ fontSize: 12, color: '#78716c' }}>Going</Text>
-                </Pressable>
-                <Pressable
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', paddingHorizontal: 20, paddingVertical: 6, gap: 8 }}>
+                {user && (
+                  <FilterChip
+                    label="Going"
+                    variant="outline"
+                    active={showGoingOnly}
+                    onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
+                  />
+                )}
+                <FilterChip
+                  label="Show past"
+                  variant="outline"
+                  active={showPastEvents}
                   onPress={() => setShowPastEvents((prev: boolean) => !prev)}
-                  style={{ flexDirection: 'row', alignItems: 'center' }}
-                >
-                  <View style={{
-                    width: 16, height: 16, borderRadius: 3, borderWidth: 1,
-                    marginRight: 8, alignItems: 'center', justifyContent: 'center',
-                    backgroundColor: showPastEvents ? '#ea580c' : 'transparent',
-                    borderColor: showPastEvents ? '#ea580c' : '#9ca3af',
-                  }}>
-                    {showPastEvents && <Text style={{ color: '#fff', fontSize: 10, fontWeight: 'bold' }}>✓</Text>}
-                  </View>
-                  <Text style={{ fontSize: 12, color: '#78716c' }}>Show past events</Text>
-                </Pressable>
+                />
               </View>
             )}
 


### PR DESCRIPTION
Fourth of the sequential UX improvements. The 'Going' + 'Show past events' checkboxes felt like leftover form fields and took noisy vertical space. Swapping for outline `FilterChip` pills (the component used elsewhere on the discover surface):

- Compact, reads as a filter not a form input
- Active state uses the same orange tint as other filters
- **'Going' only renders when there's a logged-in user** — for guests it filtered by something they couldn't set, which was confusing

Wired in three places: web desktop side panel, web mobile bottom sheet, native bottom sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)