### PR TITLE
feat(auth): add nav links to landing and discover

### DIFF
--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -324,14 +324,70 @@ export default function AuthScreen() {
           width: isNarrowWeb ? '100%' : '50%',
           backgroundColor: '#FAFAF7',
           display: 'flex',
-          alignItems: isMobile ? 'flex-start' : 'center',
-          justifyContent: 'center',
+          flexDirection: 'column',
           overflow: 'auto',
           WebkitOverflowScrolling: 'touch',
-          padding: isMobile ? '24px 16px' : isNarrowWeb ? '32px 20px' : 0,
           flex: 1,
         }}
       >
+        {/* Top nav: back to landing (left) + Discover (right) */}
+        <nav
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: isMobile ? '16px 16px' : '24px 32px',
+            flexShrink: 0,
+          }}
+        >
+          <button
+            onClick={() => router.push('/landing')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '8px 4px',
+              margin: '-8px -4px',
+              fontSize: 14,
+              fontFamily: 'Inter, sans-serif',
+              color: '#78716C',
+              minHeight: 44,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            &larr; Back to home
+          </button>
+          <button
+            onClick={() => router.push('/(tabs)')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '8px 4px',
+              margin: '-8px -4px',
+              fontSize: 14,
+              fontFamily: 'Inter, sans-serif',
+              fontWeight: '500',
+              color: '#C2410C',
+              minHeight: 44,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            Discover &rarr;
+          </button>
+        </nav>
+
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            alignItems: isMobile ? 'flex-start' : 'center',
+            justifyContent: 'center',
+            padding: isMobile ? '8px 16px 24px' : isNarrowWeb ? '0 20px 32px' : 0,
+          }}
+        >
         <div style={{ maxWidth: 400, width: '100%', padding: isNarrowWeb ? 0 : '0 48px' }}>
           {/* Back button (login/signup steps) */}
           {authStep !== 'initial' && (
@@ -699,6 +755,7 @@ export default function AuthScreen() {
             </span>
           </p>
 
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds a top nav bar inside the form column on the web auth page
- Top-left **← Back to home** → `/landing`
- Top-right **Discover →** → `/(tabs)`
- Helps users who land on `/auth` from a share link reorient without using the browser back button

## Test plan
- [x] Visual check at `http://localhost:8081/auth` (wide viewport): nav renders at the top of the form column, form stays vertically centered below
- [x] Click "Discover →" navigates to `/`
- [x] Click "← Back to home" navigates to `/landing`
- [x] Vitest suite passes (153/153)
- [ ] Spot-check narrow/mobile viewport (form column takes full width; nav sits at top)
- [ ] Verify nav doesn't overlap login/signup/invite-code steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)