### PR TITLE
chore: bring Chunk 2 + frontend clients to v2

### DIFF
--- a/migrations/0017_extend_invite_codes.sql
+++ b/migrations/0017_extend_invite_codes.sql
@@ -1,0 +1,19 @@
+-- 0017_extend_invite_codes.sql
+-- Extends invite_codes for v2 user-issued single-use links.
+--
+-- Why: v1 invite_codes were admin-managed cohort codes (multi-use, no
+-- expiry). v2 lets any Verified user mint single-use links that expire
+-- in 30 days. The same table backs both paths.
+--
+-- Backward compatibility: existing admin cohort codes have all new
+-- columns NULL/0. validateInviteCode treats NULL max_uses as unlimited
+-- and NULL expires_at as no expiry.
+--
+-- See docs/plans/2026-05-05-v2-roles-invites-messaging.md §5.A.
+
+ALTER TABLE invite_codes ADD COLUMN created_by_user_id TEXT REFERENCES users(id);
+ALTER TABLE invite_codes ADD COLUMN expires_at TEXT;
+ALTER TABLE invite_codes ADD COLUMN max_uses INTEGER;
+ALTER TABLE invite_codes ADD COLUMN uses_count INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_invite_codes_creator ON invite_codes(created_by_user_id);

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -1642,3 +1642,218 @@ describe('Admin end-to-end workflow', () => {
     expect(stats2.events).toBe(1)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════
+// USER-ISSUED INVITE CODES (v2)
+// ═══════════════════════════════════════════════════════════════════════
+
+// Developer email path: lands at BRAHMACHARI (108) without an invite code.
+// Used in tests to get a "verified" user that can mint invite codes.
+const DEV_EMAIL = 'kishparikh18@gmail.com'
+
+async function registerAsDeveloper(): Promise<{ token: string; user: any }> {
+  await jsonPost('/api/auth/register', { username: DEV_EMAIL, password: 'devpassword123' })
+  const { body } = await jsonPost('/api/auth/authenticate', {
+    username: DEV_EMAIL,
+    password: 'devpassword123',
+  })
+  return { token: body.token, user: body.user }
+}
+
+describe('POST /api/auth/invite-codes (mint)', () => {
+  it('verified user mints a single-use 30-day code', async () => {
+    const { token } = await registerAsDeveloper()
+    const { res, body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    expect(res.status).toBe(200)
+    expect(body.code).toMatch(/^[0-9A-F]{12}$/)
+    expect(body.shareUrl).toContain(body.code)
+    expect(new Date(body.expiresAt).getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('rejects unverified user with 403', async () => {
+    // Self-signup with no invite = UNVERIFIED_USER
+    await jsonPost('/api/auth/register', { username: 'noinvite@test.com', password: 'password123' })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'noinvite@test.com',
+      password: 'password123',
+    })
+    const { res, body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(auth.token))
+    expect(res.status).toBe(403)
+    expect(body.message).toContain('verified')
+  })
+
+  it('rejects missing auth with 401', async () => {
+    const { res } = await jsonPost('/api/auth/invite-codes', {})
+    expect(res.status).toBe(401)
+  })
+
+  it('returns a different code on each call', async () => {
+    const { token } = await registerAsDeveloper()
+    const { body: a } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    const { body: b } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    expect(a.code).not.toBe(b.code)
+  })
+})
+
+describe('GET /api/auth/invite-codes/mine', () => {
+  it('returns empty list when user has not minted any codes', async () => {
+    const { token } = await registerAsDeveloper()
+    const { res, body } = await fetchJSON('/api/auth/invite-codes/mine', {
+      headers: authHeader(token),
+    })
+    expect(res.status).toBe(200)
+    expect(body.codes).toEqual([])
+  })
+
+  it('returns the codes the user has minted', async () => {
+    const { token } = await registerAsDeveloper()
+    await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    const { body } = await fetchJSON('/api/auth/invite-codes/mine', {
+      headers: authHeader(token),
+    })
+    expect(body.codes).toHaveLength(2)
+    expect(body.codes[0].isUsable).toBe(true)
+    expect(body.codes[0].shareUrl).toContain(body.codes[0].code)
+  })
+
+  it("does not leak other users' codes", async () => {
+    // Mint a code as dev user, then sign up a separate user and check theirs is empty.
+    const { token: devToken } = await registerAsDeveloper()
+    await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+
+    await jsonPost('/api/auth/register', { username: 'other@test.com', password: 'password123' })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'other@test.com',
+      password: 'password123',
+    })
+    const { body } = await fetchJSON('/api/auth/invite-codes/mine', {
+      headers: authHeader(auth.token),
+    })
+    expect(body.codes).toEqual([])
+  })
+})
+
+describe('POST /api/auth/redeem-invite', () => {
+  it('records the invite code for an unverified user (no email-verify yet)', async () => {
+    // Verified user mints a code
+    const { token: devToken } = await registerAsDeveloper()
+    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+
+    // Unverified user redeems it
+    await jsonPost('/api/auth/register', { username: 'redeem@test.com', password: 'password123' })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'redeem@test.com',
+      password: 'password123',
+    })
+    const { res, body } = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: minted.code },
+      authHeader(auth.token),
+    )
+    expect(res.status).toBe(200)
+    expect(body.message).toContain('verify your email')
+    expect(body.user.verificationLevel).toBe(30) // still UNVERIFIED
+  })
+
+  it('rejects already-verified users with 400', async () => {
+    const { token } = await registerAsDeveloper()
+    const { res, body } = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: 'ANYTHING' },
+      authHeader(token),
+    )
+    expect(res.status).toBe(400)
+    expect(body.message).toContain('Already verified')
+  })
+
+  it('rejects users who already have an invite_code associated', async () => {
+    // Sign up using TEST_INVITE_CODE so invite_code is recorded
+    await jsonPost('/api/auth/register', {
+      username: 'hasinv@test.com',
+      password: 'password123',
+      inviteCode: TEST_INVITE_CODE,
+    })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'hasinv@test.com',
+      password: 'password123',
+    })
+    const { res, body } = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: 'ANYTHING' },
+      authHeader(auth.token),
+    )
+    expect(res.status).toBe(400)
+    expect(body.message).toContain('already associated')
+  })
+
+  it('rejects invalid codes with 401', async () => {
+    await jsonPost('/api/auth/register', { username: 'bad@test.com', password: 'password123' })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'bad@test.com',
+      password: 'password123',
+    })
+    const { res, body } = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: 'NOPE' },
+      authHeader(auth.token),
+    )
+    expect(res.status).toBe(401)
+    expect(body.message).toContain('Invalid')
+  })
+
+  it('rejects already-consumed single-use codes with 401 (validate fails)', async () => {
+    const { token: devToken } = await registerAsDeveloper()
+    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+
+    // First redemption: user A
+    await jsonPost('/api/auth/register', { username: 'first@test.com', password: 'password123' })
+    const { body: authA } = await jsonPost('/api/auth/authenticate', {
+      username: 'first@test.com',
+      password: 'password123',
+    })
+    const first = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: minted.code },
+      authHeader(authA.token),
+    )
+    expect(first.res.status).toBe(200)
+
+    // Second redemption attempt by user B should fail
+    await jsonPost('/api/auth/register', { username: 'second@test.com', password: 'password123' })
+    const { body: authB } = await jsonPost('/api/auth/authenticate', {
+      username: 'second@test.com',
+      password: 'password123',
+    })
+    const second = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: minted.code },
+      authHeader(authB.token),
+    )
+    expect(second.res.status).toBe(401)
+  })
+})
+
+describe('POST /api/auth/register — invite code consume', () => {
+  it('single-use code can only be redeemed once at signup', async () => {
+    const { token: devToken } = await registerAsDeveloper()
+    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+
+    const a = await jsonPost('/api/auth/register', {
+      username: 'racea@test.com',
+      password: 'password123',
+      inviteCode: minted.code,
+    })
+    const b = await jsonPost('/api/auth/register', {
+      username: 'raceb@test.com',
+      password: 'password123',
+      inviteCode: minted.code,
+    })
+    expect(a.res.status).toBe(201)
+    // Sequential: validateInviteCode rejects on the second call (uses_count
+    // already at max_uses), returning 401. In a true concurrent race the
+    // second signup could get 409 from consumeInviteCode losing. Either
+    // outcome is a correct rejection.
+    expect([401, 409]).toContain(b.res.status)
+  })
+})

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -10,13 +10,17 @@ import {
 } from 'cloudflare:test'
 
 const MIGRATION = `
+-- FK constraints are dropped in the test schema to avoid a circular ref
+-- between invite_codes.created_by_user_id and users.invite_code at
+-- table-drop time (D1 doesn't honor PRAGMA foreign_keys = OFF inside
+-- the test pool). The production migration still enforces them.
 CREATE TABLE IF NOT EXISTS invite_codes (
   code              TEXT PRIMARY KEY,
   label             TEXT NOT NULL,
   verification_level INTEGER NOT NULL DEFAULT 45,
   is_active         INTEGER NOT NULL DEFAULT 1,
   created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  created_by_user_id TEXT REFERENCES users(id),
+  created_by_user_id TEXT,
   expires_at        TEXT,
   max_uses          INTEGER,
   uses_count        INTEGER NOT NULL DEFAULT 0
@@ -41,7 +45,7 @@ CREATE TABLE IF NOT EXISTS users (
   is_active       INTEGER NOT NULL DEFAULT 0,
   profile_complete INTEGER NOT NULL DEFAULT 0,
   interests       TEXT,
-  invite_code     TEXT REFERENCES invite_codes(code),
+  invite_code     TEXT,
   email_verified_at TEXT,
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
@@ -51,7 +55,7 @@ CREATE INDEX IF NOT EXISTS idx_users_center   ON users(center_id);
 
 CREATE TABLE IF NOT EXISTS email_verification_tokens (
   token       TEXT PRIMARY KEY,
-  user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id     TEXT NOT NULL,
   expires_at  TEXT NOT NULL,
   consumed_at TEXT,
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
@@ -145,6 +149,10 @@ export async function applyMigration(): Promise<void> {
 
 /**
  * Drop all tables. Call this in afterEach() for clean isolation.
+ *
+ * invite_codes and users have a circular FK (users.invite_code ↔
+ * invite_codes.created_by_user_id), so we disable FK checks during the
+ * drop sequence and re-enable after.
  */
 export async function dropAllTables(): Promise<void> {
   const db = env.DB
@@ -153,9 +161,9 @@ export async function dropAllTables(): Promise<void> {
     'event_attendees',
     'events',
     'email_verification_tokens',
+    'invite_codes',
     'users',
     'centers',
-    'invite_codes',
   ]
   for (const table of tables) {
     await db.prepare(`DROP TABLE IF EXISTS ${table}`).run()

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -15,8 +15,13 @@ CREATE TABLE IF NOT EXISTS invite_codes (
   label             TEXT NOT NULL,
   verification_level INTEGER NOT NULL DEFAULT 45,
   is_active         INTEGER NOT NULL DEFAULT 1,
-  created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by_user_id TEXT REFERENCES users(id),
+  expires_at        TEXT,
+  max_uses          INTEGER,
+  uses_count        INTEGER NOT NULL DEFAULT 0
 );
+CREATE INDEX IF NOT EXISTS idx_invite_codes_creator ON invite_codes(created_by_user_id);
 
 CREATE TABLE IF NOT EXISTS users (
   id              TEXT PRIMARY KEY,

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -217,10 +217,15 @@ app.post('/auth/register', rateLimit(5, 60_000), async (c) => {
     if (!inviteCodeData) {
       return c.json({ message: 'Invalid or inactive invite code' }, 401)
     }
+    // Atomically consume the code so single-use invites can't be raced by
+    // two simultaneous signups. Admin cohort codes (max_uses=NULL) succeed
+    // trivially. Note: verification_level stays UNVERIFIED_USER; the bump
+    // happens at email-verify time (see GET /auth/verify-email).
+    const consumed = await inviteCodes.consumeInviteCode(c.env, inviteCodeData.code)
+    if (!consumed) {
+      return c.json({ message: 'Invite code already redeemed or expired' }, 409)
+    }
     inviteCodeUsed = inviteCodeData.code
-    // Note: verification_level stays UNVERIFIED_USER. The bump to
-    // inviteCodeData.verification_level happens at email-verify time
-    // (see GET /auth/verify-email).
   }
 
   const hashedPassword = await hashPassword(validPassword)
@@ -437,9 +442,11 @@ app.get('/auth/verify-email', async (c) => {
 
   // Path A promotion: if user signed up with an invite code and hasn't been
   // promoted yet, apply the code's verification_level now. Won't downgrade.
+  // Use getInviteCode (not validateInviteCode) since single-use codes are
+  // already consumed at signup; we just need the recorded level.
   let newLevel = user.verification_level
   if (user.invite_code && user.verification_level < NORMAL_USER) {
-    const inviteCode = await inviteCodes.validateInviteCode(c.env, user.invite_code)
+    const inviteCode = await inviteCodes.getInviteCode(c.env, user.invite_code)
     if (inviteCode) {
       newLevel = Math.max(user.verification_level, inviteCode.verification_level)
     }
@@ -460,6 +467,90 @@ app.get('/auth/verify-email', async (c) => {
   const updated = await db.getUserById(c.env.DB, user.id)
   return c.json({
     message: 'Email verified',
+    user: updated ? userRowToApi(updated) : null,
+  })
+})
+
+// ── User-issued invite codes (v2) ─────────────────────────────────────
+//
+// Verified users can mint single-use, 30-day-expiry links and share them.
+// Recipients redeem either at signup (handled in /auth/register) or
+// post-signup via /auth/redeem-invite. See
+// docs/plans/2026-05-05-v2-roles-invites-messaging.md §5.A.
+
+const INVITE_SHARE_URL_BASE = 'https://chinmayajanata.org/join'
+
+app.post('/auth/invite-codes', authMiddleware, async (c) => {
+  const user = c.get('user')
+  if (user.verification_level < NORMAL_USER) {
+    return c.json({ message: 'Only verified users can issue invite codes' }, 403)
+  }
+
+  const result = await inviteCodes.mintUserInviteCode(c.env, user.id)
+  if (!result.success) {
+    console.error('mintUserInviteCode error:', result.error)
+    return c.json({ message: 'Failed to mint invite code' }, 500)
+  }
+
+  return c.json({
+    code: result.code,
+    expiresAt: result.expiresAt,
+    shareUrl: `${INVITE_SHARE_URL_BASE}?code=${result.code}`,
+  })
+})
+
+app.get('/auth/invite-codes/mine', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const rows = await inviteCodes.getUserMintedCodes(c.env, user.id)
+  return c.json({
+    codes: rows.map((row) => ({
+      ...inviteCodes.inviteCodeRowToApi(row),
+      shareUrl: `${INVITE_SHARE_URL_BASE}?code=${row.code}`,
+    })),
+  })
+})
+
+app.post('/auth/redeem-invite', rateLimit(5, 60_000), authMiddleware, async (c) => {
+  const user = c.get('user')
+
+  if (user.verification_level >= NORMAL_USER) {
+    return c.json({ message: 'Already verified; no invite needed' }, 400)
+  }
+  if (user.invite_code) {
+    return c.json({ message: 'An invite code is already associated with this account' }, 400)
+  }
+
+  const body = await c.req.json<{ code?: string }>().catch(() => ({ code: undefined }))
+  if (!body.code || typeof body.code !== 'string' || body.code.trim().length === 0) {
+    return c.json({ message: 'Invite code is required' }, 400)
+  }
+
+  const validated = await inviteCodes.validateInviteCode(c.env, body.code)
+  if (!validated) {
+    return c.json({ message: 'Invalid, expired, or fully redeemed invite code' }, 401)
+  }
+
+  const consumed = await inviteCodes.consumeInviteCode(c.env, validated.code)
+  if (!consumed) {
+    // Race: someone else consumed it between validate and consume.
+    return c.json({ message: 'Invite code already redeemed or expired' }, 409)
+  }
+
+  // Record the code on the user. If email is already verified, apply the
+  // promotion now. Otherwise the bump happens at email-verify.
+  const updates: Partial<UserRow> = { invite_code: validated.code }
+  let promoted = false
+  if (user.email_verified_at && user.verification_level < validated.verification_level) {
+    updates.verification_level = validated.verification_level
+    promoted = true
+  }
+  await db.updateUser(c.env.DB, user.id, updates)
+
+  const updated = await db.getUserById(c.env.DB, user.id)
+  return c.json({
+    message: promoted
+      ? 'Invite redeemed; you are now verified'
+      : 'Invite recorded; verify your email to complete promotion',
     user: updated ? userRowToApi(updated) : null,
   })
 })

--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -3,66 +3,89 @@
  *
  * Om Sri Chinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
  *
- * Invite code management for beta access gating
+ * Invite code management. Supports two flavors against the same table:
+ *   - Admin cohort codes (created via createInviteCode): multi-use,
+ *     no expiry. Used for batch beta seeding.
+ *   - User-issued single-use links (created via mintUserInviteCode,
+ *     v2): one consumption, 30-day expiry, tied to a creator.
+ *
+ * See docs/plans/2026-05-05-v2-roles-invites-messaging.md §5.A.
  */
 
 import type { Env, InviteCodeRow } from './types'
-import { ADMIN_CUTOFF } from './constants'
+import { ADMIN_CUTOFF, NORMAL_USER } from './constants'
+
+const USER_INVITE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const USER_INVITE_CODE_BYTES = 6 // 12 hex chars
+
+const SELECT_COLUMNS = `code, label, verification_level, is_active, created_at,
+  created_by_user_id, expires_at, max_uses, uses_count`
+
+function normalizeCode(code: string): string {
+  return code.trim().toUpperCase()
+}
+
+function isCodeUsable(row: InviteCodeRow, now: Date = new Date()): boolean {
+  if (row.is_active !== 1) return false
+  if (row.expires_at && new Date(row.expires_at) <= now) return false
+  if (row.max_uses !== null && row.uses_count >= row.max_uses) return false
+  return true
+}
 
 /**
- * Validate an invite code
- * Returns the code row if valid and active, null otherwise
+ * Validate an invite code. Returns the row if it's active, not expired,
+ * and has remaining uses. Returns null otherwise.
  */
 export async function validateInviteCode(
   env: Env,
-  code: string
+  code: string,
 ): Promise<InviteCodeRow | null> {
   if (!code || typeof code !== 'string' || code.trim().length === 0) {
     return null
   }
 
-  const stmt = env.DB.prepare(`
-    SELECT code, label, verification_level, is_active, created_at
-    FROM invite_codes
-    WHERE code = ? AND is_active = 1
-  `)
+  const result = await env.DB.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM invite_codes WHERE code = ?`,
+  )
+    .bind(normalizeCode(code))
+    .first<InviteCodeRow>()
 
-  const result = await stmt.bind(code.trim().toUpperCase()).first<InviteCodeRow>()
-  return result || null
+  if (!result) return null
+  return isCodeUsable(result) ? result : null
 }
 
 /**
- * Get an invite code (regardless of active status)
- * Used for admin lookups
+ * Get an invite code regardless of state (active/expired/exhausted).
+ * Used for admin lookups and consumption flows that need to inspect
+ * a previously-valid code.
  */
 export async function getInviteCode(
   env: Env,
-  code: string
+  code: string,
 ): Promise<InviteCodeRow | null> {
   if (!code || typeof code !== 'string') {
     return null
   }
 
-  const stmt = env.DB.prepare(`
-    SELECT code, label, verification_level, is_active, created_at
-    FROM invite_codes
-    WHERE code = ?
-  `)
+  const result = await env.DB.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM invite_codes WHERE code = ?`,
+  )
+    .bind(normalizeCode(code))
+    .first<InviteCodeRow>()
 
-  const result = await stmt.bind(code.trim().toUpperCase()).first<InviteCodeRow>()
   return result || null
 }
 
 /**
- * Create a new invite code
- * Used by developers via admin operations
+ * Create an admin cohort code (multi-use, no expiry).
+ * Used for batch beta seeding via admin endpoints.
  */
 export async function createInviteCode(
   env: Env,
   code: string,
   label: string,
   verificationLevel: number,
-  isActive: boolean = true
+  isActive: boolean = true,
 ): Promise<{ success: boolean; error?: string }> {
   if (!code || code.trim().length === 0) {
     return { success: false, error: 'Code is required' }
@@ -79,19 +102,12 @@ export async function createInviteCode(
 
   try {
     const now = new Date().toISOString()
-    const stmt = env.DB.prepare(`
-      INSERT INTO invite_codes (code, label, verification_level, is_active, created_at)
-      VALUES (?, ?, ?, ?, ?)
-    `)
-
-    await stmt.bind(
-      code.trim().toUpperCase(),
-      label.trim(),
-      verificationLevel,
-      isActive ? 1 : 0,
-      now
-    ).run()
-
+    await env.DB.prepare(
+      `INSERT INTO invite_codes (code, label, verification_level, is_active, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+      .bind(normalizeCode(code), label.trim(), verificationLevel, isActive ? 1 : 0, now)
+      .run()
     return { success: true }
   } catch (error: any) {
     return { success: false, error: error.message || 'Failed to create invite code' }
@@ -99,91 +115,159 @@ export async function createInviteCode(
 }
 
 /**
- * Deactivate an invite code
- * Existing users keep their verification_level, but new signups are blocked
+ * Mint a single-use, 30-day-expiry invite link tied to a user.
+ * Promotes the recipient to NORMAL_USER on redemption.
  */
-export async function deactivateInviteCode(
+export async function mintUserInviteCode(
   env: Env,
-  code: string
-): Promise<{ success: boolean; error?: string }> {
-  try {
-    const stmt = env.DB.prepare(`
-      UPDATE invite_codes
-      SET is_active = 0
-      WHERE code = ?
-    `)
+  userId: string,
+): Promise<{ success: true; code: string; expiresAt: string } | { success: false; error: string }> {
+  // Random 12-char hex code. Collision space is 2^48 ≈ 2.8e14, plenty for
+  // user-issued links. Retry up to 3 times in the (vanishingly rare) case
+  // of a collision against an existing code.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const bytes = new Uint8Array(USER_INVITE_CODE_BYTES)
+    crypto.getRandomValues(bytes)
+    const code = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+      .toUpperCase()
 
-    const result = await stmt.bind(code.trim().toUpperCase()).run()
-    return result.success ? { success: true } : { success: false, error: 'Code not found' }
-  } catch (error: any) {
-    return { success: false, error: error.message }
+    const expiresAt = new Date(Date.now() + USER_INVITE_TTL_MS).toISOString()
+    const now = new Date().toISOString()
+
+    try {
+      await env.DB.prepare(
+        `INSERT INTO invite_codes
+           (code, label, verification_level, is_active, created_at,
+            created_by_user_id, expires_at, max_uses, uses_count)
+         VALUES (?, ?, ?, 1, ?, ?, ?, 1, 0)`,
+      )
+        .bind(code, `User invite from ${userId}`, NORMAL_USER, now, userId, expiresAt)
+        .run()
+      return { success: true, code, expiresAt }
+    } catch (error: any) {
+      const message = String(error?.message || '')
+      if (message.includes('UNIQUE') || message.includes('PRIMARY KEY')) {
+        continue // collision, retry with a fresh code
+      }
+      return { success: false, error: message || 'Failed to mint invite code' }
+    }
   }
+  return { success: false, error: 'Failed to mint invite code after retries' }
 }
 
 /**
- * Reactivate an invite code
+ * Atomically increment uses_count for a code, but only if it still has
+ * remaining uses. Returns true if the row was updated.
+ *
+ * Note: this does NOT promote the user. Callers are responsible for any
+ * verification_level bump on the consumer's account.
  */
-export async function reactivateInviteCode(
-  env: Env,
-  code: string
-): Promise<{ success: boolean; error?: string }> {
-  try {
-    const stmt = env.DB.prepare(`
-      UPDATE invite_codes
-      SET is_active = 1
-      WHERE code = ?
-    `)
+export async function consumeInviteCode(env: Env, code: string): Promise<boolean> {
+  if (!code || code.trim().length === 0) return false
 
-    const result = await stmt.bind(code.trim().toUpperCase()).run()
-    return result.success ? { success: true } : { success: false, error: 'Code not found' }
-  } catch (error: any) {
-    return { success: false, error: error.message }
-  }
+  const result = await env.DB.prepare(
+    `UPDATE invite_codes
+       SET uses_count = uses_count + 1
+     WHERE code = ?
+       AND is_active = 1
+       AND (expires_at IS NULL OR expires_at > ?)
+       AND (max_uses IS NULL OR uses_count < max_uses)`,
+  )
+    .bind(normalizeCode(code), new Date().toISOString())
+    .run()
+
+  // D1 .run() returns meta.changes for the number of affected rows
+  return (result.meta?.changes || 0) > 0
 }
 
 /**
- * Get all invite codes (for admin/analytics)
+ * List invite codes minted by a specific user.
  */
-export async function getAllInviteCodes(env: Env): Promise<InviteCodeRow[]> {
-  const stmt = env.DB.prepare(`
-    SELECT code, label, verification_level, is_active, created_at
-    FROM invite_codes
-    ORDER BY created_at DESC
-  `)
-
-  const result = await stmt.all<InviteCodeRow>()
+export async function getUserMintedCodes(
+  env: Env,
+  userId: string,
+): Promise<InviteCodeRow[]> {
+  const result = await env.DB.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM invite_codes
+     WHERE created_by_user_id = ?
+     ORDER BY created_at DESC`,
+  )
+    .bind(userId)
+    .all<InviteCodeRow>()
   return result.results || []
 }
 
 /**
- * Count users who signed up with a specific invite code
+ * Deactivate an invite code.
+ * Existing users keep their verification_level; new redemptions are blocked.
+ */
+export async function deactivateInviteCode(
+  env: Env,
+  code: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await env.DB.prepare(`UPDATE invite_codes SET is_active = 0 WHERE code = ?`)
+      .bind(normalizeCode(code))
+      .run()
+    return result.success ? { success: true } : { success: false, error: 'Code not found' }
+  } catch (error: any) {
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * Reactivate an invite code.
+ */
+export async function reactivateInviteCode(
+  env: Env,
+  code: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await env.DB.prepare(`UPDATE invite_codes SET is_active = 1 WHERE code = ?`)
+      .bind(normalizeCode(code))
+      .run()
+    return result.success ? { success: true } : { success: false, error: 'Code not found' }
+  } catch (error: any) {
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * Get all invite codes (admin/analytics).
+ */
+export async function getAllInviteCodes(env: Env): Promise<InviteCodeRow[]> {
+  const result = await env.DB.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM invite_codes ORDER BY created_at DESC`,
+  ).all<InviteCodeRow>()
+  return result.results || []
+}
+
+/**
+ * Count users who signed up with a specific invite code.
  */
 export async function countUsersWithCode(env: Env, code: string): Promise<number> {
-  const stmt = env.DB.prepare(`
-    SELECT COUNT(*) as count FROM users
-    WHERE invite_code = ?
-  `)
-
-  const result = await stmt.bind(code.trim().toUpperCase()).first<{ count: number }>()
+  const result = await env.DB.prepare(`SELECT COUNT(*) as count FROM users WHERE invite_code = ?`)
+    .bind(normalizeCode(code))
+    .first<{ count: number }>()
   return result?.count || 0
 }
 
 /**
- * Get all users who signed up with a specific invite code
+ * Get all users who signed up with a specific invite code.
  */
 export async function getUsersWithCode(env: Env, code: string): Promise<string[]> {
-  const stmt = env.DB.prepare(`
-    SELECT id FROM users
-    WHERE invite_code = ?
-    ORDER BY created_at DESC
-  `)
-
-  const result = await stmt.bind(code.trim().toUpperCase()).all<{ id: string }>()
+  const result = await env.DB.prepare(
+    `SELECT id FROM users WHERE invite_code = ? ORDER BY created_at DESC`,
+  )
+    .bind(normalizeCode(code))
+    .all<{ id: string }>()
   return (result.results || []).map((r) => r.id)
 }
 
 /**
- * Convert invite code row to API response format
+ * Convert invite code row to API response format.
  */
 export function inviteCodeRowToApi(row: InviteCodeRow) {
   return {
@@ -192,5 +276,14 @@ export function inviteCodeRowToApi(row: InviteCodeRow) {
     verificationLevel: row.verification_level,
     isActive: row.is_active === 1,
     createdAt: row.created_at,
+    createdByUserId: row.created_by_user_id,
+    expiresAt: row.expires_at,
+    maxUses: row.max_uses,
+    usesCount: row.uses_count,
+    // Convenience: derived "redeemable now" flag for clients.
+    isUsable:
+      row.is_active === 1 &&
+      (!row.expires_at || new Date(row.expires_at) > new Date()) &&
+      (row.max_uses === null || row.uses_count < row.max_uses),
   }
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -115,6 +115,12 @@ export interface InviteCodeRow {
   verification_level: number
   is_active: number // 0 | 1
   created_at: string
+  // v2 extensions for user-issued single-use links. Admin cohort codes
+  // leave these NULL/0 and behave as before (multi-use, no expiry).
+  created_by_user_id: string | null
+  expires_at: string | null
+  max_uses: number | null
+  uses_count: number
 }
 
 // ── API response types ────────────────────────────────────────────────

--- a/packages/frontend/src/auth/authClient.ts
+++ b/packages/frontend/src/auth/authClient.ts
@@ -323,6 +323,71 @@ export const authClient = {
     }
   },
 
+  /**
+   * Request a new verification email be sent. The user must already be
+   * authenticated (signup auto-sends one; this is the resend path).
+   * Rate-limited server-side to 3/hour per user.
+   */
+  async sendVerificationEmail(token: string): AsyncResult<GenericSuccessResponse> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/send-verification-email'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<GenericSuccessResponse>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to send verification email', response.status),
+        }
+      }
+
+      return { success: true, data: { success: true, message: data?.message } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * Consume an email-verification token. Called by the /verify-email
+   * frontend route after the user clicks the link in their inbox. No
+   * auth required — the token itself is the credential.
+   */
+  async verifyEmail(verificationToken: string): AsyncResult<{ user: User }> {
+    try {
+      const response = await withTimeout(
+        buildUrl(`/auth/verify-email?token=${encodeURIComponent(verificationToken)}`),
+        { method: 'GET' },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<{ user: User; message?: string }>(response)
+
+      if (!response.ok || !data?.user) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Email verification failed', response.status),
+        }
+      }
+
+      return { success: true, data: { user: data.user } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
   async deleteAccount(token: string): AsyncResult<GenericSuccessResponse> {
     try {
       const response = await withTimeout(

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -1,0 +1,203 @@
+/**
+ * inviteClient.ts
+ *
+ * Client for the v2 user-issued invite code endpoints.
+ *
+ *   - mintCode: verified user creates a single-use 30-day code to share
+ *   - listMyCodes: list codes the current user has minted
+ *   - redeem: an Unverified user redeems a code post-signup (the signup
+ *     path itself takes the code in /auth/register)
+ *
+ * Matches the shape of authClient.ts (withTimeout retries, AsyncResult).
+ *
+ * See packages/backend docs/plans/2026-05-24-v2-verification-backend.md
+ */
+
+import { API_BASE_URL, API_TIMEOUTS } from '../config/api'
+import type { AsyncResult, AuthError, GenericSuccessResponse, User } from './types'
+
+const withTimeout = async (
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  retries = 2,
+): Promise<Response> => {
+  let lastError: Error | undefined
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(init.headers || {}),
+        },
+      })
+      clearTimeout(timeoutId)
+      return response
+    } catch (error: any) {
+      clearTimeout(timeoutId)
+      lastError = error
+      if (error?.name === 'AbortError' && attempt === 0) {
+        throw error
+      }
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError || new Error('Network request failed')
+}
+
+const toError = (message: string, status?: number, code?: string): AuthError => ({
+  message,
+  status,
+  code,
+})
+
+const buildUrl = (path: string) => `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`
+
+const safeJson = async <T>(response: Response): Promise<T | null> => {
+  try {
+    return (await response.json()) as T
+  } catch {
+    return null
+  }
+}
+
+export interface MintedInviteCode {
+  code: string
+  expiresAt: string
+  shareUrl: string
+}
+
+export interface MintedCodeListEntry {
+  code: string
+  label: string
+  verificationLevel: number
+  isActive: boolean
+  createdAt: string
+  createdByUserId: string | null
+  expiresAt: string | null
+  maxUses: number | null
+  usesCount: number
+  isUsable: boolean
+  shareUrl: string
+}
+
+export interface RedeemResponse extends GenericSuccessResponse {
+  user: User
+}
+
+export const inviteClient = {
+  /**
+   * Mint a new single-use, 30-day-expiry invite code tied to the caller.
+   * Requires verification_level >= NORMAL_USER (45) server-side.
+   */
+  async mintCode(token: string): AsyncResult<MintedInviteCode> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/invite-codes'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<MintedInviteCode & { message?: string }>(response)
+
+      if (!response.ok || !data?.code) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to mint invite code', response.status),
+        }
+      }
+
+      return {
+        success: true,
+        data: { code: data.code, expiresAt: data.expiresAt, shareUrl: data.shareUrl },
+      }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * List invite codes the current user has minted. Each entry includes
+   * its share URL and an `isUsable` flag (active + not expired + has
+   * remaining uses).
+   */
+  async listMyCodes(token: string): AsyncResult<{ codes: MintedCodeListEntry[] }> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/invite-codes/mine'),
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<{ codes?: MintedCodeListEntry[]; message?: string }>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to list invite codes', response.status),
+        }
+      }
+
+      return { success: true, data: { codes: data?.codes ?? [] } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * Redeem an invite code post-signup. If the user's email is already
+   * verified, their verification_level is bumped immediately; otherwise
+   * the code is recorded on the user and the bump applies at next
+   * email-verify. The signup path (POST /auth/register with `inviteCode`)
+   * handles the at-signup case directly — this is for users who signed
+   * up without an invite and want to upgrade.
+   */
+  async redeem(token: string, code: string): AsyncResult<RedeemResponse> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/redeem-invite'),
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ code }),
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<RedeemResponse>(response)
+
+      if (!response.ok || !data?.user) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to redeem invite code', response.status),
+        }
+      }
+
+      return { success: true, data }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+}

--- a/packages/frontend/src/config/api.ts
+++ b/packages/frontend/src/config/api.ts
@@ -28,6 +28,13 @@ export const API_ENDPOINTS = {
     verify: '/auth/verify',
     logout: '/auth/deauthenticate',
     deleteAccount: '/auth/delete-account',
+    sendVerificationEmail: '/auth/send-verification-email',
+    verifyEmail: '/auth/verify-email',
+  },
+  invites: {
+    mint: '/auth/invite-codes',
+    listMine: '/auth/invite-codes/mine',
+    redeem: '/auth/redeem-invite',
   },
   users: {
     exists: '/userExistence',


### PR DESCRIPTION
Merges the already-reviewed-and-merged stack (#221 + #222) into v2.

The stack was opened with stacked bases (#222 → #221 → #220 → v2), so when each PR merged, commits only flowed into the *next* base, not into v2 directly. v2 received #220's commits via #220 merging. This PR brings the rest of the stack to v2 in one merge commit.

No new code — every commit here was already approved as part of #221 or #222.