### PR TITLE
fix(discover): destructure allCenters from useDiscoverData

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -455,7 +455,7 @@ function MobileDiscoverFallback() {
   const [showGoingOnly, setShowGoingOnly] = useState(false)
   const [showPastEvents, setShowPastEvents] = useState(false)
   const { user } = useUser()
-  const { items, filteredPoints, loading, allEvents, refresh } = useDiscoverData(
+  const { items, filteredPoints, loading, allEvents, allCenters, refresh } = useDiscoverData(
     activeFilter,
     searchQuery,
     user?.id,


### PR DESCRIPTION
## Summary
- `MobileDiscoverFallback` in `app/(tabs)/index.web.tsx` referenced `allCenters.length` for the Events/Centers tab counts, but the destructure on line 458 only pulled `allEvents`.
- Result: `ReferenceError: allCenters is not defined` rendered the ErrorBoundary fallback ("Something went wrong") on `/(tabs)` at narrow widths.
- The hook already returns `allCenters`; this PR just adds it to the destructure.

## Root cause
PR #146 (`feat(ux): show counts on Events / Centers tabs`) added the `counts={{ Events: allEvents.length, Centers: allCenters.length }}` prop without updating the destructure on the same render of `MobileDiscoverFallback`.

## Test plan
- [x] Discover screen renders at mobile widths without ErrorBoundary fallback
- [x] Events / Centers tab counts display correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)