### PR TITLE
chore(tests): drive test setup off real migrations + drop dead husky hooks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-yarn test

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -1,181 +1,117 @@
 /**
  * setup.ts
  *
- * Test setup: applies D1 migrations before each test suite.
+ * Test setup: applies the real D1 migrations from `migrations/*.sql` against
+ * the cloudflare:test in-memory D1 before each test. Two transforms happen
+ * on the way in:
+ *
+ *   1. Data statements (INSERT/UPDATE) are dropped. Tests start empty;
+ *      production seed data would slow things down and conflict with
+ *      tests that count rows.
+ *   2. FK `REFERENCES … ON DELETE …` clauses are stripped. The cloudflare
+ *      vitest pool doesn't honor `PRAGMA foreign_keys = OFF`, so circular
+ *      FKs (users.invite_code ↔ invite_codes.created_by_user_id) break
+ *      DROP TABLE in `dropAllTables()`. Real prod migrations keep the FKs.
+ *
+ * Loading the SQL files at runtime means new migrations are picked up
+ * automatically — no hand-maintained mirror in this file.
  */
-import {
-  env,
-  createExecutionContext,
-  waitOnExecutionContext,
-} from 'cloudflare:test'
+import { env } from 'cloudflare:test'
 
-const MIGRATION = `
--- FK constraints are dropped in the test schema to avoid a circular ref
--- between invite_codes.created_by_user_id and users.invite_code at
--- table-drop time (D1 doesn't honor PRAGMA foreign_keys = OFF inside
--- the test pool). The production migration still enforces them.
-CREATE TABLE IF NOT EXISTS invite_codes (
-  code              TEXT PRIMARY KEY,
-  label             TEXT NOT NULL,
-  verification_level INTEGER NOT NULL DEFAULT 45,
-  is_active         INTEGER NOT NULL DEFAULT 1,
-  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  created_by_user_id TEXT,
-  expires_at        TEXT,
-  max_uses          INTEGER,
-  uses_count        INTEGER NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS idx_invite_codes_creator ON invite_codes(created_by_user_id);
+/** Raw SQL files loaded at build time. Key = full path, value = file content. */
+const MIGRATION_FILES = import.meta.glob('../../../../migrations/*.sql', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
 
-CREATE TABLE IF NOT EXISTS users (
-  id              TEXT PRIMARY KEY,
-  username        TEXT NOT NULL UNIQUE COLLATE NOCASE,
-  password        TEXT NOT NULL,
-  email           TEXT COLLATE NOCASE,
-  first_name      TEXT NOT NULL DEFAULT '',
-  last_name       TEXT NOT NULL DEFAULT '',
-  date_of_birth   TEXT,
-  phone_number    TEXT,
-  profile_image   TEXT,
-  bio             TEXT,
-  center_id       TEXT REFERENCES centers(id) ON DELETE SET NULL,
-  points          INTEGER NOT NULL DEFAULT 0,
-  is_verified     INTEGER NOT NULL DEFAULT 0,
-  verification_level INTEGER NOT NULL DEFAULT 45,
-  is_active       INTEGER NOT NULL DEFAULT 0,
-  profile_complete INTEGER NOT NULL DEFAULT 0,
-  interests       TEXT,
-  invite_code     TEXT,
-  email_verified_at TEXT,
-  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
-);
-CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
-CREATE INDEX IF NOT EXISTS idx_users_center   ON users(center_id);
-
-CREATE TABLE IF NOT EXISTS email_verification_tokens (
-  token       TEXT PRIMARY KEY,
-  user_id     TEXT NOT NULL,
-  expires_at  TEXT NOT NULL,
-  consumed_at TEXT,
-  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-);
-CREATE INDEX IF NOT EXISTS idx_email_tokens_user ON email_verification_tokens(user_id);
-
-CREATE TABLE IF NOT EXISTS centers (
-  id              TEXT PRIMARY KEY,
-  name            TEXT NOT NULL,
-  latitude        REAL NOT NULL DEFAULT 0,
-  longitude       REAL NOT NULL DEFAULT 0,
-  address         TEXT,
-  website         TEXT,
-  phone           TEXT,
-  image           TEXT,
-  acharya         TEXT,
-  point_of_contact TEXT,
-  member_count    INTEGER NOT NULL DEFAULT 0,
-  is_verified     INTEGER NOT NULL DEFAULT 0,
-  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
-);
-CREATE INDEX IF NOT EXISTS idx_centers_name ON centers(name);
-
-CREATE TABLE IF NOT EXISTS events (
-  id              TEXT PRIMARY KEY,
-  title           TEXT NOT NULL DEFAULT '',
-  description     TEXT NOT NULL DEFAULT '',
-  date            TEXT NOT NULL,
-  latitude        REAL NOT NULL DEFAULT 0,
-  longitude       REAL NOT NULL DEFAULT 0,
-  address         TEXT,
-  center_id       TEXT REFERENCES centers(id) ON DELETE SET NULL,
-  tier            INTEGER NOT NULL DEFAULT 0,
-  people_attending INTEGER NOT NULL DEFAULT 0,
-  point_of_contact TEXT,
-  image           TEXT,
-  category        INTEGER,
-  end_date        TEXT,
-  is_recurring    INTEGER NOT NULL DEFAULT 0,
-  external_url    TEXT,
-  signup_url      TEXT,
-  allow_janata_signup INTEGER NOT NULL DEFAULT 0,
-  created_by      TEXT REFERENCES users(id) ON DELETE SET NULL,
-  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
-);
-CREATE INDEX IF NOT EXISTS idx_events_center ON events(center_id);
-CREATE INDEX IF NOT EXISTS idx_events_date   ON events(date);
-
-CREATE TABLE IF NOT EXISTS event_attendees (
-  event_id        TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-  user_id         TEXT NOT NULL REFERENCES users(id)  ON DELETE CASCADE,
-  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (event_id, user_id)
-);
-CREATE INDEX IF NOT EXISTS idx_ea_user  ON event_attendees(user_id);
-CREATE INDEX IF NOT EXISTS idx_ea_event ON event_attendees(event_id);
-
-CREATE TABLE IF NOT EXISTS event_endorsers (
-  event_id        TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-  user_id         TEXT NOT NULL REFERENCES users(id)  ON DELETE CASCADE,
-  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (event_id, user_id)
-);
-CREATE INDEX IF NOT EXISTS idx_ee_user  ON event_endorsers(user_id);
-CREATE INDEX IF NOT EXISTS idx_ee_event ON event_endorsers(event_id);
-`
-
-/** Test invite code seeded after migration */
-export const TEST_INVITE_CODE = 'TEST-BETA'
-
-/**
- * Run the D1 migration. Call this in beforeAll() or beforeEach().
- */
-export async function applyMigration(): Promise<void> {
-  const db = env.DB
-  const statements = MIGRATION.split(';')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-
-  for (const stmt of statements) {
-    await db.prepare(stmt).run()
-  }
-
-  // Seed a test invite code for registration tests
-  await db.prepare(
-    `INSERT OR IGNORE INTO invite_codes (code, label, verification_level, is_active) VALUES (?, ?, ?, ?)`
-  ).bind(TEST_INVITE_CODE, 'Test Beta', 45, 1).run()
+/** Strip `REFERENCES <table>(<col>) [ON DELETE …] [ON UPDATE …]` clauses. */
+function stripForeignKeys(stmt: string): string {
+  return stmt.replace(
+    /\s*REFERENCES\s+\w+\s*\([^)]+\)(?:\s+ON\s+(?:DELETE|UPDATE)\s+(?:SET\s+(?:NULL|DEFAULT)|CASCADE|RESTRICT|NO\s+ACTION))*/gi,
+    '',
+  )
 }
 
 /**
- * Drop all tables. Call this in afterEach() for clean isolation.
- *
- * invite_codes and users have a circular FK (users.invite_code ↔
- * invite_codes.created_by_user_id), so we disable FK checks during the
- * drop sequence and re-enable after.
+ * Split a migration file into individual statements, keeping only schema
+ * ones (CREATE/ALTER/DROP TABLE/INDEX). Comments and blank lines are
+ * dropped. INSERT/UPDATE statements (seed data) are skipped.
+ */
+function extractSchemaStatements(sql: string): string[] {
+  return sql
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    // Strip leading -- comments inside each statement so we can match the head
+    .map((s) =>
+      s
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('--'))
+        .join('\n')
+        .trim(),
+    )
+    .filter((s) => s.length > 0)
+    .filter((s) => {
+      const head = s.slice(0, 60).toUpperCase()
+      return (
+        head.startsWith('CREATE TABLE') ||
+        head.startsWith('CREATE INDEX') ||
+        head.startsWith('CREATE UNIQUE') ||
+        head.startsWith('ALTER TABLE') ||
+        head.startsWith('DROP TABLE') ||
+        head.startsWith('DROP INDEX')
+      )
+    })
+    .map(stripForeignKeys)
+}
+
+/** Cached list of schema statements, ordered by migration filename. */
+const SCHEMA_STATEMENTS: string[] = Object.entries(MIGRATION_FILES)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .flatMap(([, sql]) => extractSchemaStatements(sql))
+
+/** Table names referenced by CREATE TABLE, in creation order. */
+const CREATED_TABLES: string[] = SCHEMA_STATEMENTS.flatMap((s) => {
+  const m = /^CREATE TABLE(?:\s+IF NOT EXISTS)?\s+(\w+)/i.exec(s)
+  return m ? [m[1]] : []
+})
+
+/** Test invite code seeded after migration. */
+export const TEST_INVITE_CODE = 'TEST-BETA'
+
+/**
+ * Apply the real D1 migrations (schema-only, FKs stripped) to the test DB.
+ * Call from beforeEach.
+ */
+export async function applyMigration(): Promise<void> {
+  const db = env.DB
+  for (const stmt of SCHEMA_STATEMENTS) {
+    await db.prepare(stmt).run()
+  }
+  // Seed a test invite code for registration tests.
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO invite_codes (code, label, verification_level, is_active) VALUES (?, ?, ?, ?)`,
+    )
+    .bind(TEST_INVITE_CODE, 'Test Beta', 45, 1)
+    .run()
+}
+
+/**
+ * Drop every table created by the migrations, in reverse creation order
+ * so child tables go first. FKs are stripped from the test schema so
+ * order isn't strictly required, but keeping the reverse order is cheap
+ * insurance.
  */
 export async function dropAllTables(): Promise<void> {
   const db = env.DB
-  const tables = [
-    'event_endorsers',
-    'event_attendees',
-    'events',
-    'email_verification_tokens',
-    'invite_codes',
-    'users',
-    'centers',
-  ]
-  for (const table of tables) {
+  for (const table of [...CREATED_TABLES].reverse()) {
     await db.prepare(`DROP TABLE IF EXISTS ${table}`).run()
   }
 }
 
-/**
- * Helper: make a request to the Hono app with proper env bindings.
- */
-export function makeRequest(
-  path: string,
-  init?: RequestInit,
-): Request {
+/** Helper: make a request to the Hono app with proper env bindings. */
+export function makeRequest(path: string, init?: RequestInit): Request {
   return new Request(`http://localhost${path}`, init)
 }


### PR DESCRIPTION
## Summary

Two structural cleanups bundled into one small PR.

### 1. \`packages/backend/src/__tests__/setup.ts\` no longer hand-maintains the schema

Old setup.ts inlined the full D1 schema as a TypeScript string with FK constraints stripped. Adding a column to a migration meant remembering to mirror the change here — we hit that drift twice in the last few weeks (0016 email_verification, 0018 password_reset_codes from PR #224).

After this PR, setup.ts loads \`migrations/*.sql\` via Vite \`?raw\` imports, filters to schema statements (skipping seed INSERTs / corrective UPDATEs), strips FK \`REFERENCES … ON DELETE …\` clauses (the cloudflare:test pool doesn't honor \`PRAGMA foreign_keys = OFF\`, so circular FKs would break \`dropAllTables\`), and derives the drop-table list from the loaded CREATE TABLE statements.

**Net:** new migrations are picked up automatically. No more two-place edits.

\`\`\`
diff --git a/.../setup.ts -86 lines, +50 lines (hand-maintained string → loader)
\`\`\`

### 2. Delete \`.husky/pre-commit\` and \`.husky/pre-push\`

Both were dead and broken:
- \`pre-commit\`: empty 0-byte file, mode 0644 (so git warned \"hook ignored because not executable\" on every commit)
- \`pre-push\`: literally contained the string \`yarn test\` even though this is an npm project

Husky isn't a declared dependency anywhere in the repo's package.json. Nobody was actually running these hooks. Deleting them ends the warning and clears the dead code.

## Test plan

- [x] \`cd packages/backend && npm test\` → **285 / 285 pass** (same as baseline), 4.69s (was ~4.18s — negligible)
- [x] Tests now exercise the same schema as prod migrations apply
- [ ] After merging, clear the stale machine-local hooks pointer:
  \`\`\`
  git config --local --unset core.hooksPath
  \`\`\`
  Without this you'll still see \"hook ignored\" warnings until husky is properly installed.

## Drift remaining

This PR removes column-level drift. Two other test-infra drifts still exist (out of scope for this PR):
- Migrations \`0002\`, \`0007\`, \`0008\`, \`0010\`, \`0012\` contain seed data that tests *don't* run. If a future schema change is buried inside one of those files alongside the data statements, the filter would skip it. Mitigation: keep schema and data in separate migration files.
- Vitest and Jest still have separate setup files (\`setup.ts\` vs \`jest.setup.ts\`). Component tests under \`src/__tests__/app/\` don't see this migration loader. Bigger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)