### PR TITLE
feat(native): chip rework port + map zoom/location buttons + marker perf

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -25,11 +25,11 @@ import { useRouter, useFocusEffect } from 'expo-router'
 import { usePostHog } from 'posthog-react-native'
 import { useTheme } from '../../components/contexts'
 import { Badge, UnderlineTabBar, Avatar, FilterChip } from '../../components/ui'
+import FilterPickerModal, { type FilterPickerOption } from '../../components/ui/FilterPickerModal'
 import { useUser } from '../../components/contexts/UserContext'
 import { useDiscoverData, type DiscoverFilter } from '../../hooks/useApiData'
 import type { EventDisplay, DiscoverCenter, AttendeeInfo } from '../../utils/api'
 import { extractCityState } from '../../utils/addressParsing'
-import WeekCalendar from '../../components/WeekCalendar'
 
 
 // Lazy load Map to avoid loading heavy web dependencies on mobile web
@@ -231,6 +231,8 @@ export default function DiscoverScreen() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [showGoingOnly, setShowGoingOnly] = useState(false)
   const [showPastEvents, setShowPastEvents] = useState(false)
+  const [selectedCenter, setSelectedCenter] = useState<string | null>(null)
+  const [showCenterModal, setShowCenterModal] = useState(false)
     const { user } = useUser()
     const {
     items,
@@ -327,17 +329,45 @@ export default function DiscoverScreen() {
   ).current
 
   // ── Data ──────────────────────────────────────────────
-  const eventDates = React.useMemo(
-    () => new Set(allEvents.filter((e) => e.date).map((e) => e.date)),
-    [allEvents]
-  )
-
   const displayItems = React.useMemo(() => {
-    if (!selectedDate) return items
-    return items.filter(
-      (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
-    )
-  }, [items, selectedDate])
+    let result = items
+    if (selectedDate) {
+      result = result.filter(
+        (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
+      )
+    }
+    if (selectedCenter) {
+      result = result.filter((item) => {
+        if (item.type !== 'event') return true
+        return (item.data as EventDisplay).centerId === selectedCenter
+      })
+    }
+    return result
+  }, [items, selectedDate, selectedCenter])
+
+  // Filter chip helpers — counts over upcoming events
+  const todayStr = new Date().toISOString().split('T')[0]
+  const eventsForCounts = useMemo(
+    () => (showPastEvents ? allEvents : allEvents.filter((e) => !e.date || e.date >= todayStr)),
+    [allEvents, showPastEvents, todayStr]
+  )
+  const centerOptions = useMemo<FilterPickerOption<string>[]>(() => {
+    const counts: Record<string, number> = {}
+    for (const e of eventsForCounts) {
+      if (e.centerId) counts[e.centerId] = (counts[e.centerId] ?? 0) + 1
+    }
+    return [...allCenters]
+      .map((c) => ({ value: c.id, label: c.name, sublabel: c.address, count: counts[c.id] ?? 0 }))
+      .filter((o) => (o.count ?? 0) > 0)
+      .sort((a, b) => {
+        if (user?.centerID && a.value === user.centerID) return -1
+        if (user?.centerID && b.value === user.centerID) return 1
+        return a.label.localeCompare(b.label)
+      })
+  }, [allCenters, eventsForCounts, user?.centerID])
+  const centerChipLabel = selectedCenter
+    ? centerOptions.find((o) => o.value === selectedCenter)?.label ?? 'Center'
+    : 'Center'
 
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
   const toggleSection = useCallback((label: string) => {
@@ -472,9 +502,27 @@ export default function DiscoverScreen() {
               />
             </View>
 
-            {/* Filter chips */}
+            {/* Filter chips — Today / Center / Going (max 4) */}
             {activeFilter === 'Events' && (
               <View className="flex-row flex-wrap items-center px-4 py-2 gap-2">
+                <FilterChip
+                  label="Today"
+                  variant="outline"
+                  active={selectedDate === todayStr}
+                  onPress={() => {
+                    setSelectedDate((prev) => {
+                      const next = prev === todayStr ? null : todayStr
+                      if (next) posthog?.capture('discover_date_selected', { date: next })
+                      return next
+                    })
+                  }}
+                />
+                <FilterChip
+                  label={centerChipLabel}
+                  variant="outline"
+                  active={selectedCenter !== null}
+                  onPress={() => setShowCenterModal(true)}
+                />
                 {user && (
                   <FilterChip
                     label="Going"
@@ -483,27 +531,7 @@ export default function DiscoverScreen() {
                     onPress={() => setShowGoingOnly((prev) => !prev)}
                   />
                 )}
-                <FilterChip
-                  label="Show past"
-                  variant="outline"
-                  active={showPastEvents}
-                  onPress={() => setShowPastEvents((prev) => !prev)}
-                />
               </View>
-            )}
-
-            {/* Week Calendar */}
-            {activeFilter === 'Events' && !searchQuery.trim() && (
-              <WeekCalendar
-                eventDates={eventDates}
-                selectedDate={selectedDate}
-                onSelectDate={(date) => {
-                  setSelectedDate(date)
-                  if (date) {
-                    posthog?.capture('discover_date_selected', { date })
-                  }
-                }}
-              />
             )}
           </View>
 
@@ -580,6 +608,16 @@ export default function DiscoverScreen() {
         </View>
       </Animated.View>
       )}
+
+      <FilterPickerModal
+        visible={showCenterModal}
+        title="Center"
+        options={centerOptions}
+        selected={selectedCenter}
+        onSelect={setSelectedCenter}
+        onClear={() => setSelectedCenter(null)}
+        onClose={() => setShowCenterModal(false)}
+      />
     </View>
   )
 }

--- a/packages/frontend/components/Map.native.tsx
+++ b/packages/frontend/components/Map.native.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback, memo } from 'react'
-import { StyleSheet, View, Platform } from 'react-native'
+import { StyleSheet, View, Pressable, Platform } from 'react-native'
 import MapView, { Marker, Region, PROVIDER_GOOGLE } from 'react-native-maps'
+import { Plus, Minus, Navigation } from 'lucide-react-native'
 import { getCurrentPosition } from '../utils'
 
 export interface MapPoint {
@@ -106,6 +107,28 @@ const Map = memo<MapProps>(function Map({
     return PIN_COLORS[type] || PIN_COLORS.event
   }, [])
 
+  // Zoom in/out by adjusting the camera zoom level. iOS Apple Maps doesn't
+  // ship with zoom buttons by default, so we render our own.
+  const handleZoom = useCallback(async (delta: number) => {
+    const cam = await mapRef.current?.getCamera()
+    if (!cam) return
+    cam.zoom = Math.max(2, Math.min(20, (cam.zoom ?? 12) + delta))
+    mapRef.current?.animateCamera(cam, { duration: 200 })
+  }, [])
+
+  // Recenter to device location. iOS's `showsMyLocationButton` is
+  // Android-only, so we wire our own button to getCurrentPosition.
+  const handleLocate = useCallback(async () => {
+    const position = await getCurrentPosition().catch(() => null)
+    if (!position || !Array.isArray(position) || position.length !== 2) return
+    const [longitude, latitude] = position
+    if (!isValidCoord(latitude, longitude)) return
+    mapRef.current?.animateToRegion(
+      { latitude, longitude, latitudeDelta: 0.05, longitudeDelta: 0.05 },
+      500
+    )
+  }, [])
+
   return (
     <View style={styles.container}>
       <MapView
@@ -141,9 +164,27 @@ const Map = memo<MapProps>(function Map({
               pinColor={getPinColor(point.type)}
               onPress={() => handleMarkerPress(point)}
               identifier={point.id}
+              // iOS performance: without this, every marker re-renders its
+              // view on each map gesture, which is what causes the "frozen
+              // map" symptom on iOS with 100+ markers.
+              tracksViewChanges={false}
             />
           ))}
       </MapView>
+
+      {/* Custom controls — react-native-maps' built-in user-location button
+          is Android-only; zoom buttons aren't built in at all. */}
+      <View style={[styles.controls, { bottom: 16 + bottomPadding }]} pointerEvents="box-none">
+        <Pressable onPress={() => handleZoom(1)} style={styles.controlButton} accessibilityLabel="Zoom in">
+          <Plus size={18} color="#1a1a1a" />
+        </Pressable>
+        <Pressable onPress={() => handleZoom(-1)} style={styles.controlButton} accessibilityLabel="Zoom out">
+          <Minus size={18} color="#1a1a1a" />
+        </Pressable>
+        <Pressable onPress={handleLocate} style={[styles.controlButton, { marginTop: 8 }]} accessibilityLabel="Show my location">
+          <Navigation size={16} color="#E8862A" />
+        </Pressable>
+      </View>
     </View>
   )
 })
@@ -159,5 +200,23 @@ const styles = StyleSheet.create({
   map: {
     width: '100%',
     height: '100%',
+  },
+  controls: {
+    position: 'absolute',
+    right: 12,
+    gap: 4,
+  },
+  controlButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#ffffff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
   },
 })


### PR DESCRIPTION
## Summary
Brings native iOS up to web parity on Discover filtering, plus fixes two map bugs reported during testing.

**Filter chips (port of #169 + #170 to native):**
- Replaces WeekCalendar + "Going"/"Show past" with Today / Center / Going
- Today: toggle pinning date filter to today's date
- Center: opens picker with centers that have upcoming events, user's center pinned, counts beside each
- Drops "Show past" (over the 4-cap; "Today" covers the common case)
- displayItems memo extended to filter by `selectedCenter`

**Map.native fixes (two iOS bugs from testing):**
1. **Missing zoom + user-location buttons** — `showsMyLocationButton` is Android-only and zoom buttons aren't built into react-native-maps at all. Added custom `<Pressable>` controls (top-right, above the bottom sheet padding): zoom in / zoom out / recenter to user.
2. **Map freezing on iOS** — set `tracksViewChanges={false}` on each Marker. Without it, every marker re-renders its native view on every map gesture, which is the canonical cause of "frozen map" on iOS with 100+ markers.

## Test plan (after iOS build #24 lands in TestFlight)
- [x] Typecheck clean.
- [x] `npm test`: 153/153 passing.
- [ ] Discover Events tab: chip row is **Today / Center / Going** (no week strip, no Show past).
- [ ] Tap Today → filters to today's events; tap again → clears.
- [ ] Tap Center → modal opens, centers with 0 upcoming events not listed, counts shown.
- [ ] Map: zoom in / zoom out buttons work and animate.
- [ ] Map: location button recenters to device location.
- [ ] Map: scroll/pinch with all markers loaded — no longer freezes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)