### PR TITLE
fix(events/[id].web): gate native RSVP — PR #143 missed the mobile-web full-page route

### DIFF
--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions } from 'react-native'
+import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions, Linking } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, Share2, MapPin, Users, User, Clock, CheckCircle } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
@@ -128,13 +128,16 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
               </View>
             )}
 
-            {/* Attendees count */}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <Users size={18} color={colors.textSecondary} />
-              <Text style={{ color: colors.text, fontSize: 15 }}>
-                {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
-              </Text>
-            </View>
+            {/* Attendees count — hidden when signup is external-only
+                (the on-Janata count would always read 0). */}
+            {!(event.signupUrl && !event.allowJanataSignup) && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Users size={18} color={colors.textSecondary} />
+                <Text style={{ color: colors.text, fontSize: 15 }}>
+                  {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
+                </Text>
+              </View>
+            )}
 
             {/* Contact */}
             {event.pointOfContact && (
@@ -169,10 +172,65 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         )}
       </ScrollView>
 
-      {/* Action button */}
+      {/* Action button(s) — three modes (matches EventDetailPanel.ActionBar):
+          1. signupUrl + allowJanataSignup → Janata primary, external alt
+          2. signupUrl only → external referrer, no native RSVP
+          3. no signupUrl → native Register / Cancel */}
       {!isPast && (
-        <View style={{ padding: 16 }}>
-          {event.isRegistered ? (
+        <View style={{ padding: 16, gap: 8 }}>
+          {event.signupUrl && event.allowJanataSignup ? (
+            <>
+              {event.isRegistered ? (
+                <DestructiveButton
+                  onPress={() => user?.username && toggleRegistration(user.username)}
+                  disabled={isToggling}
+                  loading={isToggling}
+                >
+                  Cancel Registration
+                </DestructiveButton>
+              ) : (
+                <PrimaryButton
+                  onPress={() => {
+                    if (!user) {
+                      setShowAuthPrompt(true)
+                    } else if (user.username) {
+                      toggleRegistration(user.username)
+                    }
+                  }}
+                  disabled={isToggling}
+                  loading={isToggling}
+                >
+                  Attend on Janata
+                </PrimaryButton>
+              )}
+              <Pressable
+                onPress={() => Linking.openURL(event.signupUrl!)}
+                style={{ paddingVertical: 12, alignItems: 'center' }}
+                accessibilityLabel={`Sign up at ${hostnameOf(event.signupUrl)}`}
+              >
+                <Text style={{ fontFamily: 'Inter-SemiBold', fontSize: 14, color: '#E8862A' }}>
+                  Or sign up at {hostnameOf(event.signupUrl)}
+                </Text>
+              </Pressable>
+            </>
+          ) : event.signupUrl ? (
+            <>
+              <PrimaryButton onPress={() => Linking.openURL(event.signupUrl!)}>
+                Sign up at {hostnameOf(event.signupUrl)}
+              </PrimaryButton>
+              <Text
+                style={{
+                  fontFamily: 'Inter-Regular',
+                  fontSize: 12,
+                  color: colors.textSecondary,
+                  textAlign: 'center',
+                  marginTop: 4,
+                }}
+              >
+                Registration handled on the official site
+              </Text>
+            </>
+          ) : event.isRegistered ? (
             <DestructiveButton
               onPress={() => user?.username && toggleRegistration(user.username)}
               disabled={isToggling}
@@ -206,4 +264,12 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
       />
     </View>
   )
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
 }


### PR DESCRIPTION
## Summary
- **bug:** On mobile-Safari deep-linking to an event (`chinmayajanata.org/events/<id>`), the event detail page showed a native "Register" button even for events with `signup_url` set and `allow_janata_signup=0`. Kish caught this on a Hanuman Chalisa Havan — CMNY event that routes signup to chinmayanewyork.org.
- **cause:** PR #143 added the 3-state signup logic to `EventDetailPanel.tsx` (desktop overlay) and `app/events/[id].tsx` (native iOS) but missed `app/events/[id].web.tsx`, which is the route Expo Router uses for full-page web event detail on mobile.
- **fix:** Mirror the existing `EventDetailPanel.ActionBar` logic in `[id].web.tsx`. Same three states, same hostname helper. Also gates the "X people attending" row on the same condition (external-only events don't show "0 people attending").

## Verified
- [x] Prod D1 sanity: 41 events with `signup_url` set + `allow_janata_signup=0`, 13 native-only, 0 with the dual-CTA admin opt-in. The fix correctly handles all three.
- [x] Typecheck clean for the edited file (lucide icon errors are pre-existing across the codebase).
- [x] `npm test` (frontend): 153/153 passing.
- [ ] Post-deploy: load `chinmayajanata.org/events/<event-with-signup-url>` on mobile, expect "Sign up at <hostname>" CTA, no native Register, no attendees row.
- [ ] Post-deploy: load a native-only event (no signup_url), expect existing Register/Cancel behavior.

## Deploy
After merge, trigger Actions → Deploy → workflow_dispatch → environment=production to push to `chinmayajanata.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)