### PR TITLE
feat(events): open event creation to all signed-in users (beta)

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -30,7 +30,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "buildNumber": "26",
+      "buildNumber": "27",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",

--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -951,7 +951,9 @@ export default function DiscoverScreenWeb() {
   const { isDark } = useTheme()
   const { user } = useUser()
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
-  const canCreate = isAdmin || isLocal
+  // Beta: any signed-in user can create events. Backend enforces auth-only;
+  // post-beta this becomes a coordinator-tier gate (see issue tracker).
+  const canCreate = !!user
   const [activeFilter, setActiveFilter] = useState<DiscoverFilter>('Events')
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedDate, setSelectedDate] = useState<string | null>(null)

--- a/packages/frontend/app/events/form.tsx
+++ b/packages/frontend/app/events/form.tsx
@@ -23,7 +23,6 @@ import {
   Image as ImageIcon,
   Tag,
   Building2,
-  AlertTriangle,
 } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useUser } from '../../components/contexts'
@@ -38,7 +37,6 @@ import {
   type CenterData,
 } from '../../utils/api'
 
-const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
 const CATEGORY_OPTIONS = [
   { value: undefined, label: 'None' },
@@ -177,7 +175,6 @@ export default function EventFormPage() {
   const [image, setImage] = useState('')
   const [category, setCategory] = useState<number | undefined>(undefined)
 
-  const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
 
   // Load centers + event data (if editing)
   useEffect(() => {
@@ -346,46 +343,6 @@ export default function EventFormPage() {
     backgroundColor: colors.cardBg,
     marginLeft: 42,
   })
-
-  // ── Guard: not admin ────────────────────────────────────────────────
-
-  if (false && !isAdmin) {
-    return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 32 }}>
-          <AlertTriangle size={48} color={colors.textMuted} />
-          <Text
-            style={{
-              fontFamily: 'Inter-SemiBold',
-              fontSize: 18,
-              color: colors.text,
-              marginTop: 16,
-              textAlign: 'center',
-            }}
-          >
-            Admin Access Required
-          </Text>
-          <Text
-            style={{
-              fontFamily: 'Inter-Regular',
-              fontSize: 14,
-              color: colors.textSecondary,
-              marginTop: 8,
-              textAlign: 'center',
-            }}
-          >
-            Only administrators can create or edit events.
-          </Text>
-          <Pressable
-            onPress={() => router.back()}
-            style={{ marginTop: 24, minHeight: 44, justifyContent: 'center' }}
-          >
-            <Text style={{ fontSize: 16, fontFamily: 'Inter-Medium', color: '#E8862A' }}>Go Back</Text>
-          </Pressable>
-        </View>
-      </SafeAreaView>
-    )
-  }
 
   // ── Loading ─────────────────────────────────────────────────────────
 

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -21,7 +21,6 @@ import {
   Image as ImageIcon,
   Tag,
   Building2,
-  AlertTriangle,
   ChevronDown,
 } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
@@ -35,7 +34,6 @@ import {
   type CenterData,
 } from '../../utils/api'
 
-const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
 const CATEGORY_OPTIONS = [
   { value: undefined, label: 'None' },
@@ -128,7 +126,6 @@ export default function EventFormPage() {
   const [image, setImage] = useState('')
   const [category, setCategory] = useState<number | undefined>(undefined)
 
-  const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
 
   useEffect(() => {
     let mounted = true
@@ -278,44 +275,6 @@ export default function EventFormPage() {
     backgroundColor: colors.cardBg,
     marginLeft: 42,
   })
-
-  // ── Guard: not admin (disabled for testing) ─────────────────────────
-
-  if (false && !isAdmin) {
-    return (
-      <View style={{ flex: 1, backgroundColor: colors.panelBg, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 32 }}>
-        <AlertTriangle size={48} color={colors.textMuted} />
-        <Text
-          style={{
-            fontFamily: 'Inter-SemiBold',
-            fontSize: 18,
-            color: colors.text,
-            marginTop: 16,
-            textAlign: 'center',
-          }}
-        >
-          Admin Access Required
-        </Text>
-        <Text
-          style={{
-            fontFamily: 'Inter-Regular',
-            fontSize: 14,
-            color: colors.textSecondary,
-            marginTop: 8,
-            textAlign: 'center',
-          }}
-        >
-          Only administrators can create or edit events.
-        </Text>
-        <Pressable
-          onPress={() => router.back()}
-          style={{ marginTop: 24, minHeight: 44, justifyContent: 'center' }}
-        >
-          <Text style={{ fontSize: 16, fontFamily: 'Inter-Medium', color: '#E8862A' }}>Go Back</Text>
-        </Pressable>
-      </View>
-    )
-  }
 
   // ── Loading ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Per team decision: any logged-in user can create events during beta. Post-beta we'll add a coordinator-tier gate (tracked in #177).

- **Discover Create button**: `canCreate = isAdmin || isLocal` → `canCreate = !!user`. Beta testers now see the button; backend already accepted authenticated users.
- **Dead code cleanup**: removed `if (false && !isAdmin)` guard blocks from `app/events/form.tsx` + `form.web.tsx` — they were debugging leftovers that suggested admin-gating was intended. Form is now openly accessible (matching backend behavior).
- Orphaned `AlertTriangle` imports + unused `ADMIN_EMAIL` / `isAdmin` consts removed from both form files.

## Verified
- [x] Typecheck clean (only pre-existing lucide errors)
- [x] `npm test`: 153/153 passing
- [x] Backend `/addEvent` already permits any authenticated user (`authMiddleware`-only) — no backend change needed

## Out of scope / tracked separately
- **#177** post-beta coordinator-tier guardrails (Option A: SEVAK tier; Option B: per-center coordinator role; Option C: approval queue). Recommendation in the issue is B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)