### PR TITLE
feat(share): copy link button on web detail panels, public URL in native share

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -186,10 +186,10 @@ export default function CenterDetailPage() {
   const handleShare = async () => {
     posthog?.capture('center_shared', { centerId: id })
     try {
+      const url = id ? `https://chinmayajanata.org/center/${id}` : 'https://chinmayajanata.org'
       await Share.share({
-        message: center
-          ? `Check out ${center.name}!`
-          : 'Check out this center!',
+        message: center ? `Check out ${center.name} on Chinmaya Janata! ${url}` : `Check out this center on Chinmaya Janata! ${url}`,
+        url,
       })
     } catch {
       // Share cancelled or failed

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -209,8 +209,10 @@ function HeaderBar({
           {!isPast && (
             <Pressable
               onPress={() => {
+                const url = eventId ? `https://chinmayajanata.org/events/${eventId}` : 'https://chinmayajanata.org'
                 Share.share({
-                  message: `Check out ${title} on Chinmaya Janata!`,
+                  message: `Check out ${title} on Chinmaya Janata! ${url}`,
+                  url,
                 }).catch(() => {})
               }}
               style={{

--- a/packages/frontend/components/ui/CopyLinkButton.tsx
+++ b/packages/frontend/components/ui/CopyLinkButton.tsx
@@ -1,0 +1,105 @@
+/**
+ * CopyLinkButton — small inline button that copies a public link to the
+ * clipboard and briefly flips its label to "Copied!".
+ *
+ * Login isn't required to view event/center detail pages, so the URL
+ * shared from this button works for any recipient.
+ */
+import React, { useState, useCallback } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { Link2, Check } from 'lucide-react-native'
+
+const FALLBACK_ORIGIN = 'https://chinmayajanata.org'
+
+function buildShareUrl(path: string): string {
+  const cleanPath = path.startsWith('/') ? path : `/${path}`
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return `${window.location.origin}${cleanPath}`
+  }
+  return `${FALLBACK_ORIGIN}${cleanPath}`
+}
+
+type CopyLinkButtonProps = {
+  /** URL path, e.g. `/events/abc` or `/center/xyz`. */
+  path: string
+  /** Optional override for label color when not in copied state. */
+  color?: string
+  /** "icon" = round icon-only button, "inline" = icon + label. Default "inline". */
+  variant?: 'icon' | 'inline'
+}
+
+export default function CopyLinkButton({ path, color = '#78716C', variant = 'inline' }: CopyLinkButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handlePress = useCallback(async () => {
+    const url = buildShareUrl(path)
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url)
+      } else {
+        // No clipboard API (likely older mobile webviews). Fall back to a
+        // textarea selection trick so the action still works.
+        if (typeof document !== 'undefined') {
+          const ta = document.createElement('textarea')
+          ta.value = url
+          ta.style.position = 'fixed'
+          ta.style.opacity = '0'
+          document.body.appendChild(ta)
+          ta.select()
+          document.execCommand('copy')
+          document.body.removeChild(ta)
+        }
+      }
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // Silently swallow — the user can still copy from the URL bar.
+    }
+  }, [path])
+
+  if (variant === 'icon') {
+    return (
+      <Pressable
+        onPress={handlePress}
+        style={{
+          padding: 8,
+          minHeight: 44,
+          minWidth: 44,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        accessibilityLabel={copied ? 'Link copied' : 'Copy link'}
+      >
+        {copied ? <Check size={18} color="#16A34A" /> : <Link2 size={18} color={color} />}
+      </Pressable>
+    )
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+        borderRadius: 6,
+        minHeight: 32,
+      }}
+      accessibilityLabel={copied ? 'Link copied' : 'Copy link'}
+    >
+      {copied ? (
+        <>
+          <Check size={14} color="#16A34A" />
+          <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 13, color: '#16A34A' }}>Copied</Text>
+        </>
+      ) : (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <Link2 size={14} color={color} />
+          <Text style={{ fontFamily: 'Inter-Medium', fontSize: 13, color }}>Copy link</Text>
+        </View>
+      )}
+    </Pressable>
+  )
+}

--- a/packages/frontend/components/ui/index.ts
+++ b/packages/frontend/components/ui/index.ts
@@ -21,6 +21,7 @@ import Logo from './Logo'
 import UnderlineTabBar from './UnderlineTabBar'
 import Avatar from './Avatar'
 import AuthPromptModal from './AuthPromptModal'
+import CopyLinkButton from './CopyLinkButton'
 
 export {
   PrimaryButton,
@@ -37,4 +38,5 @@ export {
   UnderlineTabBar,
   Avatar,
   AuthPromptModal,
+  CopyLinkButton,
 }

--- a/packages/frontend/components/web/CenterDetailPanel.tsx
+++ b/packages/frontend/components/web/CenterDetailPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text, Image, ScrollView, Pressable, Linking } from 'react-native'
 import { MapPin, Globe, Phone, User, ChevronLeft, Navigation, BadgeCheck, Users } from 'lucide-react-native'
+import CopyLinkButton from '../ui/CopyLinkButton'
 import type { CenterDisplay } from '../../hooks/useApiData'
 import type { EventDisplay } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
@@ -79,8 +80,8 @@ export default function CenterDetailPanel({
           gap: 10,
         }}
       >
-        {/* Top row: back */}
-        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        {/* Top row: back + copy link */}
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
           <Pressable
             onPress={onClose}
             style={{ flexDirection: 'row', alignItems: 'center', gap: 4, padding: 8, minHeight: 44, minWidth: 44 }}
@@ -97,6 +98,7 @@ export default function CenterDetailPanel({
               Back
             </Text>
           </Pressable>
+          <CopyLinkButton path={`/center/${center.id}`} color={colors.iconHeader} />
         </View>
 
         {/* Title row */}

--- a/packages/frontend/components/web/EventDetailPanel.tsx
+++ b/packages/frontend/components/web/EventDetailPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { View, Text, Image, ScrollView, Pressable, ActivityIndicator, Linking } from 'react-native'
 import { MapPin, Users, User, Clock, CheckCircle, ChevronLeft, Pencil, ExternalLink } from 'lucide-react-native'
+import CopyLinkButton from '../ui/CopyLinkButton'
 import Badge from '../ui/Badge'
 import UnderlineTabBar from '../ui/UnderlineTabBar'
 import Avatar from '../ui/Avatar'
@@ -214,6 +215,7 @@ function HeaderBar({
         </Pressable>
 
         <View className="flex-row items-center" style={{ gap: 4 }}>
+          {eventId && <CopyLinkButton path={`/events/${eventId}`} variant="icon" color={colors.iconHeader} />}
           {eventId && onEdit && (
             <Pressable
               onPress={() => onEdit(eventId)}


### PR DESCRIPTION
Login isn't required to view event/center detail pages, so URLs shared from these surfaces work for any recipient. Adds explicit copy affordances + makes the existing native Share emit a real link.

## New component
`components/ui/CopyLinkButton.tsx`
- Copies a path's full URL to clipboard
- Briefly flips to 'Copied' with a checkmark
- `inline` (icon + text) and `icon` (round icon-only) variants
- `navigator.clipboard` with textarea fallback for old webviews; silent error handling

## Web side panels
- **CenterDetailPanel**: inline 'Copy link' pill in header next to Back. Path = `/center/{id}`.
- **EventDetailPanel**: icon-only Link2 button in the header actions cluster. Path = `/events/{id}`.
- Previously these panels had no share affordance at all.

## Native event + center pages
- Existing `Share.share` calls just said 'Check out X!' with no link.
- Now include the canonical URL in both `message` and the platform `url` field — Messages/Mail/Social will pull a proper preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)