### PR TITLE
fix(mobile): repair +not-found dark mode + VoiceOver labels

### DIFF
--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -244,6 +244,8 @@ export default function ProfileNative() {
           ].map((stat, i, arr) => (
             <View
               key={stat.label}
+              accessible
+              accessibilityLabel={`${stat.value} ${stat.label}`}
               style={{
                 flex: 1,
                 alignItems: 'center',
@@ -292,6 +294,8 @@ export default function ProfileNative() {
         >
           <Pressable
             onPress={() => router.push('/edit-profile')}
+            accessibilityRole="button"
+            accessibilityLabel="Edit profile"
             style={{
               flex: 1,
               paddingVertical: 9,
@@ -311,6 +315,8 @@ export default function ProfileNative() {
           </Pressable>
           <Pressable
             onPress={handleShare}
+            accessibilityRole="button"
+            accessibilityLabel="Share profile"
             style={{
               flex: 1,
               paddingVertical: 9,

--- a/packages/frontend/app/+not-found.tsx
+++ b/packages/frontend/app/+not-found.tsx
@@ -6,9 +6,11 @@ export default function NotFoundScreen() {
     <>
       <Stack.Screen options={{ title: 'Oops!' }} />
       <View className="flex-1 items-center justify-center p-5">
-        <Text className="text-xl font-bold mb-2">This screen doesn't exist.</Text>
+        <Text className="text-xl font-bold mb-2 text-content dark:text-content-dark">
+          This screen doesn't exist.
+        </Text>
         <Link href="/" className="mt-4 py-4">
-          <Text className="text-base text-blue-600">Go to home screen!</Text>
+          <Text className="text-base text-primary">Go to home screen!</Text>
         </Link>
       </View>
     </>

--- a/packages/frontend/components/ui/TabHeader.tsx
+++ b/packages/frontend/components/ui/TabHeader.tsx
@@ -113,6 +113,15 @@ export default function TabHeader({
         {action && (
           <Pressable
             onPress={handleActionPress}
+            accessibilityRole="button"
+            accessibilityLabel={
+              action === 'create'
+                ? 'Create'
+                : action === 'notifications'
+                  ? 'Notifications'
+                  : 'Settings'
+            }
+            hitSlop={8}
             style={({ pressed }) => ({
               width: 36,
               height: 36,


### PR DESCRIPTION
Found during an on-device iOS design review (iPhone 16 Pro simulator, light + dark). Three small, scoped fixes — no behavior change beyond the bugs described.

## What & why

**1. `app/+not-found.tsx` — broken in dark mode (user-facing)**
The "This screen doesn't exist." heading had no color class, so it defaulted to dark text → **invisible on the dark background** (~1:1 contrast, WCAG fail). The recovery link was hardcoded `text-blue-600` — off-brand (app accent is orange `#E8862A`) and a violation of STYLING.md's "never hardcode, use tokens."
- Heading → `text-content dark:text-content-dark`
- Link → `text-primary`
- **Verified on-device:** renders white heading + orange link in dark mode.

**2. `components/ui/TabHeader.tsx` — VoiceOver + touch target**
The icon-only action button (settings / create / notifications, used across tabs) had no accessibility role/label, so VoiceOver users couldn't operate it. Added `accessibilityRole="button"` + a contextual `accessibilityLabel`, plus `hitSlop={8}` (button is 36pt → ~52pt effective hit area, clearing Apple's 44pt minimum).

**3. `app/(tabs)/profile.tsx` — VoiceOver**
Edit Profile / Share `Pressable`s and the stat cells were invisible to VoiceOver. Added roles/labels; each stat cell now reads as one element ("0 Events").

## Scope / not in this PR
This is the "worst offenders" slice of a larger accessibility gap — only ~14 files appwide use accessibility props, and the native a11y tree still exposes only the tab bar on Feed/Explore/Chat. A full a11y sweep is logged as a follow-up.

## Test
- `+not-found` dark-mode fix confirmed live on iPhone 16 Pro.
- Other changes are additive a11y props on existing controls (no layout/behavior change).

Full design review (9 screens, scored 7.6/10) lives in the local gstack project artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)