### PR TITLE
fix(error-boundary): 'Reset session and reload' recovery path

### DIFF
--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -38,6 +38,50 @@ export class ErrorBoundary extends Component<Props, State> {
     this.setState({ hasError: false })
   }
 
+  /**
+   * Recovery path for users whose session is the cause of the crash (stale
+   * auth tokens, malformed cached state, etc.). Wipes localStorage,
+   * sessionStorage, and cookies for the current origin, then hard-reloads —
+   * the page comes back as if it's a first visit.
+   *
+   * "Try Again" alone wasn't enough: re-rendering with the same broken
+   * persisted state just loops on the same crash.
+   */
+  private handleResetAndReload = () => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage?.clear()
+    } catch {
+      // Ignore — some browsers block storage access in private/incognito.
+    }
+    try {
+      window.sessionStorage?.clear()
+    } catch {
+      // Ignore.
+    }
+    if (typeof document !== 'undefined') {
+      try {
+        const cookies = document.cookie.split(';')
+        for (const c of cookies) {
+          const eq = c.indexOf('=')
+          const name = (eq > -1 ? c.substring(0, eq) : c).trim()
+          if (!name) continue
+          // Expire on this path and root domain, with and without leading dot.
+          const host = window.location.hostname
+          const stripped = host.replace(/^www\./, '')
+          for (const domain of [host, '.' + stripped, stripped]) {
+            document.cookie =
+              name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/; domain=' + domain
+          }
+          document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/'
+        }
+      } catch {
+        // Ignore — best-effort.
+      }
+    }
+    window.location.replace(window.location.pathname || '/')
+  }
+
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
@@ -86,6 +130,17 @@ export class ErrorBoundary extends Component<Props, State> {
               Try Again
             </Text>
           </Pressable>
+
+          {typeof window !== 'undefined' && (
+            <Pressable
+              onPress={this.handleResetAndReload}
+              style={{ marginTop: 16, paddingHorizontal: 16, paddingVertical: 10 }}
+            >
+              <Text style={{ color: '#666', fontSize: 13, textDecorationLine: 'underline' }}>
+                Still stuck? Reset session and reload
+              </Text>
+            </Pressable>
+          )}
         </View>
       )
     }


### PR DESCRIPTION
When a render crash is caused by corrupt persisted state (stale auth tokens, malformed cached state), the existing 'Try Again' just re-renders the same broken state and loops. Adds a secondary action: **'Still stuck? Reset session and reload'** — clears localStorage, sessionStorage, and cookies for the current origin, then hard-reloads. The page comes back as if it's a first visit.

Primary 'Try Again' stays for transient bugs unrelated to persisted state.

Pairs with the React #130 debug logging from #152 — once we identify the root cause we can keep this recovery path or drop it.