### PR TITLE
feat(landing/hero): tighter, more concrete subtitle and tagline

### DIFF
--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -479,8 +479,8 @@ export function Hero() {
             maxWidth: 480,
           }}
         >
-          Discover Chinmaya Mission centers, connect with your local community, and grow through
-          events, study groups, and seva opportunities.
+          One place where any CHYK can find events and centers nearby, RSVP in a tap, and run their
+          own events without juggling five group chats.
         </Text>
 
         {/* CTAs */}
@@ -522,7 +522,7 @@ export function Hero() {
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
           <AvatarStack />
           <Text style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: '#78716C' }}>
-            A project built by CHYKs, for CHYKs.
+            By CHYKs, for CHYKs.
           </Text>
         </View>
 


### PR DESCRIPTION
## Summary
- Hero subtitle: replaced generic "Discover/connect/grow" framing with the concrete jobs CHYKs do on Janata — find events/centers nearby, RSVP in a tap, run their own events.
- Tagline: trimmed "A project built by CHYKs, for CHYKs." → "By CHYKs, for CHYKs."
- Copy-only change in `Hero.tsx`. No structural / styling / dep changes.

## Test plan
- [ ] CI green
- [ ] Visual check on `/landing` (wide and narrow widths) that the new copy fits within the existing hero layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)