### PR TITLE
fix(events): Create button gate on _layout was missed (PR #178 changed unused var)

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -7,7 +7,6 @@ import SettingsPanel from '../../components/SettingsPanel'
 import Logo from '../../components/ui/Logo'
 import { Avatar } from '../../components/ui'
 import { usePostHog } from 'posthog-react-native'
-import { isSuperAdmin } from '../../utils/admin'
 
 /**
  * TabLayout Component - The main layout for the tab-based navigation.
@@ -19,7 +18,9 @@ export default function TabLayout() {
   const { user, loading, logout } = useUser()
   const { isDark } = useTheme()
   const [settingsVisible, setSettingsVisible] = useState(false)
-  const canCreate = isSuperAdmin(user)
+  // Beta: any signed-in user can create events. Backend enforces auth-only;
+  // post-beta this becomes a coordinator-tier gate (issue #177).
+  const canCreate = !!user
   const posthog = usePostHog()
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
PR #178 was supposed to make the Create Event button visible to all logged-in users in beta, but it changed `canCreate` in `app/(tabs)/index.web.tsx` — which turns out to be an unused variable. The actual Create Event button lives in the tab header (`app/(tabs)/_layout.tsx:22`) and was still gated on `isSuperAdmin(user)`.

Confirmed by Kish: signed in as a non-admin user on `chinmayajanata.org`, no Create button visible after #178 deployed.

## Fix
- Flip the actual gate in `_layout.tsx`: `canCreate = isSuperAdmin(user)` → `canCreate = !!user`
- Drop the now-unused `isSuperAdmin` import

## Verified
- [x] Typecheck clean (only pre-existing lucide errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)