### PR TITLE
feat(discover/events): Today/Type/Center/Going filter chips replace WeekCalendar (mobile)

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -25,6 +25,7 @@ import { MapPin, Search, Building2, Users, ChevronUp, ChevronDown } from 'lucide
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router'
 import { useTheme, useUser } from '../../components/contexts'
 import { FilterChip, Badge, UnderlineTabBar, Avatar } from '../../components/ui'
+import FilterPickerModal, { type FilterPickerOption } from '../../components/ui/FilterPickerModal'
 const Map = lazy(() => import('../../components/Map'))
 import MapPopover from '../../components/MapPopover'
 import {
@@ -455,6 +456,10 @@ function MobileDiscoverFallback() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [showGoingOnly, setShowGoingOnly] = useState(false)
   const [showPastEvents, setShowPastEvents] = useState(false)
+  const [selectedCategory, setSelectedCategory] = useState<number | 'other' | null>(null)
+  const [selectedCenter, setSelectedCenter] = useState<string | null>(null)
+  const [showTypeModal, setShowTypeModal] = useState(false)
+  const [showCenterModal, setShowCenterModal] = useState(false)
   const { user } = useUser()
   const { items, filteredPoints, loading, allEvents, allCenters, refresh } = useDiscoverData(
     activeFilter,
@@ -592,14 +597,64 @@ function MobileDiscoverFallback() {
   }, [allEvents, selectedDate, showPastEvents, activeFilter, searchQuery])
 
   const displayItems = useMemo(() => {
-    if (!selectedDate) return items
-    return items.filter(
-      (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
-    )
-  }, [items, selectedDate])
+    let result = items
+    if (selectedDate) {
+      result = result.filter(
+        (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
+      )
+    }
+    if (selectedCategory !== null) {
+      result = result.filter((item) => {
+        if (item.type !== 'event') return true // keep section headers
+        const cat = (item.data as EventDisplay).category
+        if (selectedCategory === 'other') {
+          return cat != null && cat !== 91 && cat !== 92
+        }
+        return cat === selectedCategory
+      })
+    }
+    if (selectedCenter) {
+      result = result.filter((item) => {
+        if (item.type !== 'event') return true
+        return (item.data as EventDisplay).centerId === selectedCenter
+      })
+    }
+    return result
+  }, [items, selectedDate, selectedCategory, selectedCenter])
 
   const isExpanded = sheetSnap === 'expanded' && sheetTranslateY === null
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
+
+  // Filter chip helpers
+  const todayStr = new Date().toISOString().split('T')[0]
+  const typeOptions = useMemo<FilterPickerOption<number | 'other'>[]>(
+    () => [
+      { value: 91, label: 'Satsangs' },
+      { value: 92, label: 'Bhiksha' },
+      { value: 'other', label: 'Other' },
+    ],
+    []
+  )
+  const centerOptions = useMemo<FilterPickerOption<string>[]>(
+    () =>
+      [...allCenters]
+        .sort((a, b) => {
+          if (user?.centerID && a.id === user.centerID) return -1
+          if (user?.centerID && b.id === user.centerID) return 1
+          return a.name.localeCompare(b.name)
+        })
+        .map((c) => ({ value: c.id, label: c.name, sublabel: c.address })),
+    [allCenters, user?.centerID]
+  )
+  const typeChipLabel =
+    selectedCategory === null
+      ? 'Type'
+      : selectedCategory === 'other'
+        ? 'Other'
+        : typeOptions.find((o) => o.value === selectedCategory)?.label ?? 'Type'
+  const centerChipLabel = selectedCenter
+    ? centerOptions.find((o) => o.value === selectedCenter)?.label ?? 'Center'
+    : 'Center'
   const toggleSection = useCallback((label: string) => {
     setCollapsedSections((prev) => {
       const next = new Set(prev)
@@ -724,9 +779,27 @@ function MobileDiscoverFallback() {
               />
             </View>
 
-            {/* Filter chips */}
+            {/* Filter chips — Today / Type / Center / Going (max 4) */}
             {activeFilter === 'Events' && (
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 6, gap: 8 }}>
+                <FilterChip
+                  label="Today"
+                  variant="outline"
+                  active={selectedDate === todayStr}
+                  onPress={() => setSelectedDate((prev) => (prev === todayStr ? null : todayStr))}
+                />
+                <FilterChip
+                  label={typeChipLabel}
+                  variant="outline"
+                  active={selectedCategory !== null}
+                  onPress={() => setShowTypeModal(true)}
+                />
+                <FilterChip
+                  label={centerChipLabel}
+                  variant="outline"
+                  active={selectedCenter !== null}
+                  onPress={() => setShowCenterModal(true)}
+                />
                 {user && (
                   <FilterChip
                     label="Going"
@@ -735,23 +808,6 @@ function MobileDiscoverFallback() {
                     onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
                   />
                 )}
-                <FilterChip
-                  label="Show past"
-                  variant="outline"
-                  active={showPastEvents}
-                  onPress={() => setShowPastEvents((prev: boolean) => !prev)}
-                />
-              </View>
-            )}
-
-            {/* Week Calendar */}
-            {activeFilter === 'Events' && !searchQuery.trim() && (
-              <View style={{ paddingHorizontal: 12, paddingTop: 4 }}>
-                <WeekCalendar
-                  eventDates={eventDates}
-                  selectedDate={selectedDate}
-                  onSelectDate={setSelectedDate}
-                />
               </View>
             )}
           </div>
@@ -838,6 +894,25 @@ function MobileDiscoverFallback() {
           </ScrollView>
         </div>
       </div>
+
+      <FilterPickerModal
+        visible={showTypeModal}
+        title="Event type"
+        options={typeOptions}
+        selected={selectedCategory}
+        onSelect={setSelectedCategory}
+        onClear={() => setSelectedCategory(null)}
+        onClose={() => setShowTypeModal(false)}
+      />
+      <FilterPickerModal
+        visible={showCenterModal}
+        title="Center"
+        options={centerOptions}
+        selected={selectedCenter}
+        onSelect={setSelectedCenter}
+        onClear={() => setSelectedCenter(null)}
+        onClose={() => setShowCenterModal(false)}
+      />
     </div>
   )
 }

--- a/packages/frontend/components/ui/FilterPickerModal.tsx
+++ b/packages/frontend/components/ui/FilterPickerModal.tsx
@@ -1,0 +1,174 @@
+import { useEffect } from 'react'
+import { View, Text, Pressable, ScrollView, Modal, Platform } from 'react-native'
+import { Check } from 'lucide-react-native'
+import { useDetailColors } from '../../hooks/useDetailColors'
+
+export type FilterPickerOption<V> = {
+  value: V
+  label: string
+  sublabel?: string
+}
+
+interface FilterPickerModalProps<V> {
+  visible: boolean
+  title: string
+  options: FilterPickerOption<V>[]
+  selected: V | null
+  onSelect: (value: V) => void
+  onClear: () => void
+  onClose: () => void
+}
+
+export default function FilterPickerModal<V extends string | number>({
+  visible,
+  title,
+  options,
+  selected,
+  onSelect,
+  onClear,
+  onClose,
+}: FilterPickerModalProps<V>) {
+  const colors = useDetailColors()
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !visible) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [visible, onClose])
+
+  if (!visible) return null
+
+  const renderRow = (opt: FilterPickerOption<V>) => {
+    const isSelected = selected === opt.value
+    return (
+      <Pressable
+        key={String(opt.value)}
+        onPress={() => {
+          onSelect(opt.value)
+          onClose()
+        }}
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text style={{ fontSize: 15, color: colors.text, fontFamily: 'Inter-SemiBold' }}>
+            {opt.label}
+          </Text>
+          {opt.sublabel && (
+            <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+              {opt.sublabel}
+            </Text>
+          )}
+        </View>
+        {isSelected && <Check size={18} color="#E8862A" />}
+      </Pressable>
+    )
+  }
+
+  const sheet = (
+    <View
+      style={{
+        backgroundColor: colors.panelBg,
+        borderRadius: 16,
+        width: 360,
+        maxWidth: '90%',
+        maxHeight: '80%',
+        overflow: 'hidden',
+        shadowColor: '#000',
+        shadowOpacity: 0.15,
+        shadowRadius: 20,
+        shadowOffset: { width: 0, height: 8 },
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: 16,
+          paddingVertical: 14,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        <Text style={{ fontSize: 16, fontFamily: 'Inter-Bold', color: colors.text }}>{title}</Text>
+        <Pressable onPress={onClose}>
+          <Text style={{ fontSize: 14, color: colors.textSecondary, fontFamily: 'Inter-Medium' }}>
+            Close
+          </Text>
+        </Pressable>
+      </View>
+      <ScrollView style={{ maxHeight: 480 }}>{options.map(renderRow)}</ScrollView>
+      {selected !== null && (
+        <Pressable
+          onPress={() => {
+            onClear()
+            onClose()
+          }}
+          style={{
+            paddingVertical: 14,
+            alignItems: 'center',
+            borderTopWidth: 1,
+            borderTopColor: colors.border,
+          }}
+        >
+          <Text style={{ fontSize: 14, color: '#E8862A', fontFamily: 'Inter-SemiBold' }}>
+            Clear selection
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+
+  if (Platform.OS === 'web') {
+    return (
+      <View
+        style={{
+          position: 'fixed' as any,
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.5)',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 9999,
+        }}
+      >
+        <Pressable
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          onPress={onClose}
+        />
+        {sheet}
+      </View>
+    )
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(0,0,0,0.5)',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Pressable
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          onPress={onClose}
+        />
+        {sheet}
+      </View>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Summary
Replaces the week-strip date picker on mobile-web Events tab with 4 filter chips, per the design ask.

| Chip | Behavior |
|---|---|
| **Today** | Toggle — pins date filter to today's date; tap again to clear |
| **Type** | Opens a picker with Satsangs (cat 91), Bhiksha (cat 92), Other (lumps the 39 events with category IDs 93/94/95/99 that aren't labeled in `CATEGORY_TO_INTEREST` yet) |
| **Center** | Opens a picker with all 91 centers; user's center pinned to top, alphabetical otherwise |
| **Going** | Existing toggle preserved as the 4th chip |

The previous inline "Show past" chip is dropped (over the 4-cap, and "Today" covers the most common case). WeekCalendar is removed from `MobileDiscoverFallback`. Desktop (`DiscoverScreenWeb`) still uses WeekCalendar — out of scope for this PR; can follow in a second PR if you want consistency there.

## Implementation notes
- New component: `components/ui/FilterPickerModal.tsx` — generic single-select modal with optional clear, used by both Type and Center.
- `displayItems` memo extended to filter by `selectedCategory` and `selectedCenter` on top of the existing `selectedDate` filter.
- "Other" category bucket is computed as `cat != null && cat !== 91 && cat !== 92` — works for the 4 unlabeled IDs without needing schema changes.
- Center options use the existing `allCenters` from `useDiscoverData` so no new fetch.

## Test plan
- [x] Typecheck clean for the edited file.
- [x] `npm test` (frontend): 153/153 passing.
- [ ] **Visual smoke test on staging:** load chinmayajanata.org on mobile, hit Events tab, verify all 4 chips render in a row with no week-strip below.
- [ ] Tap Today → only today's events show; tap again → clears.
- [ ] Tap Type → modal opens; pick Satsangs → list filters to those 14 events; Clear selection → reset.
- [ ] Tap Center → modal opens with user's center pinned; pick one → list filters to that center.
- [ ] Tap Going (logged in) → only registered events.
- [ ] Combine 2-3 chips → AND-style filtering.

## Out of scope (call out)
- Desktop `DiscoverScreenWeb` still has the old WeekCalendar + Going/Show-past chips. Untouched in this PR.
- Native iOS `app/(tabs)/index.tsx` likewise untouched.
- The "Other" type bucket is a workaround. A follow-up PR could properly label categories 93/94/95/99 in the DB or add them to `CATEGORY_TO_INTEREST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)