### PR TITLE
chore(frontend): clear remaining 29 TS errors + drop phantom worklets root dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "node-gyp": "^11.0.0",
         "react": "19.2.0",
         "react-native": "0.83.4",
-        "react-native-worklets": "^0.8.1",
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
@@ -15850,31 +15849,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
-    },
-    "node_modules/react-native-worklets": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
-      "integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
-        "react": "*",
-        "react-native": "0.81 - 0.85"
-      }
     },
     "node_modules/react-native/node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "node-gyp": "^11.0.0",
     "react": "19.2.0",
     "react-native": "0.83.4",
-    "react-native-worklets": "^0.8.1",
     "tailwindcss": "^3.4.19"
   },
   "overrides": {

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -632,7 +632,6 @@ export default function EventFormPage() {
                 trackColor={{ true: '#E8862A', false: colors.border }}
                 thumbColor="#FFFFFF"
                 ios_backgroundColor={colors.border}
-                activeThumbColor="#FFFFFF"
               />
             </View>
           ) : null}

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -339,7 +339,12 @@ export function BoardPostCard({
                       color: '#C2410C',
                     }}
                   >
-                    {message.author.role || 'SEVAK'}
+                    {/* The author.verification === 'sevak' guard above means the label
+                        is always SEVAK in this branch. PersonSummary used to have a
+                        free-form `role` string that overrode the label; it was
+                        consolidated into the `verification` enum, so the fallback is
+                        the only path now. */}
+                    SEVAK
                   </Text>
                 ) : null}
                 {!isFeedCard && message.pinned ? <Pill label="Pinned" colors={colors} /> : null}

--- a/packages/frontend/components/contexts/UserContext.tsx
+++ b/packages/frontend/components/contexts/UserContext.tsx
@@ -93,10 +93,13 @@ const resolveEndpointUrl = (endpoint: string): string => {
 
 /** Helper to build the PostHog person properties from a User object */
 const userTraits = (u: User) => ({
-  email: u.email,
-  firstName: u.firstName,
-  lastName: u.lastName,
-  profileComplete: u.profileComplete,
+  // PostHog's PostHogEventProperties doesn't accept `undefined`, only null /
+  // string / number / boolean. The User type marks several fields optional,
+  // so coerce undefined→null at the boundary.
+  email: u.email ?? null,
+  firstName: u.firstName ?? null,
+  lastName: u.lastName ?? null,
+  profileComplete: u.profileComplete ?? false,
 })
 
 export const UserProvider = ({ children }: { children: ReactNode }) => {
@@ -109,7 +112,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const login = useCallback(async (username: string, password: string) => {
     const result = await authService.login(username, password)
     if (!result.success) {
-      posthog?.capture('login_failed', { reason: result.message })
+      posthog?.capture('login_failed', { reason: result.message ?? null })
       return { success: false, message: result.message }
     }
 
@@ -125,7 +128,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const signup = useCallback(async (username: string, password: string, inviteCode?: string) => {
     const result = await authService.signup(username, password, inviteCode)
     if (!result.success || !result.user) {
-      posthog?.capture('signup_failed', { reason: result.message })
+      posthog?.capture('signup_failed', { reason: result.message ?? null })
       return { success: false, message: result.message || 'Signup failed. Please try again.' }
     }
 
@@ -198,7 +201,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const deleteAccount = useCallback(async () => {
     const result = await authService.deleteAccount()
     if (!result.success) {
-      posthog?.capture('delete_account_failed', { reason: result.message })
+      posthog?.capture('delete_account_failed', { reason: result.message ?? null })
       return { success: false, message: result.message || 'Failed to delete account' }
     }
 
@@ -223,7 +226,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     if (!result.success || !result.user) {
       // Rollback optimistic update on failure
       setUser(previousUser)
-      posthog?.capture('profile_update_failed', { reason: result.message })
+      posthog?.capture('profile_update_failed', { reason: result.message ?? null })
       return { success: false, message: result.message || 'Failed to update profile' }
     }
 

--- a/packages/frontend/components/events/EventFormPanel.web.tsx
+++ b/packages/frontend/components/events/EventFormPanel.web.tsx
@@ -682,7 +682,6 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
                 trackColor={{ true: '#E8862A', false: colors.border }}
                 thumbColor="#FFFFFF"
                 ios_backgroundColor={colors.border}
-                activeThumbColor="#FFFFFF"
               />
             </View>
           ) : null}

--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -422,7 +422,9 @@ function InfiniteScrollColumn({
   )
 }
 
-const TEAM = [
+type TeamMember = { name: string; image: any; color?: string }
+
+const TEAM: TeamMember[] = [
   { name: 'Abhiram', image: require('../../assets/images/landing/abhiram.jpg') },
   { name: 'Kish', image: require('../../assets/images/landing/kish.jpg') },
   { name: 'Sahanav', image: require('../../assets/images/landing/sahanav.jpg') },
@@ -453,7 +455,7 @@ function AvatarStack() {
                 width: 38,
                 height: 38,
                 borderRadius: 19,
-                backgroundColor: person.color,
+                backgroundColor: person.color ?? '#9CA3AF',
                 borderWidth: 2,
                 borderColor: '#FAFAF7',
                 alignItems: 'center',

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -107,10 +107,13 @@ function SettingsPanel({ visible, onClose, onLogout }) {
 
   return (
     <>
-      {/* Backdrop */}
+      {/* Backdrop. position: 'fixed' is web CSS — honored by react-native-web
+          at runtime but not in RN's ViewStyle type. This component renders
+          inside WebHeader (web-only branch in app/(tabs)/_layout.tsx), so
+          the cast is safe. */}
       <Pressable
         style={{
-          position: 'fixed',
+          position: 'fixed' as 'absolute',
           top: 0,
           left: 0,
           right: 0,
@@ -123,7 +126,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
       {/* Settings Panel */}
       <Animated.View
         style={{
-          position: 'fixed',
+          position: 'fixed' as 'absolute',
           top: 56,
           right: 16,
           zIndex: 100,

--- a/packages/frontend/src/__tests__/api.test.ts
+++ b/packages/frontend/src/__tests__/api.test.ts
@@ -4,9 +4,53 @@
  * Covers API_URL generation, fetch helpers, caching, and data normalization.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { CenterData, EventData } from '../../utils/api'
 
 // We need to be able to re-import the module with different Platform/DEV settings,
 // so we'll use dynamic imports and resetModules where needed.
+
+// ── Fixture builders ───────────────────────────────────────────────────
+// Build full CenterData/EventData objects so tests stay type-correct as the
+// types evolve. Tests pass only the fields they care about; defaults fill the
+// rest with sensible nulls matching the wire shape from the backend.
+
+function makeCenter(overrides: Partial<CenterData> = {}): CenterData {
+  return {
+    centerID: '',
+    name: '',
+    latitude: 0,
+    longitude: 0,
+    address: null,
+    website: null,
+    phone: null,
+    image: null,
+    acharya: null,
+    pointOfContact: null,
+    memberCount: 0,
+    isVerified: false,
+    ...overrides,
+  }
+}
+
+function makeEvent(overrides: Partial<EventData> = {}): EventData {
+  return {
+    eventID: '',
+    title: '',
+    description: '',
+    date: '2025-01-01',
+    latitude: 0,
+    longitude: 0,
+    address: null,
+    centerID: null,
+    tier: 1,
+    peopleAttending: 0,
+    pointOfContact: null,
+    image: null,
+    category: null,
+    createdBy: null,
+    ...overrides,
+  }
+}
 
 // ── Global fetch mock ──────────────────────────────────────────────────
 const mockFetch = vi.fn()
@@ -441,8 +485,8 @@ describe('centersToMapPoints', () => {
 
   it('converts centers with lat/lng to map points', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0, address: null, memberCount: 10, isVerified: true },
-      { centerID: '2', name: 'B', latitude: 38.0, longitude: -121.0, address: 'Addr', memberCount: 5, isVerified: false },
+      makeCenter({ centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0, memberCount: 10, isVerified: true }),
+      makeCenter({ centerID: '2', name: 'B', latitude: 38.0, longitude: -121.0, address: 'Addr', memberCount: 5, isVerified: false }),
     ]
     const result = api.centersToMapPoints(centers)
     expect(result).toHaveLength(2)
@@ -451,8 +495,8 @@ describe('centersToMapPoints', () => {
 
   it('keeps entries with latitude=0 (valid coordinate)', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 0, longitude: -122.0, address: null, memberCount: 10, isVerified: true },
-      { centerID: '2', name: 'B', latitude: 38.0, longitude: -121.0, address: null, memberCount: 5, isVerified: false },
+      makeCenter({ centerID: '1', name: 'A', latitude: 0, longitude: -122.0, memberCount: 10, isVerified: true }),
+      makeCenter({ centerID: '2', name: 'B', latitude: 38.0, longitude: -121.0, memberCount: 5, isVerified: false }),
     ]
     const result = api.centersToMapPoints(centers)
     expect(result).toHaveLength(2)
@@ -460,7 +504,7 @@ describe('centersToMapPoints', () => {
 
   it('keeps entries with longitude=0 (valid coordinate)', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 37.0, longitude: 0, address: null, memberCount: 10, isVerified: true },
+      makeCenter({ centerID: '1', name: 'A', latitude: 37.0, longitude: 0, memberCount: 10, isVerified: true }),
     ]
     const result = api.centersToMapPoints(centers)
     expect(result).toHaveLength(1)
@@ -468,7 +512,7 @@ describe('centersToMapPoints', () => {
 
   it('uses "Unknown Center" when name is empty', () => {
     const centers = [
-      { centerID: '1', name: '', latitude: 37.0, longitude: -122.0, address: null, memberCount: 0, isVerified: false },
+      makeCenter({ centerID: '1', name: '', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.centersToMapPoints(centers)
     expect(result[0].name).toBe('Unknown Center')
@@ -489,7 +533,7 @@ describe('eventsToMapPoints', () => {
 
   it('converts events with lat/lng to map points', () => {
     const events = [
-      { eventID: 'e1', title: 'Ev1', description: '', date: '2025-01-01', latitude: 37.0, longitude: -122.0, address: null, centerID: null, tier: 1, peopleAttending: 0, pointOfContact: null, image: null, category: null },
+      makeEvent({ eventID: 'e1', title: 'Ev1', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.eventsToMapPoints(events)
     expect(result).toHaveLength(1)
@@ -498,8 +542,8 @@ describe('eventsToMapPoints', () => {
 
   it('keeps entries with lat/lng=0 (valid coordinates)', () => {
     const events = [
-      { eventID: 'e1', title: 'Ev1', description: '', date: '2025-01-01', latitude: 0, longitude: -122.0, address: null, centerID: null, tier: 1, peopleAttending: 0, pointOfContact: null, image: null, category: null },
-      { eventID: 'e2', title: 'Ev2', description: '', date: '2025-01-01', latitude: 37.0, longitude: 0, address: null, centerID: null, tier: 1, peopleAttending: 0, pointOfContact: null, image: null, category: null },
+      makeEvent({ eventID: 'e1', title: 'Ev1', latitude: 0, longitude: -122.0 }),
+      makeEvent({ eventID: 'e2', title: 'Ev2', latitude: 37.0, longitude: 0 }),
     ]
     const result = api.eventsToMapPoints(events)
     expect(result).toHaveLength(2)
@@ -507,7 +551,7 @@ describe('eventsToMapPoints', () => {
 
   it('uses description as fallback when title is empty', () => {
     const events = [
-      { eventID: 'e1', title: '', description: 'Desc', date: '2025-01-01', latitude: 37.0, longitude: -122.0, address: null, centerID: null, tier: 1, peopleAttending: 0, pointOfContact: null, image: null, category: null },
+      makeEvent({ eventID: 'e1', description: 'Desc', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.eventsToMapPoints(events)
     expect(result[0].name).toBe('Desc')
@@ -515,7 +559,7 @@ describe('eventsToMapPoints', () => {
 
   it('uses "Event" when both title and description are empty', () => {
     const events = [
-      { eventID: 'e1', title: '', description: '', date: '2025-01-01', latitude: 37.0, longitude: -122.0, address: null, centerID: null, tier: 1, peopleAttending: 0, pointOfContact: null, image: null, category: null },
+      makeEvent({ eventID: 'e1', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.eventsToMapPoints(events)
     expect(result[0].name).toBe('Event')
@@ -536,7 +580,7 @@ describe('centersToDiscoverCenters', () => {
 
   it('transforms centers to DiscoverCenter format', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0, address: '123 St', memberCount: 10, isVerified: true },
+      makeCenter({ centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0, address: '123 St', memberCount: 10, isVerified: true }),
     ]
     const result = api.centersToDiscoverCenters(centers)
     expect(result).toEqual([
@@ -546,8 +590,8 @@ describe('centersToDiscoverCenters', () => {
 
   it('keeps entries with lat/lng=0 (valid coordinates)', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 0, longitude: -122.0, address: null, memberCount: 10, isVerified: true },
-      { centerID: '2', name: 'B', latitude: 37.0, longitude: -122.0, address: null, memberCount: 5, isVerified: false },
+      makeCenter({ centerID: '1', name: 'A', latitude: 0, longitude: -122.0, memberCount: 10, isVerified: true }),
+      makeCenter({ centerID: '2', name: 'B', latitude: 37.0, longitude: -122.0, memberCount: 5, isVerified: false }),
     ]
     const result = api.centersToDiscoverCenters(centers)
     expect(result).toHaveLength(2)
@@ -555,7 +599,7 @@ describe('centersToDiscoverCenters', () => {
 
   it('converts null address to undefined', () => {
     const centers = [
-      { centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0, address: null, memberCount: 10, isVerified: true },
+      makeCenter({ centerID: '1', name: 'A', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.centersToDiscoverCenters(centers)
     expect(result[0].address).toBeUndefined()
@@ -563,7 +607,7 @@ describe('centersToDiscoverCenters', () => {
 
   it('uses "Unknown Center" for empty name', () => {
     const centers = [
-      { centerID: '1', name: '', latitude: 37.0, longitude: -122.0, address: null, memberCount: 0, isVerified: false },
+      makeCenter({ centerID: '1', name: '', latitude: 37.0, longitude: -122.0 }),
     ]
     const result = api.centersToDiscoverCenters(centers)
     expect(result[0].name).toBe('Unknown Center')

--- a/packages/frontend/src/__tests__/app/events/[id].test.tsx
+++ b/packages/frontend/src/__tests__/app/events/[id].test.tsx
@@ -31,9 +31,12 @@ jest.mock('../../../../hooks/useDetailColors', () => ({
   })),
 }))
 
-const { useLocalSearchParams, useRouter } = jest.requireMock('expo-router')
-const { useEventDetail } = jest.requireMock('../../../../hooks/useApiData')
-const { useUser } = jest.requireMock('../../../../components/contexts')
+// jest.requireMock returns `unknown` by default; cast to the shape we
+// stub out in the vi.mock factories above so destructuring stays type-safe.
+type MockedModule = Record<string, jest.Mock>
+const { useLocalSearchParams, useRouter } = jest.requireMock('expo-router') as MockedModule
+const { useEventDetail } = jest.requireMock('../../../../hooks/useApiData') as MockedModule
+const { useUser } = jest.requireMock('../../../../components/contexts') as MockedModule
 
 const mockUseLocalSearchParams = useLocalSearchParams as jest.Mock
 const mockUseRouter = useRouter as jest.Mock


### PR DESCRIPTION
## Summary

Companion to #231 (lucide augment, 240 → 29). After this PR, \`npx tsc --noEmit -p packages/frontend\` reports **0 errors** — CI can enable typecheck without flooding.

Stacked on #231. Merge that first; this auto-retargets to v2.

## Per-file breakdown

### `src/__tests__/api.test.ts` — 12 errors

\`CenterData\` and \`EventData\` types had drifted from the test fixtures. Replaced inline literals with \`makeCenter()\` / \`makeEvent()\` fixture builders so call sites only specify the fields they care about; defaults fill the rest with sensible nulls matching the wire shape. Type changes in future will be caught immediately because the builders return the full type.

\`\`\`ts
function makeCenter(overrides: Partial<CenterData> = {}): CenterData { ... }
function makeEvent(overrides: Partial<EventData> = {}): EventData { ... }
\`\`\`

All 45 cases in api.test.ts still pass.

### `components/contexts/UserContext.tsx` — 7 errors

PostHog's \`PostHogEventProperties\` and \`JsonType\` don't accept \`undefined\`, only \`null\`. \`User.email\` / \`firstName\` / \`lastName\` / \`profileComplete\` are optional. Coerced undefined → null in \`userTraits()\` and on \`{ reason: result.message }\` capture calls.

### `src/__tests__/app/events/[id].test.tsx` — 4 errors

\`jest.requireMock()\` returns \`unknown\` by default. Cast each call to \`Record<string, jest.Mock>\` so the destructured names type-check.

### `components/settings/SettingsPanel.tsx` — 2 errors

\`position: 'fixed'\` is CSS, not in RN's \`ViewStyle.position\` union. react-native-web honors it at runtime, and this component only renders inside the web-only \`WebHeader\` branch of \`(tabs)/_layout.tsx\`. Cast \`'fixed' as 'absolute'\` with a comment.

### `app/events/form.web.tsx` + `components/events/EventFormPanel.web.tsx` — 2 errors

\`Switch.activeThumbColor\` doesn't exist in RN 0.83's type. Both call sites set it to \`"#FFFFFF"\` while \`thumbColor\` was already \`"#FFFFFF"\`. Removed — no runtime change.

### `components/boards/ThreadPanel.tsx` — 1 error

\`PersonSummary.role\` doesn't exist (consolidated into the \`verification\` enum). Surrounding code already guards on \`verification === 'sevak'\`, so the \`.role || 'SEVAK'\` fallback always evaluated to \`'SEVAK'\`. Replaced with the literal.

### `components/landing/Hero.tsx` — 1 error

\`TEAM\` array inferred as \`{ name; image }[]\` because no entry has a \`color\` field. Annotated \`TeamMember = { name; image; color? }\` with a \`?? '#9CA3AF'\` fallback on the (currently unreachable) color branch.

## Phantom dep cleanup

Removed \`react-native-worklets@^0.8.1\` from the **root** \`package.json\` dependencies. Nothing in the root code imports worklets directly — it's pulled in transitively by:

- \`react-native-reanimated@4.2.1\` (used by frontend, needs 0.7.2)
- \`expo-modules-core@55.0.22\` (needs 0.8.1, pulled in by expo)

The root declaration was creating an unnecessary version "mismatch" with \`packages/frontend\`'s \`^0.7.2\`. After removal:

\`\`\`
npm ls react-native-worklets
└── react-native-worklets@0.7.2  (deduped everywhere)
\`\`\`

## Verified

- [x] \`npx tsc --noEmit -p packages/frontend\` → **0 errors** (was 29)
- [x] \`cd packages/frontend && npx vitest run\` → 153/153 pass
- [x] \`npm ls react-native-worklets\` → single version, no \`invalid:\`

## Suggested follow-up (not in this PR)

Now that frontend TS is clean, add typecheck to CI:

\`\`\`yaml
- run: npx tsc --noEmit -p packages/frontend
- run: cd packages/backend && npm run typecheck
\`\`\`

Catches regressions immediately. Separate cleanup since CI config is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)