### PR TITLE
feat(web): mobile-web bottom-tab nav + Create Event on Explore

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs, usePathname, useRouter } from 'expo-router'
-import { Platform, View, Text, Pressable, Image, StatusBar } from 'react-native'
+import { Platform, View, Text, Pressable, Image, StatusBar, useWindowDimensions } from 'react-native'
 import { useState, useEffect } from 'react'
 import { useUser, useTheme } from '../../components/contexts'
 import { HeaderActionProvider } from '../../components/contexts/HeaderActionContext'
@@ -19,6 +19,8 @@ export default function TabLayout() {
   const canCreate = !!user
   const posthog = usePostHog()
   const tabBarShowLabel = Platform.OS === 'web'
+  const { width } = useWindowDimensions()
+  const isDesktopWeb = Platform.OS === 'web' && width >= 768
 
   useEffect(() => {
     if (Platform.OS !== 'web' && !loading && !user) {
@@ -210,7 +212,7 @@ export default function TabLayout() {
             options={{
               tabBarShowLabel: tabBarShowLabel,
               title: 'Home',
-              header: isWeb
+              header: isDesktopWeb
                 ? () => <WebHeader />
                 : () => <TabHeader showLogo action="notifications" />,
               tabBarIcon: ({ color, size }) => <House size={size} color={color} />,
@@ -221,10 +223,20 @@ export default function TabLayout() {
             options={{
               tabBarShowLabel: false,
               title: 'Explore',
-              headerTransparent: !isWeb,
-              header: isWeb
+              headerTransparent: !isDesktopWeb,
+              header: isDesktopWeb
                 ? () => <WebHeader />
-                : () => <TabHeader title="Explore" transparent pillTitle borderAvatar />,
+                : () => (
+                    <TabHeader
+                      title="Explore"
+                      transparent
+                      pillTitle
+                      borderAvatar
+                      {...(Platform.OS === 'web'
+                        ? { action: 'create' as const, onActionPress: () => router.push('/events/form') }
+                        : {})}
+                    />
+                  ),
               tabBarIcon: ({ color, size }) => <Compass size={size} color={color} />,
             }}
           />
@@ -233,7 +245,7 @@ export default function TabLayout() {
             options={{
               tabBarShowLabel: false,
               title: 'Feed',
-              header: isWeb
+              header: isDesktopWeb
                 ? () => <WebHeader />
                 : () => <TabHeader title="Feed" action="create" />,
               tabBarIcon: ({ color, size }) => <Newspaper size={size} color={color} />,
@@ -244,7 +256,7 @@ export default function TabLayout() {
             options={{
               tabBarShowLabel: false,
               title: 'Chat',
-              header: isWeb
+              header: isDesktopWeb
                 ? () => <WebHeader />
                 : () => <TabHeader title="Chat" action="create" />,
               tabBarIcon: ({ color, size }) => <MessageSquare size={size} color={color} />,
@@ -255,7 +267,7 @@ export default function TabLayout() {
             options={{
               tabBarShowLabel: false,
               title: 'Profile',
-              header: isWeb
+              header: isDesktopWeb
                 ? () => <WebHeader />
                 : () => <TabHeader title="You" action="settings" />,
               tabBarIcon: ({ size, focused }) => (

--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -126,14 +126,7 @@ export default function TabLayout() {
               }}
               onPress={() => {
                 posthog?.capture('nav_create_event')
-                if (typeof window !== 'undefined') {
-                  const isMobile = window.innerWidth < 768
-                  if (isMobile) {
-                    router.push('/events/form')
-                  } else {
-                    window.dispatchEvent(new CustomEvent('open-event-form'))
-                  }
-                }
+                router.push('/explore?action=create')
               }}
             >
               <Plus size={16} color="#E8862A" />

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -1044,16 +1044,16 @@ export default function DiscoverScreenWeb() {
     }))
   }, [selectedItem, filteredPoints, allEvents, allCenters])
 
-  // Listen for create event from header nav button
+  // Open the create-event form when navigated with ?action=create (from the
+  // desktop "Create Event" button). Clear the param afterward so refresh/back
+  // doesn't reopen it and repeat clicks re-trigger.
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const handler = () => {
+    if (params.action === 'create') {
       setSelectedItem(null)
       setFormPanel({})
+      router.setParams({ action: undefined } as never)
     }
-    window.addEventListener('open-event-form', handler)
-    return () => window.removeEventListener('open-event-form', handler)
-  }, [])
+  }, [params.action])
 
   // Fixed 440px width for both list and detail panels — no shift on selection
   const rightPanelWidth = 440

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -1,6 +1,6 @@
 import '@expo/metro-runtime'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Animated, LogBox, Platform, Text } from 'react-native'
+import { Animated, LogBox, Platform, Text, View, useWindowDimensions } from 'react-native'
 
 // Suppress non-fatal WorkletsTurboModule error in Expo Go (reanimated v4 compat)
 LogBox.ignoreLogs(['Exception in HostFunction: <unknown>'])
@@ -27,6 +27,7 @@ import {
   useTheme,
 } from '../components/contexts'
 import { ErrorBoundary } from '../components/ui/ErrorBoundary'
+import WebBottomNav from '../components/ui/WebBottomNav'
 import '../globals.css'
 
 export const unstable_settings = {
@@ -109,6 +110,15 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
   const pathname = usePathname()
   const router = useRouter()
   const isAuthenticated = !!user
+  const { width } = useWindowDimensions()
+  // Mirrors the desktop WebHeader, which shows its nav regardless of auth —
+  // only hide on the full-screen landing/auth/onboarding flows.
+  const showBottomNav =
+    Platform.OS === 'web' &&
+    width < 768 &&
+    !pathname.startsWith('/auth') &&
+    !pathname.startsWith('/onboarding') &&
+    pathname !== '/landing'
 
   useEffect(() => {
     if (!loading) {
@@ -172,6 +182,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
   return (
     <Animated.View style={{ flex: 1, opacity: fadeAnim }}>
       <NavigationThemeProvider value={navTheme}>
+        <View style={{ flex: 1 }}>
         <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="auth" options={{ headerShown: false }} />
@@ -213,6 +224,8 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
           <Stack.Screen name="center-picker" options={{ headerShown: false }} />
           <Stack.Screen name="admin" options={{ headerShown: false }} />
         </Stack>
+        </View>
+        {showBottomNav && <WebBottomNav />}
       </NavigationThemeProvider>
     </Animated.View>
   )

--- a/packages/frontend/components/ui/WebBottomNav.tsx
+++ b/packages/frontend/components/ui/WebBottomNav.tsx
@@ -1,0 +1,73 @@
+import { View, Text, Pressable } from 'react-native'
+import { usePathname, useRouter } from 'expo-router'
+import { House, Compass, Newspaper, MessageSquare } from 'lucide-react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useUser, useTheme } from '../contexts'
+import Avatar from './Avatar'
+
+const NAV_ITEMS = [
+  { label: 'Home', href: '/', icon: House },
+  { label: 'Explore', href: '/explore', icon: Compass },
+  { label: 'Feed', href: '/feed', icon: Newspaper },
+  { label: 'Messages', href: '/chat', icon: MessageSquare },
+  { label: 'Profile', href: '/profile', icon: null },
+] as const
+
+export default function WebBottomNav() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const { user } = useUser()
+  const { isDark } = useTheme()
+  const insets = useSafeAreaInsets()
+
+  const isActive = (href: string) => {
+    if (href === '/') return pathname === '/'
+    return pathname === href || pathname.startsWith(`${href}/`)
+  }
+
+  const ACTIVE = '#E8862A'
+  const inactive = isDark ? '#A8A29E' : '#78716C'
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        borderTopWidth: 1,
+        borderTopColor: isDark ? '#262626' : '#E7E5E4',
+        backgroundColor: isDark ? '#171717' : '#FFFFFF',
+        paddingTop: 8,
+        paddingBottom: Math.max(insets.bottom, 8),
+      }}
+    >
+      {NAV_ITEMS.map(({ label, href, icon: Icon }) => {
+        const on = isActive(href)
+        const color = on ? ACTIVE : inactive
+        return (
+          <Pressable
+            key={href}
+            onPress={() => router.push(href as never)}
+            accessibilityRole="button"
+            accessibilityLabel={label}
+            style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 2 }}
+          >
+            {href === '/profile' ? (
+              <Avatar
+                image={user?.profileImage ?? undefined}
+                name={
+                  user?.firstName
+                    ? `${user.firstName} ${user.lastName ?? ''}`.trim()
+                    : user?.username
+                }
+                size={24}
+                style={{ borderWidth: on ? 2 : 0, borderColor: ACTIVE }}
+              />
+            ) : Icon ? (
+              <Icon size={24} color={color} />
+            ) : null}
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 10, color }}>{label}</Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}

--- a/packages/frontend/src/__tests__/app/WebBottomNav.test.tsx
+++ b/packages/frontend/src/__tests__/app/WebBottomNav.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import { render, screen, fireEvent } from '@testing-library/react-native'
+
+jest.mock('expo-router', () => ({
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+}))
+jest.mock('../../../components/contexts', () => ({
+  useUser: jest.fn(),
+  useTheme: jest.fn(() => ({ isDark: false })),
+}))
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}))
+jest.mock('../../../components/ui/Avatar', () => 'Avatar')
+
+const { usePathname, useRouter } = jest.requireMock('expo-router')
+const { useUser } = jest.requireMock('../../../components/contexts')
+const mockPush = jest.fn()
+const WebBottomNav = require('../../../components/ui/WebBottomNav').default
+
+describe('WebBottomNav', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue({ push: mockPush })
+    ;(usePathname as jest.Mock).mockReturnValue('/')
+    ;(useUser as jest.Mock).mockReturnValue({ user: { username: 'kish' } })
+  })
+
+  it('renders all five tabs', () => {
+    render(<WebBottomNav />)
+    expect(screen.getByText('Home')).toBeTruthy()
+    expect(screen.getByText('Explore')).toBeTruthy()
+    expect(screen.getByText('Feed')).toBeTruthy()
+    expect(screen.getByText('Messages')).toBeTruthy()
+    expect(screen.getByText('Profile')).toBeTruthy()
+  })
+
+  it('navigates to the tab route when pressed', () => {
+    render(<WebBottomNav />)
+    fireEvent.press(screen.getByText('Explore'))
+    expect(mockPush).toHaveBeenCalledWith('/explore')
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces the overflowing horizontal top nav on **mobile web** with a persistent iOS-style **bottom tab bar** (Home · Explore · Feed · Messages · Profile). New `WebBottomNav` component is mounted at the root layout so it stays visible on every route — including the full-page `/events/form`.
- Mobile-web screen headers switch from the desktop `WebHeader` to the compact native `TabHeader` (no more overflow). Desktop web is unchanged.
- **Create Event:** desktop "Create Event" now navigates to `/explore?action=create` and opens the side-panel form (replacing a window event that only worked when already on Explore). On mobile web, a `+` in the Explore header opens the full-page `/events/form`.
- Removes the dead `open-event-form` window-event mechanism.

Design + plan: `docs/superpowers/specs/2026-05-24-mobile-web-bottom-nav-design.md`, `docs/superpowers/plans/2026-05-24-mobile-web-bottom-nav.md`.

## Test Plan
Verified by driving the running app at both breakpoints (component unit tests can't run repo-wide due to a pre-existing `react-test-renderer@19.2.4` vs `react@19.2.0` mismatch):
- [x] Mobile (390px): compact headers, no overflow; bottom tabs navigate with active state
- [x] Mobile Explore `+` → `/events/form` with the bottom nav still visible
- [x] Desktop (1200px): Create Event from any tab → Explore with side-panel form open; close + reopen work; nav unchanged
- [ ] Native iOS/Android unaffected (Explore `+` is web-gated; native uses the built-in tab bar) — sanity-check on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)