### PR TITLE
fix(theme/native): pass resolved theme to NativeWind so OS dark-mode flips hot-reload

### DIFF
--- a/packages/frontend/components/contexts/ThemeContext.tsx
+++ b/packages/frontend/components/contexts/ThemeContext.tsx
@@ -115,11 +115,31 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme: ResolvedTheme = preference === 'system' ? system : preference
 
   // ── Apply to NativeWind + DOM on every change ──────────────────────────────
+  //
+  // Platform split is deliberate:
+  //
+  //   Web: pass the *preference* ('system' | 'light' | 'dark'). Browsers
+  //   resolve `system` natively via `prefers-color-scheme` CSS, NativeWind
+  //   reads `<html>`'s `color-scheme`, and the listener in `useSystemTheme`
+  //   keeps `theme` in sync for any code that reads it directly. This is
+  //   what shipped after PR #173 was reverted.
+  //
+  //   Native: pass the *resolved* theme ('light' | 'dark'). NativeWind v4
+  //   on native does NOT resubscribe to `Appearance` when given the literal
+  //   string `'system'` — it reads OS once and caches. So when the user
+  //   flips iOS dark mode mid-session, NativeWind's `dark:` variants stay
+  //   on the old value even though our `theme` state has flipped.
+  //   Forcing a resolved value sidesteps NativeWind's system-tracking
+  //   entirely; our `useSystemTheme` hook already subscribes to
+  //   `Appearance.addChangeListener` and updates `system` (and therefore
+  //   `theme`) on its own, so this effect re-runs on every OS flip.
   useEffect(() => {
-    setColorScheme(preference)
     if (isWeb) {
+      setColorScheme(preference)
       document.documentElement.classList.toggle('dark', theme === 'dark')
       document.documentElement.style.colorScheme = theme
+    } else {
+      setColorScheme(theme)
     }
   }, [theme, preference, setColorScheme])
 
@@ -137,12 +157,21 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // On web the <html> class handles everything; on native we need a root View
   // that carries the NativeWind dark-mode class so child components resolve
   // their dark: variants correctly.
+  //
+  // The `key={theme}` on the native wrapper is a defensive belt-and-suspenders
+  // remount: if NativeWind ever caches a `dark:` resolution at component level
+  // and skips the re-render on a class change, keying forces React to throw
+  // away the subtree and rebuild it with the new theme.
   return (
     <ThemeContext.Provider value={value}>
       {isWeb ? (
         children
       ) : (
-        <View className={`flex-1${theme === 'dark' ? ' dark' : ''}`} style={{ flex: 1 }}>
+        <View
+          key={theme}
+          className={`flex-1${theme === 'dark' ? ' dark' : ''}`}
+          style={{ flex: 1 }}
+        >
           {children}
         </View>
       )}


### PR DESCRIPTION
> **Don't merge yet — please flash this build and confirm before we ship.** This is the bug we've been chasing across PR #173 and PR #175; I don't have a way to test live OS theme flips on a real iPhone.

## Symptom (Abhiram in #product-dev, May 1 + 2)

- iOS device, app preference = **System**, system in dark mode
- App stays in light when iOS flips to dark
- Only catches up after force-quit + relaunch
- Some components also render in mismatched themes mid-session

## What we already shipped (currently in main)

| Attempt | Where | Outcome |
|---|---|---|
| Re-read `Appearance.getColorScheme()` on mount in `useSystemTheme` | `ThemeContext.tsx:77` | Fixes the iOS cold-start "null" race that stranded the app in light mode. **Doesn't fix live OS flips.** |
| Subscribe to `Appearance.addChangeListener` on native | `ThemeContext.tsx:78–81` | Fires on the flip and updates `system` state, so `theme` re-resolves. But the NativeWind `dark:` variants in children still aren't picking it up. |
| `expo-system-ui` install (PR #175) | global | Fixes iOS native chrome (status bar, root view bg) so cold-start in dark mode renders dark immediately. **Doesn't touch NativeWind's class resolution.** |

## What we tried and reverted (PR #173)

Changed `setColorScheme(preference)` → `setColorScheme(theme)` globally. Caused a regression Abhiram reported as **"system theming doesn't work now :melting_face:"** — reverted in PR #175.

My current theory on why that regressed: passing `'light'`/`'dark'` to NativeWind on **web** broke web's reliance on `<html>`'s `color-scheme: light dark` plus the CSS `prefers-color-scheme` media query, which is what makes web "system" mode actually follow the OS. Removing `'system'` from NativeWind on web meant NativeWind no longer signaled the dual light-and-dark color scheme to the browser.

## This PR's hypothesis

Platform-split it. Web keeps the working behavior; native gets the explicit override.

```diff
   useEffect(() => {
-    setColorScheme(preference)
     if (isWeb) {
+      setColorScheme(preference)               // CSS handles 'system'
       document.documentElement.classList.toggle('dark', theme === 'dark')
       document.documentElement.style.colorScheme = theme
+    } else {
+      setColorScheme(theme)                    // explicit on native
     }
   }, [theme, preference, setColorScheme])
```

- **Web**: keep `setColorScheme(preference)` so `'system'` tells NativeWind to emit `color-scheme: light dark` and the browser's CSS handles OS following. (No regression.)
- **Native**: pass `setColorScheme(theme)` — the resolved `'light' | 'dark'`. NativeWind v4 on native does not resubscribe to `Appearance` when given the literal `'system'` (it reads once and caches), so forcing a resolved value bypasses that. Our existing `Appearance.addChangeListener` already drives the re-resolve, so the effect re-runs and pushes the new value into NativeWind on every flip.

Belt-and-suspenders: `key={theme}` on the native wrapper `<View>`. If NativeWind ever caches a `dark:` resolution at the component level and skips a re-render on a class change, keying forces React to throw away the subtree and rebuild it with the new theme.

## Test plan (Abhiram)

1. `git checkout fix/native-system-theme-live-reload` and run a dev build on your iPhone
2. Set the in-app theme preference to **System**
3. With the app in the foreground, flip iOS Settings → Display → Dark/Light
4. **Expected:** the app re-themes within ~1 second, no force-quit needed
5. Try the same after a cold start (kill the app, set OS to dark, relaunch) — should still come up dark
6. Toggle the in-app preference between Light / Dark / System repeatedly — should flip cleanly

If it works, ship via `gh pr merge` + EAS production build. If it still flickers or doesn't update, log what you see in #product-dev — the next fallback is to call `Appearance.addChangeListener` directly inside the render path, but that's heavier and worth avoiding if this works.

## Web

No expected change. The web path is identical to what's in main today (`setColorScheme(preference)` + `<html>` class + `colorScheme` style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)