### PR TITLE
feat(events/form): native date+time pickers, future-only, drop field icons

### DIFF
--- a/packages/frontend/app/(tabs)/index.web.tsx
+++ b/packages/frontend/app/(tabs)/index.web.tsx
@@ -1265,6 +1265,10 @@ export default function DiscoverScreenWeb() {
         {formPanel ? (
           <EventFormPanel
             eventId={formPanel.id}
+            onSaved={(savedId) => {
+              setFormPanel(null)
+              setSelectedItem({ type: 'event', id: savedId })
+            }}
             onClose={() => {
               const editId = formPanel.id
               setFormPanel(null)

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -9,21 +9,8 @@ import {
   useWindowDimensions,
 } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import {
-  ChevronLeft,
-  Type,
-  FileText,
-  Calendar,
-  Clock,
-  MapPin,
-  Navigation,
-  User,
-  Image as ImageIcon,
-  Tag,
-  Building2,
-  ChevronDown,
-} from 'lucide-react-native'
-import { useUser } from '../../components/contexts'
+import { ChevronLeft, ChevronDown } from 'lucide-react-native'
+import { useTheme } from '../../components/contexts'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { PrimaryButton, SecondaryButton } from '../../components/ui'
 import {
@@ -33,6 +20,14 @@ import {
   updateEvent,
   type CenterData,
 } from '../../utils/api'
+
+const todayLocalISODate = (): string => {
+  const d = new Date()
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
 
 
 const CATEGORY_OPTIONS = [
@@ -44,7 +39,6 @@ const CATEGORY_OPTIONS = [
 // ── Field row ────────────────────────────────────────────────────────────
 
 function FieldRow({
-  icon: Icon,
   label,
   colors,
   error,
@@ -52,7 +46,6 @@ function FieldRow({
   hint,
   children,
 }: {
-  icon: React.ElementType
   label: string
   colors: DetailColors
   error?: string
@@ -61,45 +54,71 @@ function FieldRow({
   children: React.ReactNode
 }) {
   return (
-    <View style={{ gap: 8 }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-        <View
-          style={{
-            width: 32,
-            height: 32,
-            borderRadius: 8,
-            backgroundColor: colors.iconBoxBg,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <Icon size={16} color="#E8862A" />
-        </View>
-        <Text
-          style={{
-            fontFamily: 'Inter-Medium',
-            fontSize: 11,
-            color: colors.textMuted,
-            letterSpacing: 0.5,
-            textTransform: 'uppercase',
-          }}
-        >
-          {label}
-          {required ? <Text style={{ color: '#E8862A' }}> *</Text> : null}
-        </Text>
-      </View>
-      {children}
+    <View style={{ gap: 6 }}>
+      <Text
+        style={{
+          fontFamily: 'Inter-Medium',
+          fontSize: 11,
+          color: colors.textMuted,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+        }}
+      >
+        {label}
+        {required ? <Text style={{ color: '#E8862A' }}> *</Text> : null}
+      </Text>
       {hint && !error ? (
-        <Text style={{ fontFamily: 'Inter-Regular', fontSize: 12, color: colors.textMuted, marginLeft: 42 }}>
+        <Text style={{ fontFamily: 'Inter-Regular', fontSize: 12, color: colors.textMuted }}>
           {hint}
         </Text>
       ) : null}
+      {children}
       {error ? (
-        <Text style={{ fontFamily: 'Inter-Regular', fontSize: 12, color: '#DC2626', marginLeft: 42 }}>
+        <Text style={{ fontFamily: 'Inter-Regular', fontSize: 12, color: '#DC2626' }}>
           {error}
         </Text>
       ) : null}
     </View>
+  )
+}
+
+function NativeDateTimeInput({
+  type,
+  value,
+  onChange,
+  min,
+  hasError,
+  colors,
+  isDark,
+}: {
+  type: 'date' | 'time'
+  value: string
+  onChange: (v: string) => void
+  min?: string
+  hasError?: boolean
+  colors: DetailColors
+  isDark?: boolean
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      min={min}
+      style={{
+        fontFamily: 'Inter, -apple-system, sans-serif',
+        fontSize: 15,
+        color: colors.text,
+        padding: '12px 14px',
+        borderRadius: 10,
+        border: `1px solid ${hasError ? '#DC2626' : colors.border}`,
+        backgroundColor: colors.cardBg,
+        outline: 'none',
+        boxSizing: 'border-box',
+        width: '100%',
+        colorScheme: isDark ? 'dark' : 'light',
+      }}
+    />
   )
 }
 
@@ -110,8 +129,9 @@ export default function EventFormPage() {
   const eventId = params.id
   const isEdit = !!eventId
   const router = useRouter()
-  const { user } = useUser()
   const colors = useDetailColors()
+  const { isDark } = useTheme()
+  const today = todayLocalISODate()
   const { width: viewportWidth } = useWindowDimensions()
 
   const isNarrow = viewportWidth < 768
@@ -157,10 +177,13 @@ export default function EventFormPage() {
 
             if (event.date) {
               const d = new Date(event.date)
-              setDate(d.toISOString().split('T')[0])
-              setTime(
-                d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-              )
+              const yyyy = d.getFullYear()
+              const mm = String(d.getMonth() + 1).padStart(2, '0')
+              const dd = String(d.getDate()).padStart(2, '0')
+              const hh = String(d.getHours()).padStart(2, '0')
+              const mi = String(d.getMinutes()).padStart(2, '0')
+              setDate(`${yyyy}-${mm}-${dd}`)
+              setTime(`${hh}:${mi}`)
             }
 
             setAddress(event.address || '')
@@ -190,8 +213,20 @@ export default function EventFormPage() {
     const newErrors: Record<string, string> = {}
 
     if (!title.trim()) newErrors.title = 'Title is required'
-    if (!date.trim()) newErrors.date = 'Date is required (YYYY-MM-DD)'
+    if (!date.trim()) newErrors.date = 'Date is required'
     if (!centerID) newErrors.center = 'Center is required'
+
+    if (date && !newErrors.date) {
+      // If time is missing, treat as end-of-day so today still passes the future-check
+      const eventDateTime = new Date(`${date}T${time || '23:59'}:00`)
+      if (!isNaN(eventDateTime.getTime()) && eventDateTime <= new Date()) {
+        if (date < today) {
+          newErrors.date = 'Date must be today or later'
+        } else {
+          newErrors.time = 'Time must be in the future'
+        }
+      }
+    }
 
     const lat = parseFloat(latitude)
     const lng = parseFloat(longitude)
@@ -205,22 +240,11 @@ export default function EventFormPage() {
     setErrors(newErrors)
     if (newErrors.latitude || newErrors.longitude) setShowAdvanced(true)
     return Object.keys(newErrors).length === 0
-  }, [title, date, centerID, latitude, longitude])
+  }, [title, date, time, centerID, latitude, longitude, today])
 
   const buildDateISO = (): string => {
     if (!time.trim()) return `${date}T12:00:00`
-
-    const match = time.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
-    if (match) {
-      let hours = parseInt(match[1], 10)
-      const minutes = match[2]
-      const ampm = match[3].toUpperCase()
-      if (ampm === 'PM' && hours !== 12) hours += 12
-      if (ampm === 'AM' && hours === 12) hours = 0
-      return `${date}T${String(hours).padStart(2, '0')}:${minutes}:00`
-    }
-
-    return `${date}T12:00:00`
+    return `${date}T${time}:00`
   }
 
   const handleSave = async () => {
@@ -242,8 +266,9 @@ export default function EventFormPage() {
           image: image.trim() || undefined,
           category,
         })
+        router.replace(`/events/${eventId}`)
       } else {
-        await createEvent({
+        const created = await createEvent({
           title: title.trim(),
           description: description.trim(),
           date: buildDateISO(),
@@ -255,12 +280,10 @@ export default function EventFormPage() {
           image: image.trim() || undefined,
           category,
         })
+        router.replace(`/events/${created.id}`)
       }
-      router.back()
     } catch (err: any) {
-      if (typeof window !== 'undefined') {
-        window.alert(err?.message || 'Something went wrong')
-      }
+      setErrors({ submit: err?.message || 'Something went wrong. Please try again.' })
     } finally {
       setSaving(false)
     }
@@ -285,7 +308,6 @@ export default function EventFormPage() {
     borderWidth: 1,
     borderColor: hasError ? '#DC2626' : colors.border,
     backgroundColor: colors.cardBg,
-    marginLeft: 42,
   })
 
   // ── Loading ─────────────────────────────────────────────────────────
@@ -351,8 +373,24 @@ export default function EventFormPage() {
         }}
         showsVerticalScrollIndicator={false}
       >
+        {errors.submit ? (
+          <View
+            style={{
+              padding: 12,
+              borderRadius: 10,
+              borderWidth: 1,
+              borderColor: '#DC2626',
+              backgroundColor: 'rgba(220,38,38,0.08)',
+            }}
+          >
+            <Text style={{ fontFamily: 'Inter-Medium', fontSize: 13, color: '#DC2626' }}>
+              {errors.submit}
+            </Text>
+          </View>
+        ) : null}
+
         {/* Title */}
-        <FieldRow icon={Type} label="Title" colors={colors} error={errors.title} required>
+        <FieldRow label="Title" colors={colors} error={errors.title} required>
           <TextInput
             value={title}
             onChangeText={setTitle}
@@ -363,7 +401,7 @@ export default function EventFormPage() {
         </FieldRow>
 
         {/* Description */}
-        <FieldRow icon={FileText} label="Description" colors={colors} hint="What will attendees experience? Speakers, agenda, what to bring.">
+        <FieldRow label="Description" colors={colors} hint="What will attendees experience? Speakers, agenda, what to bring.">
           <TextInput
             value={description}
             onChangeText={setDescription}
@@ -381,32 +419,34 @@ export default function EventFormPage() {
         {/* Date + Time side by side */}
         <View style={{ flexDirection: isNarrow ? 'column' : 'row', gap: isNarrow ? 24 : 28 }}>
           <View style={{ flex: 1 }}>
-            <FieldRow icon={Calendar} label="Date" colors={colors} error={errors.date} required hint="Format: YYYY-MM-DD">
-              <TextInput
+            <FieldRow label="Date" colors={colors} error={errors.date} required>
+              <NativeDateTimeInput
+                type="date"
                 value={date}
-                onChangeText={setDate}
-                placeholder="2026-06-15"
-                placeholderTextColor={colors.textMuted}
-                style={inputStyle(!!errors.date)}
-                {...({ dataSet: { type: 'date' } } as any)}
+                onChange={setDate}
+                min={today}
+                hasError={!!errors.date}
+                colors={colors}
+                isDark={isDark}
               />
             </FieldRow>
           </View>
           <View style={{ flex: 1 }}>
-            <FieldRow icon={Clock} label="Time" colors={colors} hint="12-hour format with AM/PM">
-              <TextInput
+            <FieldRow label="Time" colors={colors} error={errors.time}>
+              <NativeDateTimeInput
+                type="time"
                 value={time}
-                onChangeText={setTime}
-                placeholder="10:30 AM"
-                placeholderTextColor={colors.textMuted}
-                style={inputStyle()}
+                onChange={setTime}
+                hasError={!!errors.time}
+                colors={colors}
+                isDark={isDark}
               />
             </FieldRow>
           </View>
         </View>
 
         {/* Center selection */}
-        <FieldRow icon={Building2} label="Center" colors={colors} error={errors.center} required hint="Picking a center auto-fills address & coordinates.">
+        <FieldRow label="Center" colors={colors} error={errors.center} required hint="Picking a center auto-fills address & coordinates.">
           <Pressable
             onPress={() => setShowCenterPicker(!showCenterPicker)}
             style={{
@@ -493,7 +533,7 @@ export default function EventFormPage() {
         </FieldRow>
 
         {/* Address */}
-        <FieldRow icon={MapPin} label="Address" colors={colors} hint="Where the event is held. Auto-filled from center if blank.">
+        <FieldRow label="Address" colors={colors} hint="Where the event is held. Auto-filled from center if blank.">
           <TextInput
             value={address}
             onChangeText={setAddress}
@@ -504,7 +544,7 @@ export default function EventFormPage() {
         </FieldRow>
 
         {/* Point of contact */}
-        <FieldRow icon={User} label="Point of Contact" colors={colors} hint="Optional. Email or name attendees can reach.">
+        <FieldRow label="Point of Contact" colors={colors} hint="Optional. Email or name attendees can reach.">
           <TextInput
             value={pointOfContact}
             onChangeText={setPointOfContact}
@@ -515,7 +555,7 @@ export default function EventFormPage() {
         </FieldRow>
 
         {/* Image URL */}
-        <FieldRow icon={ImageIcon} label="Image URL" colors={colors} hint="Optional. A direct link to a JPG/PNG.">
+        <FieldRow label="Image URL" colors={colors} hint="Optional. A direct link to a JPG/PNG.">
           <TextInput
             value={image}
             onChangeText={setImage}
@@ -527,7 +567,7 @@ export default function EventFormPage() {
         </FieldRow>
 
         {/* Category */}
-        <FieldRow icon={Tag} label="Category" colors={colors}>
+        <FieldRow label="Category" colors={colors}>
           <View style={{ flexDirection: 'row', gap: 8, marginLeft: 42, flexWrap: 'wrap' }}>
             {CATEGORY_OPTIONS.map((opt) => {
               const selected = category === opt.value
@@ -589,7 +629,7 @@ export default function EventFormPage() {
             ) : null}
           </Pressable>
           {showAdvanced && (
-            <FieldRow icon={Navigation} label="Coordinates" colors={colors} error={errors.latitude || errors.longitude} hint="Auto-filled when you pick a center. Override only if pin is wrong.">
+            <FieldRow label="Coordinates" colors={colors} error={errors.latitude || errors.longitude} hint="Auto-filled when you pick a center. Override only if pin is wrong.">
               <View style={{ flexDirection: 'row', gap: 10, marginLeft: 42 }}>
                 <TextInput
                   value={latitude}

--- a/packages/frontend/components/web/EventFormPanel.tsx
+++ b/packages/frontend/components/web/EventFormPanel.tsx
@@ -1,16 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { View, Text, ScrollView, TextInput, Pressable, ActivityIndicator } from 'react-native'
-import {
-  ChevronLeft,
-  Calendar,
-  Clock,
-  MapPin,
-  User,
-  Tag,
-  Building2,
-  ChevronDown,
-} from 'lucide-react-native'
+import { ChevronLeft, ChevronDown } from 'lucide-react-native'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import { useTheme } from '../../components/contexts'
 import PrimaryButton from '../ui/buttons/PrimaryButton'
 import SecondaryButton from '../ui/buttons/SecondaryButton'
 import {
@@ -20,6 +12,14 @@ import {
   updateEvent,
   type CenterData,
 } from '../../utils/api'
+
+const todayLocalISODate = (): string => {
+  const d = new Date()
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
 
 const CATEGORY_OPTIONS = [
   { value: undefined as number | undefined, label: 'None' },
@@ -32,7 +32,7 @@ const CATEGORY_OPTIONS = [
 type EventFormPanelProps = {
   eventId?: string
   onClose: () => void
-  onSaved?: () => void
+  onSaved?: (savedEventId: string) => void
 }
 
 // ── Input component ──────────────────────────────────────────────────────
@@ -82,31 +82,21 @@ function FormInput({
   )
 }
 
-// ── Section label ────────────────────────────────────────────────────────
+// ── Field label ──────────────────────────────────────────────────────────
 
-function SectionLabel({
-  icon: Icon,
+function FieldLabel({
   label,
   colors,
+  required,
+  hint,
 }: {
-  icon: React.ElementType
   label: string
   colors: DetailColors
+  required?: boolean
+  hint?: string
 }) {
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-      <View
-        style={{
-          width: 28,
-          height: 28,
-          borderRadius: 7,
-          backgroundColor: colors.iconBoxBg,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Icon size={14} color="#E8862A" />
-      </View>
+    <View style={{ marginBottom: 6, gap: 2 }}>
       <Text
         style={{
           fontFamily: 'Inter-Medium',
@@ -117,8 +107,56 @@ function SectionLabel({
         }}
       >
         {label}
+        {required ? <Text style={{ color: '#E8862A' }}> *</Text> : null}
       </Text>
+      {hint ? (
+        <Text style={{ fontFamily: 'Inter-Regular', fontSize: 11, color: colors.textMuted }}>
+          {hint}
+        </Text>
+      ) : null}
     </View>
+  )
+}
+
+// ── Native HTML date / time inputs ───────────────────────────────────────
+
+function NativeDateTimeInput({
+  type,
+  value,
+  onChange,
+  min,
+  hasError,
+  colors,
+  isDark,
+}: {
+  type: 'date' | 'time'
+  value: string
+  onChange: (v: string) => void
+  min?: string
+  hasError?: boolean
+  colors: DetailColors
+  isDark?: boolean
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      min={min}
+      style={{
+        fontFamily: 'Inter, -apple-system, sans-serif',
+        fontSize: 14,
+        color: colors.text,
+        padding: '10px 12px',
+        borderRadius: 8,
+        border: `1px solid ${hasError ? '#DC2626' : colors.border}`,
+        backgroundColor: colors.cardBg,
+        outline: 'none',
+        boxSizing: 'border-box',
+        width: '100%',
+        colorScheme: isDark ? 'dark' : 'light',
+      }}
+    />
   )
 }
 
@@ -127,6 +165,8 @@ function SectionLabel({
 export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormPanelProps) {
   const isEdit = !!eventId
   const colors = useDetailColors()
+  const { isDark } = useTheme()
+  const today = todayLocalISODate()
 
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)
@@ -147,6 +187,7 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
   const [pointOfContact, setPointOfContact] = useState('')
   const [image, setImage] = useState('')
   const [category, setCategory] = useState<number | undefined>(undefined)
+  const [showAdvanced, setShowAdvanced] = useState(false)
 
   useEffect(() => {
     let mounted = true
@@ -167,10 +208,13 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
 
             if (event.date) {
               const d = new Date(event.date)
-              setDate(d.toISOString().split('T')[0])
-              setTime(
-                d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-              )
+              const yyyy = d.getFullYear()
+              const mm = String(d.getMonth() + 1).padStart(2, '0')
+              const dd = String(d.getDate()).padStart(2, '0')
+              const hh = String(d.getHours()).padStart(2, '0')
+              const mi = String(d.getMinutes()).padStart(2, '0')
+              setDate(`${yyyy}-${mm}-${dd}`)
+              setTime(`${hh}:${mi}`)
             }
 
             setAddress(event.address || '')
@@ -202,6 +246,18 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
     if (!date.trim()) newErrors.date = 'Date is required'
     if (!centerID) newErrors.center = 'Center is required'
 
+    if (date && !newErrors.date) {
+      // If time is missing, treat as end-of-day (so today still passes the future-check)
+      const eventDateTime = new Date(`${date}T${time || '23:59'}:00`)
+      if (!isNaN(eventDateTime.getTime()) && eventDateTime <= new Date()) {
+        if (date < today) {
+          newErrors.date = 'Date must be today or later'
+        } else {
+          newErrors.time = 'Time must be in the future'
+        }
+      }
+    }
+
     const lat = parseFloat(latitude)
     const lng = parseFloat(longitude)
     if (!latitude || isNaN(lat) || lat < -90 || lat > 90) {
@@ -212,21 +268,13 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
     }
 
     setErrors(newErrors)
+    if (newErrors.latitude || newErrors.longitude) setShowAdvanced(true)
     return Object.keys(newErrors).length === 0
-  }, [title, date, centerID, latitude, longitude])
+  }, [title, date, time, centerID, latitude, longitude, today])
 
   const buildDateISO = (): string => {
     if (!time.trim()) return `${date}T12:00:00`
-    const match = time.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
-    if (match) {
-      let hours = parseInt(match[1], 10)
-      const minutes = match[2]
-      const ampm = match[3].toUpperCase()
-      if (ampm === 'PM' && hours !== 12) hours += 12
-      if (ampm === 'AM' && hours === 12) hours = 0
-      return `${date}T${String(hours).padStart(2, '0')}:${minutes}:00`
-    }
-    return `${date}T12:00:00`
+    return `${date}T${time}:00`
   }
 
   const handleSave = async () => {
@@ -234,6 +282,7 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
     setSaving(true)
 
     try {
+      let savedId = eventId
       if (isEdit && eventId) {
         await updateEvent({
           id: eventId,
@@ -249,7 +298,7 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
           category,
         })
       } else {
-        await createEvent({
+        const created = await createEvent({
           title: title.trim(),
           description: description.trim(),
           date: buildDateISO(),
@@ -261,11 +310,11 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
           image: image.trim() || undefined,
           category,
         })
+        savedId = created.id
       }
-      onSaved?.()
-      onClose()
+      if (savedId) onSaved?.(savedId)
     } catch (err: any) {
-      alert(err?.message || 'Something went wrong')
+      setErrors({ submit: err?.message || 'Something went wrong. Please try again.' })
     } finally {
       setSaving(false)
     }
@@ -382,13 +431,30 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
         contentContainerStyle={{ padding: 20, gap: 20, paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}
       >
+        {/* Submit error banner (network / backend) */}
+        {errors.submit ? (
+          <View
+            style={{
+              padding: 12,
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: '#DC2626',
+              backgroundColor: 'rgba(220,38,38,0.08)',
+            }}
+          >
+            <Text style={{ fontFamily: 'Inter-Medium', fontSize: 12, color: '#DC2626' }}>
+              {errors.submit}
+            </Text>
+          </View>
+        ) : null}
+
         {/* Title */}
         <View>
-          <SectionLabel icon={Tag} label="Title" colors={colors} />
+          <FieldLabel label="Title" colors={colors} required />
           <FormInput
             value={title}
             onChangeText={setTitle}
-            placeholder="Event title"
+            placeholder="Sunday Satsang with Swamiji"
             colors={colors}
             hasError={!!errors.title}
           />
@@ -397,11 +463,11 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
 
         {/* Description */}
         <View>
-          <SectionLabel icon={Tag} label="Description" colors={colors} />
+          <FieldLabel label="Description" colors={colors} hint="What attendees will experience." />
           <FormInput
             value={description}
             onChangeText={setDescription}
-            placeholder="Describe the event..."
+            placeholder="Speakers, agenda, what to bring..."
             colors={colors}
             multiline
           />
@@ -410,30 +476,35 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
         {/* Date & Time row */}
         <View style={{ flexDirection: 'row', gap: 12 }}>
           <View style={{ flex: 1 }}>
-            <SectionLabel icon={Calendar} label="Date" colors={colors} />
-            <FormInput
+            <FieldLabel label="Date" colors={colors} required />
+            <NativeDateTimeInput
+              type="date"
               value={date}
-              onChangeText={setDate}
-              placeholder="YYYY-MM-DD"
-              colors={colors}
+              onChange={setDate}
+              min={today}
               hasError={!!errors.date}
+              colors={colors}
+              isDark={isDark}
             />
             {errorText('date')}
           </View>
           <View style={{ flex: 1 }}>
-            <SectionLabel icon={Clock} label="Time" colors={colors} />
-            <FormInput
+            <FieldLabel label="Time" colors={colors} />
+            <NativeDateTimeInput
+              type="time"
               value={time}
-              onChangeText={setTime}
-              placeholder="e.g. 10:30 AM"
+              onChange={setTime}
+              hasError={!!errors.time}
               colors={colors}
+              isDark={isDark}
             />
+            {errorText('time')}
           </View>
         </View>
 
         {/* Center */}
         <View>
-          <SectionLabel icon={Building2} label="Center" colors={colors} />
+          <FieldLabel label="Center" colors={colors} required hint="Picking a center auto-fills address & coordinates." />
           <Pressable
             onPress={() => setShowCenterPicker(!showCenterPicker)}
             style={{
@@ -521,56 +592,29 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
 
         {/* Address */}
         <View>
-          <SectionLabel icon={MapPin} label="Address" colors={colors} />
+          <FieldLabel label="Address" colors={colors} hint="Auto-filled from center if blank." />
           <FormInput
             value={address}
             onChangeText={setAddress}
-            placeholder="Event address"
+            placeholder="123 Main St, City, ST 12345"
             colors={colors}
           />
         </View>
 
-        {/* Coordinates */}
-        <View>
-          <SectionLabel icon={MapPin} label="Coordinates" colors={colors} />
-          <View style={{ flexDirection: 'row', gap: 8 }}>
-            <View style={{ flex: 1 }}>
-              <FormInput
-                value={latitude}
-                onChangeText={setLatitude}
-                placeholder="Latitude"
-                colors={colors}
-                hasError={!!errors.latitude}
-              />
-            </View>
-            <View style={{ flex: 1 }}>
-              <FormInput
-                value={longitude}
-                onChangeText={setLongitude}
-                placeholder="Longitude"
-                colors={colors}
-                hasError={!!errors.longitude}
-              />
-            </View>
-          </View>
-          {errorText('latitude')}
-          {errorText('longitude')}
-        </View>
-
         {/* Point of Contact */}
         <View>
-          <SectionLabel icon={User} label="Point of Contact" colors={colors} />
+          <FieldLabel label="Point of Contact" colors={colors} hint="Optional. Email or name." />
           <FormInput
             value={pointOfContact}
             onChangeText={setPointOfContact}
-            placeholder="Contact person"
+            placeholder="contact@example.org"
             colors={colors}
           />
         </View>
 
         {/* Image URL */}
         <View>
-          <SectionLabel icon={MapPin} label="Image URL" colors={colors} />
+          <FieldLabel label="Image URL" colors={colors} hint="Optional. Direct link to a JPG/PNG." />
           <FormInput
             value={image}
             onChangeText={setImage}
@@ -580,9 +624,67 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
           />
         </View>
 
+        {/* Advanced: coordinates (auto-filled from center) */}
+        <View style={{ gap: 10 }}>
+          <Pressable
+            onPress={() => setShowAdvanced((v) => !v)}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+            accessibilityLabel="Toggle advanced location options"
+          >
+            <ChevronDown
+              size={12}
+              color={colors.textMuted}
+              style={{ transform: [{ rotate: showAdvanced ? '0deg' : '-90deg' }] }}
+            />
+            <Text
+              style={{
+                fontFamily: 'Inter-Medium',
+                fontSize: 11,
+                color: colors.textMuted,
+                letterSpacing: 0.4,
+                textTransform: 'uppercase',
+              }}
+            >
+              Advanced location
+            </Text>
+            {(errors.latitude || errors.longitude) ? (
+              <Text style={{ fontFamily: 'Inter-Regular', fontSize: 11, color: '#DC2626' }}>
+                · check coordinates
+              </Text>
+            ) : null}
+          </Pressable>
+          {showAdvanced && (
+            <View>
+              <FieldLabel label="Coordinates" colors={colors} hint="Override only if the center's pin is wrong." />
+              <View style={{ flexDirection: 'row', gap: 8 }}>
+                <View style={{ flex: 1 }}>
+                  <FormInput
+                    value={latitude}
+                    onChangeText={setLatitude}
+                    placeholder="Latitude"
+                    colors={colors}
+                    hasError={!!errors.latitude}
+                  />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <FormInput
+                    value={longitude}
+                    onChangeText={setLongitude}
+                    placeholder="Longitude"
+                    colors={colors}
+                    hasError={!!errors.longitude}
+                  />
+                </View>
+              </View>
+              {errorText('latitude')}
+              {errorText('longitude')}
+            </View>
+          )}
+        </View>
+
         {/* Category */}
         <View>
-          <SectionLabel icon={Tag} label="Category" colors={colors} />
+          <FieldLabel label="Category" colors={colors} />
           <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap' }}>
             {CATEGORY_OPTIONS.map((opt) => {
               const selected = category === opt.value


### PR DESCRIPTION
## Why

User feedback after first beta create-event attempt:
> "I submitted an event called Test in prod. I don't see any errors (or success message)."
> "Add validation to date and time input, ideally make input easier with some date and time inputs. Don't allow people to choose stuff in the past."
> "Remove the icons from each form field to make it cleaner."

## Changes

Both web surfaces — desktop modal (`EventFormPanel.tsx`) and the mobile-web full page (`app/events/form.web.tsx`):

- **Drop the per-field icon box.** `SectionLabel`/`FieldRow` are now bare labels with optional `required` and `hint` props. Inputs are no longer indented under an icon column.
- **Native HTML date + time pickers.** Replace the date/time `TextInput`s with raw `<input type="date">` and `<input type="time">`. Browsers render their real platform pickers; the date input gets `min={today}` so the past calendar is greyed out; we read 24h `HH:MM` directly (drops the brittle AM/PM regex parser). Inputs respect light/dark via `colorScheme`.
- **Future-only validation.** Combined date+time must be in the future. Past date → error on the date field. Today + past time → error on the time field.
- **Success → straight to the new event.** Mobile web routes to `/events/{id}` after create. Desktop modal hands the saved id back via `onSaved(id)` and the parent opens the detail panel. On edit, route back to the same event's detail.
- **Failure → inline banner.** Replace the jarring `alert()` with a red-bordered banner at the top of the form so the user sees what went wrong without losing field state.
- Coordinates moved into a collapsible **Advanced location** group in the desktop modal too (matches the mobile-web treatment); auto-expands if the user enters bad lat/lng.

Native form (`app/events/form.tsx`) is intentionally untouched — same polish should follow there in a separate pass.

## Test plan

- [ ] Sign in, click **Create Event**
- [ ] Form shows no per-field icons; required fields marked `*`
- [ ] Click the date field → a real calendar appears; past days are disabled
- [ ] Click the time field → a real time picker appears
- [ ] Pick a date in the past, hit Create → date error renders inline
- [ ] Pick today + a past time, hit Create → time error renders inline
- [ ] Pick a valid future date+time, fill required fields, hit Create → goes straight to the new event detail page
- [ ] Open an existing event you created, hit Edit, save → goes back to the event detail
- [ ] Disconnect / kill the API, hit Create → red banner at top of form, field state preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)