### PR TITLE
fix(contexts): re-export OnboardingProvider as named — unblocks new admin/tester logins

### DIFF
--- a/packages/frontend/components/contexts/index.ts
+++ b/packages/frontend/components/contexts/index.ts
@@ -3,7 +3,7 @@ import UserContext, { UserProvider, useUser } from './UserContext'
 import { ThemeProvider, useTheme } from './ThemeContext'
 
 export {
-  OnboardingProvider as default,
+  OnboardingProvider,
   UserProvider,
   useOnboarding,
   UserContext,

--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, type ErrorInfo, type ReactNode } from 'react'
-import { View, Text, Pressable } from 'react-native'
+import { ScrollView, View, Text, Pressable } from 'react-native'
 
 interface Props {
   children: ReactNode
@@ -8,16 +8,22 @@ interface Props {
 
 interface State {
   hasError: boolean
+  error: Error | null
+  componentStack: string | null
+  copied: boolean
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, error: null, componentStack: null, copied: false }
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true }
+  // Capture the error here (runs before render) so the fallback can show it
+  // on first paint — componentDidCatch runs after render and would leave the
+  // first paint empty.
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -32,10 +38,42 @@ export class ErrorBoundary extends Component<Props, State> {
         componentStack: info.componentStack,
       }
     }
+    this.setState({ componentStack: info.componentStack ?? null })
   }
 
   private handleRetry = () => {
-    this.setState({ hasError: false })
+    this.setState({ hasError: false, error: null, componentStack: null, copied: false })
+  }
+
+  private buildErrorReport = (): string => {
+    const { error, componentStack } = this.state
+    const url = typeof window !== 'undefined' ? window.location.href : ''
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : ''
+    return [
+      `Message: ${error?.message ?? '(no message)'}`,
+      `URL: ${url}`,
+      `UA: ${ua}`,
+      '',
+      'Stack:',
+      error?.stack ?? '(no stack)',
+      '',
+      'Component stack:',
+      componentStack ?? '(no component stack)',
+    ].join('\n')
+  }
+
+  private handleCopyDetails = async () => {
+    const text = this.buildErrorReport()
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+        this.setState({ copied: true })
+        setTimeout(() => this.setState({ copied: false }), 2000)
+      }
+    } catch {
+      // Clipboard can be blocked (insecure context, denied permission). Users
+      // can still read the on-screen text and screenshot it.
+    }
   }
 
   /**
@@ -140,6 +178,68 @@ export class ErrorBoundary extends Component<Props, State> {
                 Still stuck? Reset session and reload
               </Text>
             </Pressable>
+          )}
+
+          {/* Beta-phase debug panel: shown to every user so a screenshot is
+              enough to triage. Remove or gate behind a flag at public launch. */}
+          {this.state.error && (
+            <View
+              style={{
+                marginTop: 32,
+                width: '100%',
+                maxWidth: 640,
+                borderWidth: 1,
+                borderColor: '#e5e5e5',
+                borderRadius: 8,
+                padding: 12,
+                backgroundColor: '#fafafa',
+              }}
+            >
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 8,
+                }}
+              >
+                <Text style={{ fontSize: 12, fontWeight: '600', color: '#666' }}>
+                  Debug details (beta)
+                </Text>
+                <Pressable
+                  onPress={this.handleCopyDetails}
+                  style={{
+                    paddingHorizontal: 10,
+                    paddingVertical: 4,
+                    borderRadius: 6,
+                    backgroundColor: this.state.copied ? '#16a34a' : '#1a1a1a',
+                  }}
+                >
+                  <Text style={{ color: '#fff', fontSize: 12, fontWeight: '600' }}>
+                    {this.state.copied ? 'Copied' : 'Copy details'}
+                  </Text>
+                </Pressable>
+              </View>
+              <Text
+                selectable
+                style={{ fontSize: 12, color: '#1a1a1a', marginBottom: 6 }}
+              >
+                {this.state.error.message || '(no message)'}
+              </Text>
+              <ScrollView style={{ maxHeight: 240 }} nestedScrollEnabled>
+                <Text
+                  selectable
+                  style={{
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: '#444',
+                    lineHeight: 16,
+                  }}
+                >
+                  {this.buildErrorReport()}
+                </Text>
+              </ScrollView>
+            </View>
           )}
         </View>
       )


### PR DESCRIPTION
## Summary
- **fix:** New users (anyone with `profileComplete=false`) crash on first authed render with React #130 — \"Element type is invalid... Check the render method of `Onboarding(./onboarding.tsx)`\". Repros for `walkthrough.tester` and Abhiram's tester account; works fine for `kish@gmail.com` whose profile was completed long ago.
- **cause:** `components/contexts/index.ts` re-exported `OnboardingProvider` only as `default`, but `app/onboarding.tsx` imports it as `{ OnboardingProvider }` (named). Resolves to `undefined`, React throws on element creation. `UserProvider` and `ThemeProvider` in the same file are correctly named — this one was the inconsistency.
- **fix:** one-line — re-export `OnboardingProvider` as a named export.

Also bundled in this PR: a beta-phase debug panel on `ErrorBoundary` that surfaces the actual error message + stack on the fallback screen, so phone testers can screenshot crashes instead of needing devtools. (`Remove or gate behind a flag at public launch` — comment in the file.)

## Test plan
- [x] Reproduced locally: created a level-108 admin via `/api/auth/register` + UPDATE, `profileComplete=false`. Login → \"Something went wrong\" → debug panel showed the exact error.
- [x] Applied fix, hard-reloaded — `/onboarding` now renders Step 1 of 4 cleanly.
- [x] `npm test` (frontend): 153/153 passing.
- [x] No new TS errors introduced (pre-existing icon/posthog typing errors are unrelated).
- [ ] On staging post-merge: log in as a fresh non-onboarded user, confirm Step 1 renders.
- [ ] On staging: confirm `kish@gmail.com` (already onboarded) still works.
- [ ] After staging is green, manually dispatch the production deploy via Actions → Deploy → workflow_dispatch → environment: production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)