### PR TITLE
chore(frontend): augment LucideProps to recognize color/strokeWidth/style/className

### DIFF
--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -8,6 +8,7 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts",
-    "nativewind-env.d.ts"
+    "nativewind-env.d.ts",
+    "types/**/*.d.ts"
   ]
 }

--- a/packages/frontend/types/lucide-augment.d.ts
+++ b/packages/frontend/types/lucide-augment.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Module augmentation for lucide-react-native@1.8.
+ *
+ * LucideProps formally extends react-native-svg's SvgProps, which declares
+ * `color?: ColorValue`. But under our React 19 / RN 0.83 toolchain TypeScript
+ * resolves `LucideProps & RefAttributes<SVGSVGElement>` without picking up
+ * the SvgProps members, so `<ChevronRight color="#000" />` fails to type-check
+ * across ~200 call sites — even though the prop works correctly at runtime.
+ *
+ * `strokeWidth` and `className` are similarly accepted at runtime (via
+ * SvgProps and NativeWind respectively) but missing from the resolved type.
+ *
+ * Adding them here augments the existing LucideProps interface without
+ * touching call sites. If a future lucide-react-native release fixes the
+ * type resolution upstream, delete this file.
+ */
+import 'lucide-react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
+
+declare module 'lucide-react-native' {
+  interface LucideProps {
+    color?: string
+    strokeWidth?: string | number
+    className?: string
+    style?: StyleProp<ViewStyle>
+  }
+}


### PR DESCRIPTION
## Summary

Drops frontend TypeScript errors from **240 → 29** with one 13-line type-augmentation file. No call-site changes, no runtime change, no API surface change.

## What's going on

\`LucideProps\` in \`lucide-react-native@1.8.0\` formally extends \`SvgProps\` from \`react-native-svg\`, and \`SvgProps\` declares \`color\`, \`style\`, etc. But under our React 19 + RN 0.83 toolchain, TypeScript resolves

\`\`\`
LucideProps & RefAttributes<SVGSVGElement>
\`\`\`

without picking up the SvgProps members. Result: ~210 errors across ~50 files for code that works fine at runtime, like:

\`\`\`tsx
<ChevronRight size={20} color={'#fff'} />
<House size={size} color={color} />            // standard expo-router pattern
<Search size={18} style={{ marginRight: 8 }} />
\`\`\`

NativeWind's \`className\` has the same issue.

## What this PR does

Adds \`packages/frontend/types/lucide-augment.d.ts\` — a module augmentation that re-declares LucideProps with the four props callers actually use:

\`\`\`ts
declare module 'lucide-react-native' {
  interface LucideProps {
    color?: string
    strokeWidth?: string | number
    className?: string
    style?: StyleProp<ViewStyle>
  }
}
\`\`\`

Plus a one-line tsconfig change so it gets picked up.

## Counts

\`\`\`
npx tsc --noEmit -p packages/frontend
- before: 240 errors
- after:   29 errors  (-88%)
\`\`\`

The remaining 29 are real type bugs in **unrelated** code:
- \`UserContext.tsx\` — PostHog \`JsonType\` property mismatch (~8 errors)
- \`ThreadPanel.tsx\` — \`PersonSummary.role\` doesn't exist
- \`form.web.tsx\`, \`EventFormPanel.web.tsx\` — TextInput overload issues

Those are separate cleanups, not in scope.

## Why augmentation, not a wrapper

I considered building a \`<Icon Component={Foo} ... />\` wrapper component. It would have required touching ~50 files with hundreds of call-site edits, risked visual regressions, and changed the API for icon usage. The augmentation gets the same TS benefit with zero call-site churn and is one rm command away if a future lucide release fixes the upstream type resolution.

## Test plan

- [x] \`npx tsc --noEmit -p packages/frontend\` → 29 errors (was 240)
- [x] No runtime changes — pure type-level augmentation
- [ ] Reviewer: confirm icons still render in the running app (they will — no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)