### PR TITLE
chore(backend): remove plaintext JWT secrets from wrangler configs

### DIFF
--- a/packages/backend/wrangler.staging.toml
+++ b/packages/backend/wrangler.staging.toml
@@ -14,10 +14,11 @@ database_id = "d38b4cd2-963b-45eb-9f83-1e72f9d3aa5d"
 binding = "AVATARS"
 bucket_name = "chinmaya-janata-avatars"
 
+# Non-secret vars only. Secrets come from `wrangler secret put`.
 [vars]
-JWT_SECRET = "dev-secret-key-change-in-production"
-JWT_REFRESH_SECRET = "dev-refresh-secret-key-change-in-production"
 RESEND_FROM_EMAIL = "noreply@chinmayajanata.org"
 
 # Secrets set via:
-#   npx wrangler secret put RESEND_API_KEY --config wrangler.staging.toml
+#   npx wrangler secret put JWT_SECRET         --config wrangler.staging.toml
+#   npx wrangler secret put JWT_REFRESH_SECRET --config wrangler.staging.toml
+#   npx wrangler secret put RESEND_API_KEY     --config wrangler.staging.toml

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -25,7 +25,8 @@ database_id = "d38b4cd2-963b-45eb-9f83-1e72f9d3aa5d"
 binding = "AVATARS"
 bucket_name = "chinmaya-janata-avatars"
 
+# Non-secret vars only. JWT_SECRET / JWT_REFRESH_SECRET / RESEND_API_KEY
+# come from `wrangler secret put` (see comment block at top). For `wrangler
+# dev`, values come from .dev.vars (gitignored, see .dev.vars.example).
 [vars]
-JWT_SECRET = "dev-secret-key-change-in-production"
-JWT_REFRESH_SECRET = "dev-refresh-secret-key-change-in-production"
 RESEND_FROM_EMAIL = "noreply@chinmayajanata.org"


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE YET.** This PR is parked. Merging it without first running the prep steps below will either (a) break auth on the next deploy, or (b) silently undo the prod/staging secret rotation. Read the full runbook before touching the Merge button.

## What this PR does

Strips `JWT_SECRET` and `JWT_REFRESH_SECRET` from the `[vars]` block of both `wrangler.toml` (prod) and `wrangler.staging.toml`. The dev-default strings used to live there:

```toml
[vars]
JWT_SECRET = "dev-secret-key-change-in-production"
JWT_REFRESH_SECRET = "dev-refresh-secret-key-change-in-production"
```

After this PR: `[vars]` keeps only `RESEND_FROM_EMAIL`. The JWT secrets are expected to come from `wrangler secret put` (out-of-band, not in git).

## Why it's parked

The values that were rotated via the Cloudflare dashboard are currently sitting on each worker as **plaintext vars** (type `plain_text`), not as **secrets** (type `secret_text`). That matters because:

| Binding type | `wrangler deploy`'s behavior |
|---|---|
| Plaintext var (`[vars]` in toml) | **Overwrites the live value** with whatever's in the toml — even if a human edited it via the dashboard. |
| Secret (out-of-band) | **Untouched.** Persists across deploys. Only `wrangler secret put` can change it. |

Combine that with the current state and you get two booby traps:

| What you do | What breaks |
|---|---|
| Merge this PR → v2 → main → staging deploy | Next deploy reads new toml, sees no `JWT_SECRET` in `[vars]`, and **deletes the var binding**. Worker has no `JWT_SECRET` → all auth requests crash (`undefined` passed to jose's signer). |
| Don't merge this PR → v2 → main → staging deploy | Next deploy reads current toml, sees `JWT_SECRET = "dev-secret-key-change-in-production"` in `[vars]`, and **pushes that value to the live worker**, silently undoing your rotation. JWTs go back to being signed with the public default. |

Either way, deploying without first converting the vars to true secrets is bad. This PR can't be merged until that conversion happens.

## Runbook to ship this safely

For each of the two workers (`chinmaya-janata-api`, `chinmaya-janata-api-staging`), do the following. Expect 30–60 seconds of auth 500s per worker between steps 1 and 2.

### Step 1 — delete the plaintext vars (dashboard only)

Wrangler CLI can't delete plain-text env vars; this is a dashboard-only operation. Repeat for both workers:

1. Open https://dash.cloudflare.com → **Workers & Pages** → the worker
2. **Settings** → **Variables and Secrets**
3. Under "Environment Variables" (plain text), find `JWT_SECRET` → **Delete**
4. Same for `JWT_REFRESH_SECRET` → **Delete**

> **Auth downtime starts here.** Every auth request to that worker now returns a 500 because the binding doesn't exist.

### Step 2 — put them back as secrets (CLI)

From `packages/backend` on a checkout that has this PR's branch (or current `v2` after this merges — either works), generate fresh random values and write them as secret_text bindings:

```bash
# Production worker (uses wrangler.toml by default)
echo "$(openssl rand -base64 48)" | npx wrangler secret put JWT_SECRET
echo "$(openssl rand -base64 48)" | npx wrangler secret put JWT_REFRESH_SECRET

# Staging worker
echo "$(openssl rand -base64 48)" | npx wrangler secret put JWT_SECRET --config wrangler.staging.toml
echo "$(openssl rand -base64 48)" | npx wrangler secret put JWT_REFRESH_SECRET --config wrangler.staging.toml
```

> **Auth downtime ends** the moment each `secret put` returns. Worker now has the secret_text bindings, signs fresh JWTs immediately. Every JWT issued before this is now invalid (signature mismatch); beta users on the affected worker get a 401 and need to log in again.

### Step 3 — verify

```bash
npx wrangler secret list
npx wrangler secret list --config wrangler.staging.toml
```

Each command should return three entries, all type `secret_text`:

```
- JWT_SECRET (secret_text)
- JWT_REFRESH_SECRET (secret_text)
- RESEND_API_KEY (secret_text)
```

If `JWT_SECRET` or `JWT_REFRESH_SECRET` is missing or shows a different type, stop and fix before merging.

### Step 4 — merge this PR

Now safe to merge. The toml no longer declares the secrets in `[vars]`, and the live workers have them as out-of-band secret_text bindings that `wrangler deploy` won't touch.

### Step 5 — first deploy after merge

When you next push v2 → main (auto-deploys staging) or trigger a manual production deploy:
- Wrangler reads the cleaned toml — no `JWT_SECRET` in `[vars]`
- Deploy succeeds, secret_text bindings remain untouched
- Auth keeps working

Smoke test post-deploy:

```bash
curl -s -X POST https://api.chinmayajanata.org/api/auth/authenticate \
  -H "Content-Type: application/json" \
  -d '{"username":"someone","password":"wrong"}'
# Should return 401 with {"message":"Invalid credentials"}, NOT 500.
```

A 500 here means a secret is missing. Fix before continuing.

## Rollback

If you discover at any point that auth is fully broken (worker returning 500 on every auth route), the fastest rollback is to set the secret to ANY value via the dashboard or `wrangler secret put` — the worker will start signing JWTs again immediately. Then debug why.

## Two booby traps to NOT do

- **Don't put the rotated values into `wrangler.toml`'s `[vars]` block.** That re-commits a secret to git history.
- **Don't merge this PR before step 3's verification passes.** The whole point of this runbook is that auth survives the next deploy.

## What this PR doesn't do

- Doesn't rotate any existing secret values (you've already done that via the dashboard)
- Doesn't touch local `.dev.vars` (those still hold local test secrets, unaffected)
- Doesn't change how the worker reads secrets at runtime — `c.env.JWT_SECRET` works the same whether the binding is plain_text or secret_text

## Original context

Both `packages/backend/wrangler.toml` (prod) and `wrangler.staging.toml` originally had `JWT_SECRET` and `JWT_REFRESH_SECRET` committed in plaintext as `dev-secret-key-change-in-production` and `dev-refresh-secret-key-change-in-production`. These strings are in the git history. Any worker that was deployed without `wrangler secret put` having been run first would have shipped signing JWTs with those known-public defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
