### PR TITLE
feat(discover): Seva tab (coming soon) + sheet expanded full-height

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -38,6 +38,7 @@ const Map = React.lazy(() => import('../../components/Map'))
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'Events' },
   { label: 'Centers' },
+  { label: 'Seva' },
 ]
 
 /**
@@ -445,7 +446,7 @@ export default function DiscoverScreen() {
             </View>
 
             {/* Filter chips */}
-            {activeFilter !== 'Centers' && (
+            {activeFilter === 'Events' && (
               <View className="flex-row flex-wrap items-center px-4 py-2 gap-2">
                 {user && (
                   <FilterChip
@@ -465,7 +466,7 @@ export default function DiscoverScreen() {
             )}
 
             {/* Week Calendar */}
-            {activeFilter !== 'Centers' && !searchQuery.trim() && (
+            {activeFilter === 'Events' && !searchQuery.trim() && (
               <WeekCalendar
                 eventDates={eventDates}
                 selectedDate={selectedDate}
@@ -493,10 +494,13 @@ export default function DiscoverScreen() {
             showsVerticalScrollIndicator={false}
             scrollEnabled={isSheetExpanded}
           >
-            {!loading && displayItems.length === 0 && (
+            {!loading && activeFilter === 'Seva' && (
+              <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
+            )}
+            {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
               <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
-            {displayItems.map((item, idx) => {
+            {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
               if (item.type === 'section') {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -46,6 +46,7 @@ import { ADMIN_EMAIL, isLocal } from '../../utils/admin'
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'Events' },
   { label: 'Centers' },
+  { label: 'Seva' },
 ]
 
 function formatDatePill(dateStr: string): { month: string; day: string } {
@@ -482,7 +483,7 @@ function MobileDiscoverFallback() {
   const getSnapPositions = useCallback(() => {
     const h = containerRef.current?.clientHeight || window.innerHeight
     return {
-      expanded: 56, // 56px from top (below status bar area)
+      expanded: 0, // flush with the top of the container — full height
       mid: h * 0.55, // 55% down
       collapsed: h - 80, // 80px from bottom (just the handle + peek)
     }
@@ -575,7 +576,7 @@ function MobileDiscoverFallback() {
   // "Coming up" hint shown when there's a real gap between today and the
   // next event. Bridges the dead air for users browsing an empty week.
   const comingUpHint = useMemo(() => {
-    if (selectedDate || showPastEvents || activeFilter === 'Centers' || searchQuery.trim()) return null
+    if (selectedDate || showPastEvents || activeFilter !== 'Events' || searchQuery.trim()) return null
     const todayStr = new Date().toISOString().split('T')[0]
     const upcoming = allEvents
       .filter((e) => e.date && e.date >= todayStr)
@@ -724,7 +725,7 @@ function MobileDiscoverFallback() {
             </View>
 
             {/* Filter chips */}
-            {activeFilter !== 'Centers' && (
+            {activeFilter === 'Events' && (
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 6, gap: 8 }}>
                 {user && (
                   <FilterChip
@@ -744,7 +745,7 @@ function MobileDiscoverFallback() {
             )}
 
             {/* Week Calendar */}
-            {activeFilter !== 'Centers' && !searchQuery.trim() && (
+            {activeFilter === 'Events' && !searchQuery.trim() && (
               <View style={{ paddingHorizontal: 12, paddingTop: 4 }}>
                 <WeekCalendar
                   eventDates={eventDates}
@@ -791,10 +792,13 @@ function MobileDiscoverFallback() {
                 </Text>
               </View>
             )}
-            {!loading && displayItems.length === 0 && (
+            {!loading && activeFilter === 'Seva' && (
+              <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
+            )}
+            {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
               <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
-            {displayItems.map((item, idx) => {
+            {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
               if (item.type === 'section') {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)
@@ -945,7 +949,7 @@ export default function DiscoverScreenWeb() {
   // "Coming up" hint shown when there's a real gap between today and the
   // next event. Bridges the dead air for users browsing an empty week.
   const comingUpHint = useMemo(() => {
-    if (selectedDate || showPastEvents || activeFilter === 'Centers' || searchQuery.trim()) return null
+    if (selectedDate || showPastEvents || activeFilter !== 'Events' || searchQuery.trim()) return null
     const todayStr = new Date().toISOString().split('T')[0]
     const upcoming = allEvents
       .filter((e) => e.date && e.date >= todayStr)
@@ -1173,7 +1177,7 @@ export default function DiscoverScreenWeb() {
             </View>
 
             {/* Filter chips */}
-            {activeFilter !== 'Centers' && (
+            {activeFilter === 'Events' && (
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', paddingHorizontal: 20, paddingVertical: 6, gap: 8 }}>
                 {user && (
                   <FilterChip
@@ -1193,7 +1197,7 @@ export default function DiscoverScreenWeb() {
             )}
 
             {/* Week Calendar — hidden when Centers filter or searching */}
-            {activeFilter !== 'Centers' && !searchQuery.trim() && (
+            {activeFilter === 'Events' && !searchQuery.trim() && (
               <View style={{ paddingHorizontal: 20, paddingTop: 4 }}>
                 <WeekCalendar
                   eventDates={eventDates}
@@ -1216,10 +1220,13 @@ export default function DiscoverScreenWeb() {
               contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 4 }}
               showsVerticalScrollIndicator={false}
             >
-              {!loading && displayItems.length === 0 && (
+              {!loading && activeFilter === 'Seva' && (
+                <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
+              )}
+              {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
                 <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
               )}
-              {displayItems.map((item, idx) => {
+              {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
                 if (item.type === 'section') {
                   const label = item.data.label
                   const isCollapsed = collapsedSections.has(label)

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -126,7 +126,7 @@ export type DiscoverItem =
   | { type: 'center'; data: DiscoverCenter }
   | { type: 'section'; data: { label: string } }
 
-export type DiscoverFilter = 'Events' | 'Centers'
+export type DiscoverFilter = 'Events' | 'Centers' | 'Seva'
 
 // ── Fetch helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Two small Discover-screen changes the user asked for in chat:

1. **Seva tab (coming soon).** Adds 'Seva' as a third option after Events/Centers. Selecting it shows a centered "Seva — coming soon" placeholder (reuses EmptyState's `message`/`subtitle` props). Filter chips and the week calendar are hidden on Seva, same pattern as Centers. Applied to both `app/(tabs)/index.web.tsx` and `app/(tabs)/index.tsx` for parity between mobile-web and native iOS.

2. **Sheet expanded → full height.** The bottom sheet's `expanded` snap was 56px from the top of the container; user said current tallest setting wasn't enough. Moved to `0`. `mid` and `collapsed` are unchanged.

Gating logic switched from `activeFilter !== 'Centers'` to `activeFilter === 'Events'` (and the inverse for the upcoming-hint guards) so Seva is handled by the same pattern instead of needing a third comparison.

## Test plan
- [x] Typecheck clean for edited files (lucide icon errors are pre-existing).
- [x] `npm test` (frontend): 153/153 passing.
- [ ] On staging/prod: tap Seva tab → shows placeholder, no list, no week calendar.
- [ ] Tap Events tab → existing behavior unchanged.
- [ ] Drag sheet up to expanded → reaches the very top of the container (no map peeking above).
- [ ] If sheet header now overlaps with browser chrome on certain devices, raise back to ~16 in a follow-up.

## Out of scope (separate next task)
The filter-chip rework on Events tab (replace WeekCalendar with date chips, add Type/Center/Going chips) — needs a design discussion before implementation. Tracked locally; will come back with a concrete proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)