### PR TITLE
feat(client): API clients for v2 email verification + invite codes

### DIFF
--- a/packages/frontend/src/auth/authClient.ts
+++ b/packages/frontend/src/auth/authClient.ts
@@ -323,6 +323,71 @@ export const authClient = {
     }
   },
 
+  /**
+   * Request a new verification email be sent. The user must already be
+   * authenticated (signup auto-sends one; this is the resend path).
+   * Rate-limited server-side to 3/hour per user.
+   */
+  async sendVerificationEmail(token: string): AsyncResult<GenericSuccessResponse> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/send-verification-email'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<GenericSuccessResponse>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to send verification email', response.status),
+        }
+      }
+
+      return { success: true, data: { success: true, message: data?.message } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * Consume an email-verification token. Called by the /verify-email
+   * frontend route after the user clicks the link in their inbox. No
+   * auth required — the token itself is the credential.
+   */
+  async verifyEmail(verificationToken: string): AsyncResult<{ user: User }> {
+    try {
+      const response = await withTimeout(
+        buildUrl(`/auth/verify-email?token=${encodeURIComponent(verificationToken)}`),
+        { method: 'GET' },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<{ user: User; message?: string }>(response)
+
+      if (!response.ok || !data?.user) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Email verification failed', response.status),
+        }
+      }
+
+      return { success: true, data: { user: data.user } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
   async deleteAccount(token: string): AsyncResult<GenericSuccessResponse> {
     try {
       const response = await withTimeout(

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -1,0 +1,203 @@
+/**
+ * inviteClient.ts
+ *
+ * Client for the v2 user-issued invite code endpoints.
+ *
+ *   - mintCode: verified user creates a single-use 30-day code to share
+ *   - listMyCodes: list codes the current user has minted
+ *   - redeem: an Unverified user redeems a code post-signup (the signup
+ *     path itself takes the code in /auth/register)
+ *
+ * Matches the shape of authClient.ts (withTimeout retries, AsyncResult).
+ *
+ * See packages/backend docs/plans/2026-05-24-v2-verification-backend.md
+ */
+
+import { API_BASE_URL, API_TIMEOUTS } from '../config/api'
+import type { AsyncResult, AuthError, GenericSuccessResponse, User } from './types'
+
+const withTimeout = async (
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  retries = 2,
+): Promise<Response> => {
+  let lastError: Error | undefined
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(init.headers || {}),
+        },
+      })
+      clearTimeout(timeoutId)
+      return response
+    } catch (error: any) {
+      clearTimeout(timeoutId)
+      lastError = error
+      if (error?.name === 'AbortError' && attempt === 0) {
+        throw error
+      }
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError || new Error('Network request failed')
+}
+
+const toError = (message: string, status?: number, code?: string): AuthError => ({
+  message,
+  status,
+  code,
+})
+
+const buildUrl = (path: string) => `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`
+
+const safeJson = async <T>(response: Response): Promise<T | null> => {
+  try {
+    return (await response.json()) as T
+  } catch {
+    return null
+  }
+}
+
+export interface MintedInviteCode {
+  code: string
+  expiresAt: string
+  shareUrl: string
+}
+
+export interface MintedCodeListEntry {
+  code: string
+  label: string
+  verificationLevel: number
+  isActive: boolean
+  createdAt: string
+  createdByUserId: string | null
+  expiresAt: string | null
+  maxUses: number | null
+  usesCount: number
+  isUsable: boolean
+  shareUrl: string
+}
+
+export interface RedeemResponse extends GenericSuccessResponse {
+  user: User
+}
+
+export const inviteClient = {
+  /**
+   * Mint a new single-use, 30-day-expiry invite code tied to the caller.
+   * Requires verification_level >= NORMAL_USER (45) server-side.
+   */
+  async mintCode(token: string): AsyncResult<MintedInviteCode> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/invite-codes'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<MintedInviteCode & { message?: string }>(response)
+
+      if (!response.ok || !data?.code) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to mint invite code', response.status),
+        }
+      }
+
+      return {
+        success: true,
+        data: { code: data.code, expiresAt: data.expiresAt, shareUrl: data.shareUrl },
+      }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * List invite codes the current user has minted. Each entry includes
+   * its share URL and an `isUsable` flag (active + not expired + has
+   * remaining uses).
+   */
+  async listMyCodes(token: string): AsyncResult<{ codes: MintedCodeListEntry[] }> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/invite-codes/mine'),
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<{ codes?: MintedCodeListEntry[]; message?: string }>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to list invite codes', response.status),
+        }
+      }
+
+      return { success: true, data: { codes: data?.codes ?? [] } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * Redeem an invite code post-signup. If the user's email is already
+   * verified, their verification_level is bumped immediately; otherwise
+   * the code is recorded on the user and the bump applies at next
+   * email-verify. The signup path (POST /auth/register with `inviteCode`)
+   * handles the at-signup case directly — this is for users who signed
+   * up without an invite and want to upgrade.
+   */
+  async redeem(token: string, code: string): AsyncResult<RedeemResponse> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/redeem-invite'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ code }),
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<RedeemResponse>(response)
+
+      if (!response.ok || !data?.user) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to redeem invite code', response.status),
+        }
+      }
+
+      return { success: true, data }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+}

--- a/packages/frontend/src/config/api.ts
+++ b/packages/frontend/src/config/api.ts
@@ -28,6 +28,13 @@ export const API_ENDPOINTS = {
     verify: '/auth/verify',
     logout: '/auth/deauthenticate',
     deleteAccount: '/auth/delete-account',
+    sendVerificationEmail: '/auth/send-verification-email',
+    verifyEmail: '/auth/verify-email',
+  },
+  invites: {
+    mint: '/auth/invite-codes',
+    listMine: '/auth/invite-codes/mine',
+    redeem: '/auth/redeem-invite',
   },
   users: {
     exists: '/userExistence',


### PR DESCRIPTION
## Summary

Frontend API client wrappers for the v2 backend (PR #220 + #221). Pure additions — no existing screen touched. Lets Abhiram wire when he's ready on `feat/v2-onboarding`.

**Stacked on:** PR #221 → PR #220 → v2. Merge those first.

## What's added

**`authClient.ts` gets two methods:**
- `sendVerificationEmail(token)` — POST `/auth/send-verification-email` (rate-limited 3/hr server-side)
- `verifyEmail(verificationToken)` — GET `/auth/verify-email`. No bearer; the link token is the credential. Called by the (future) `/verify-email` frontend route.

**New `inviteClient` module:**
- `mintCode(token)` — POST `/auth/invite-codes`. Verified users only. Returns `{ code, expiresAt, shareUrl }`.
- `listMyCodes(token)` — GET `/auth/invite-codes/mine`. Returns codes with `shareUrl` and `isUsable` flag.
- `redeem(token, code)` — POST `/auth/redeem-invite`. For users who signed up without an invite and want to upgrade.

**`API_ENDPOINTS` extended:**
- `auth.sendVerificationEmail`, `auth.verifyEmail`
- `invites.mint`, `invites.listMine`, `invites.redeem`

## Shapes

```ts
interface MintedInviteCode {
  code: string
  expiresAt: string
  shareUrl: string  // chinmayajanata.org/join?code=XXX
}

interface MintedCodeListEntry {
  code: string
  label: string
  verificationLevel: number
  isActive: boolean
  createdAt: string
  createdByUserId: string | null
  expiresAt: string | null
  maxUses: number | null
  usesCount: number
  isUsable: boolean  // derived: active + not expired + has remaining uses
  shareUrl: string
}
```

All methods return the standard `AsyncResult<T>` shape used elsewhere in `authClient`.

## What this does NOT touch

- `packages/frontend/app/settings/invite.tsx` — Abhiram's invite screen (#219). Currently displays `user.inviteCode` and uses a placeholder URL (`janata.app/i/CODE`). Wiring this to the new client is a real refactor of his UX, intentionally left for him to do on his branch.
- No new screens for `/verify-email` or `/join`. Backend is callable; UI lands later.

## Verification

- All 285 backend tests pass (no change there)
- Frontend type-check: no new errors from these files (pre-existing Lucide prop errors in other files are unrelated)
- API endpoints validated end-to-end against real Resend + real Gmail in PR #221 testing (full Path A: mint → invite signup → email verify → auto-promote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)