### PR TITLE
feat(discover): scroll at mid, search-snap, sticky/collapsed centers, top spacing, directions text-link

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 // Discover tab — mobile / native layout
-import React, { useState, Suspense, useRef, useCallback } from 'react'
+import React, { useState, Suspense, useRef, useCallback, useMemo } from 'react'
 import { EmptyState } from '../../components/ui/EmptyState'
 import { DiscoverListSkeleton } from '../../components/ui/Skeleton'
 import {
@@ -349,6 +349,33 @@ export default function DiscoverScreen() {
     })
   }, [])
 
+  // Default Centers list to fully collapsed on first visit (90+ centers,
+  // an all-expanded view is overwhelming).
+  const collapsedInitFor = useRef<DiscoverFilter | null>(null)
+  React.useEffect(() => {
+    if (activeFilter !== 'Centers') {
+      collapsedInitFor.current = null
+      return
+    }
+    if (collapsedInitFor.current === 'Centers') return
+    if (items.length === 0) return
+    const labels = new Set<string>()
+    for (const item of items) {
+      if (item.type === 'section') labels.add(item.data.label)
+    }
+    setCollapsedSections(labels)
+    collapsedInitFor.current = 'Centers'
+  }, [activeFilter, items])
+
+  const stickyHeaderIndices = useMemo(
+    () =>
+      displayItems.reduce<number[]>((acc, item, idx) => {
+        if (item.type === 'section') acc.push(idx)
+        return acc
+      }, []),
+    [displayItems]
+  )
+
   const handleFilterPress = (f: DiscoverFilter) => {
     posthog?.capture('discover_filter_changed', { filter: f })
     setActiveFilter(f)
@@ -490,9 +517,10 @@ export default function DiscoverScreen() {
           {/* Unified List */}
           <ScrollView
             style={{ flex: 1 }}
-            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40, gap: 4 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 12, paddingBottom: 40, gap: 4 }}
             showsVerticalScrollIndicator={false}
             scrollEnabled={isSheetExpanded}
+            stickyHeaderIndices={stickyHeaderIndices}
           >
             {!loading && activeFilter === 'Seva' && (
               <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
@@ -505,7 +533,12 @@ export default function DiscoverScreen() {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)
                 return (
-                  <Pressable key={`section-${idx}`} onPress={() => toggleSection(label)} className={`${idx > 0 ? 'mt-3' : ''} mb-1`}>
+                  <Pressable
+                    key={`section-${idx}`}
+                    onPress={() => toggleSection(label)}
+                    className="bg-white dark:bg-neutral-900"
+                    style={{ paddingTop: idx > 0 ? 12 : 4, paddingBottom: 6 }}
+                  >
                     <View className="flex-row items-center gap-2 px-1">
                       <Text className="text-xs font-inter-semibold text-stone-400 dark:text-stone-500 uppercase" style={{ letterSpacing: 0.5 }}>
                         {label}

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -613,6 +613,34 @@ function MobileDiscoverFallback() {
   const isExpanded = sheetSnap === 'expanded' && sheetTranslateY === null
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
 
+  // Default the Centers list to fully collapsed on first visit. The list
+  // is long (state groupings across 90+ centers) and an all-expanded view
+  // is overwhelming. Re-initializes when user toggles back from another tab.
+  const collapsedInitFor = useRef<DiscoverFilter | null>(null)
+  useEffect(() => {
+    if (activeFilter !== 'Centers') {
+      collapsedInitFor.current = null
+      return
+    }
+    if (collapsedInitFor.current === 'Centers') return
+    if (items.length === 0) return
+    const labels = new Set<string>()
+    for (const item of items) {
+      if (item.type === 'section') labels.add(item.data.label)
+    }
+    setCollapsedSections(labels)
+    collapsedInitFor.current = 'Centers'
+  }, [activeFilter, items])
+
+  const stickyHeaderIndices = useMemo(
+    () =>
+      displayItems.reduce<number[]>((acc, item, idx) => {
+        if (item.type === 'section') acc.push(idx)
+        return acc
+      }, []),
+    [displayItems]
+  )
+
   // Filter chip helpers — counts are computed over upcoming events
   // (past events are hidden by default, so the counts should match
   // what the user would actually see when picking that option).
@@ -749,6 +777,7 @@ function MobileDiscoverFallback() {
                 placeholderTextColor="#9CA3AF"
                 value={searchQuery}
                 onChangeText={setSearchQuery}
+                onFocus={() => setSheetSnap('expanded')}
               />
             </View>
 
@@ -799,9 +828,10 @@ function MobileDiscoverFallback() {
           {/* Scrollable list */}
           <ScrollView
             className="flex-1"
-            contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 32, gap: 4 }}
+            contentContainerStyle={{ paddingHorizontal: 12, paddingTop: 12, paddingBottom: 32, gap: 4 }}
             showsVerticalScrollIndicator={false}
-            scrollEnabled={isExpanded}
+            scrollEnabled={sheetSnap !== 'collapsed' && sheetTranslateY === null}
+            stickyHeaderIndices={stickyHeaderIndices}
           >
             {!loading && comingUpHint && (
               <View
@@ -836,7 +866,12 @@ function MobileDiscoverFallback() {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)
                 return (
-                  <Pressable key={`section-${idx}`} onPress={() => toggleSection(label)} style={{ marginTop: idx > 0 ? 12 : 0, marginBottom: 4 }}>
+                  <Pressable
+                    key={`section-${idx}`}
+                    onPress={() => toggleSection(label)}
+                    className="bg-white dark:bg-neutral-900"
+                    style={{ paddingTop: idx > 0 ? 12 : 4, paddingBottom: 6 }}
+                  >
                     <View className="flex-row items-center gap-2 px-1">
                       <Text className="text-xs font-inter-semibold text-stone-400 dark:text-stone-500 uppercase" style={{ letterSpacing: 0.5 }}>
                         {label}

--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -305,29 +305,17 @@ export default function CenterDetailPage() {
                   </Text>
                   <Pressable
                     onPress={handleAddressPress}
-                    style={{
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      gap: 6,
-                      backgroundColor: '#E8862A',
-                      paddingVertical: 9,
-                      paddingHorizontal: 14,
-                      borderRadius: 8,
-                      alignSelf: 'flex-start',
-                      minHeight: 36,
-                    }}
+                    style={{ alignSelf: 'flex-start', paddingVertical: 4 }}
                     accessibilityLabel="Get directions"
                   >
-                    <Navigation size={14} color="#fff" />
                     <Text
                       style={{
                         fontFamily: 'Inter-SemiBold',
-                        fontSize: 13,
-                        color: '#fff',
+                        fontSize: 14,
+                        color: '#E8862A',
                       }}
                     >
-                      Get Directions
+                      Get directions →
                     </Text>
                   </Pressable>
                 </View>

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -155,21 +155,12 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
                 <Text style={{ color: colors.text, fontSize: 15 }}>{center.address}</Text>
                 <Pressable
                   onPress={handleAddressPress}
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: 6,
-                    backgroundColor: '#E8862A',
-                    paddingVertical: 9,
-                    paddingHorizontal: 14,
-                    borderRadius: 8,
-                    alignSelf: 'flex-start',
-                  }}
+                  style={{ alignSelf: 'flex-start', paddingVertical: 4 }}
                   accessibilityLabel="Get directions"
                 >
-                  <Navigation size={14} color="#fff" />
-                  <Text style={{ color: '#fff', fontSize: 13, fontWeight: '600' }}>Get Directions</Text>
+                  <Text style={{ color: '#E8862A', fontSize: 14, fontWeight: '600', fontFamily: 'Inter-SemiBold' }}>
+                    Get directions →
+                  </Text>
                 </Pressable>
               </View>
             </View>

--- a/packages/frontend/components/web/CenterDetailPanel.tsx
+++ b/packages/frontend/components/web/CenterDetailPanel.tsx
@@ -207,29 +207,17 @@ export default function CenterDetailPanel({
                   </Text>
                   <Pressable
                     onPress={handleAddressPress}
-                    style={{
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      gap: 6,
-                      backgroundColor: '#E8862A',
-                      paddingVertical: 9,
-                      paddingHorizontal: 14,
-                      borderRadius: 8,
-                      alignSelf: 'flex-start',
-                      minHeight: 36,
-                    }}
+                    style={{ alignSelf: 'flex-start', paddingVertical: 4 }}
                     accessibilityLabel="Get directions"
                   >
-                    <Navigation size={14} color="#fff" />
                     <Text
                       style={{
                         fontFamily: 'Inter-SemiBold',
-                        fontSize: 13,
-                        color: '#fff',
+                        fontSize: 14,
+                        color: '#E8862A',
                       }}
                     >
-                      Get Directions
+                      Get directions →
                     </Text>
                   </Pressable>
                 </View>


### PR DESCRIPTION
## Summary
Bundle of mobile UX tweaks for Discover, on web + native.

**Sheet behavior (web mobile only):**
- `scrollEnabled` triggers at mid + expanded snaps (not only expanded). Users can scroll the list without first dragging the sheet up.
- Search input `onFocus` snaps the sheet to expanded so results + search bar are both visible.

**Centers list (web mobile + native iOS):**
- Default-collapsed on first visit to the Centers tab. Re-initializes on every tab switch — user sees the state-grouped overview instead of a 90-row scroll.
- Sticky section headers via `stickyHeaderIndices`. Section row gets a panel-matching background so content doesn't bleed through.
- 12px `paddingTop` on the ScrollView contentContainerStyle to add breathing room between the tabs and the list.

**Get Directions (everywhere):**
- Replaced the orange button with an inline orange text link "Get directions →". Lower visual weight; matches the simpler treatment in the rest of the detail pages. Updated 3 sites: native event/center detail (`app/center/[id].tsx`), web mobile (`app/center/[id].web.tsx`), desktop side panel (`components/web/CenterDetailPanel.tsx`).

## Test plan
- [x] Typecheck clean (lucide errors are pre-existing).
- [x] `npm test`: 153/153 passing.
- [ ] Web mobile: drag sheet to mid → scroll the list (was disabled before).
- [ ] Web mobile: tap search bar → sheet snaps to full height.
- [ ] Web mobile + iOS: tap Centers tab → all states collapsed; tap a state → expands; switch tabs and back → all collapsed again.
- [ ] Web mobile + iOS: scroll Centers list → state header sticks at top of scroll area.
- [ ] Web mobile + iOS: tap a center → "Get directions →" is an inline orange text link, not a button.
- [ ] Centers tab now has visible spacing between the tab underline and "CALIFORNIA" header.

## Out of scope (next batch — already greenlit)
- Native iOS port of PR #169 + #170 (Today/Center/Going chips replacing WeekCalendar, sheet height tunes, center counts). Will follow as batch B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)