### PR TITLE
fix(explore): drop React.lazy(Map) on native — Metro monorepo crash

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -1,5 +1,5 @@
 // Discover tab — mobile / native layout
-import React, { useState, Suspense, useRef, useCallback, useMemo } from 'react'
+import React, { useState, useRef, useCallback, useMemo } from 'react'
 import { EmptyState } from '../../components/ui/EmptyState'
 import { DiscoverListSkeleton } from '../../components/ui/Skeleton'
 import {
@@ -7,7 +7,6 @@ import {
   Text,
   ScrollView,
   Pressable,
-  ActivityIndicator,
   TextInput,
   Animated,
   PanResponder,
@@ -32,8 +31,16 @@ import type { EventDisplay, DiscoverCenter, AttendeeInfo } from '../../utils/api
 import { extractCityState } from '../../utils/addressParsing'
 
 
-// Lazy load Map to avoid loading heavy web dependencies on mobile web
-const Map = React.lazy(() => import('../../components/map/Map'))
+// Map.native.tsx is the only file that bundles for native, so the
+// react-native-maps deps would never have been lazy-skippable here.
+// Lazy loading the chunk also crashes iOS in this monorepo setup:
+// Metro resolves lazy-chunk URLs from the workspace root instead of
+// packages/frontend/, returning 404 to the device and producing a
+// "Could not load bundle" render error.
+// See app/(tabs)/explore.web.tsx — web still lazy-loads Map there
+// because Map.web.tsx pulls in maplibre-gl (~800KB) and the bug is
+// Metro-specific.
+import Map from '../../components/map/Map'
 
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'Events' },
@@ -448,15 +455,7 @@ export default function DiscoverScreen() {
     >
       {/* Map — full bleed behind the sheet */}
       <View style={StyleSheet.absoluteFill}>
-        <Suspense
-          fallback={
-            <View className="flex-1 justify-center items-center bg-stone-100 dark:bg-neutral-800">
-              <ActivityIndicator size="large" color="#9A3412" />
-            </View>
-          }
-        >
-          <Map points={filteredPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} bottomPadding={90} />
-        </Suspense>
+        <Map points={filteredPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} bottomPadding={90} />
       </View>
 
       {/* Bottom Sheet — hidden until we measure the container */}


### PR DESCRIPTION
## Summary

Navigating to the Explore tab on iOS rendered \"Could not load bundle\" with a \`LoadBundleFromServerError\`. Root cause is a Metro monorepo bug, not a code defect — the cheapest fix is to drop the (unnecessary) lazy import on native.

## Repro

iOS simulator → /explore → red error screen:

> Render Error  
> Could not load bundle  
> ...  
> LoadBundleFromServerError

## Root cause

\`packages/frontend/app/(tabs)/explore.tsx\` was the only \`React.lazy\` call in the codebase:

\`\`\`tsx
const Map = React.lazy(() => import('../../components/map/Map'))
\`\`\`

When iOS triggered the lazy chunk request:

\`\`\`
GET /components/map/Map.bundle?platform=ios&lazy=true&...
\`\`\`

Metro tried to resolve \`./components/map/Map\` from \`/Users/kishparikh/Code/Project-Janatha/.\` (the monorepo root) instead of \`packages/frontend/\`. The file exists at \`packages/frontend/components/map/Map.native.tsx\` so Metro returned 404, which the device surfaced as \"Could not load bundle.\"

Reproduced with a direct curl:

\`\`\`
$ curl 'http://localhost:8081/components/map/Map.bundle?platform=ios&lazy=true...'
HTTP 404
{\"type\":\"UnableToResolveError\",
 \"originModulePath\":\"/Users/kishparikh/Code/Project-Janatha/.\",
 \"targetModuleName\":\"./components/map/Map\",
 \"message\":\"Unable to resolve module ./components/map/Map from /Users/kishparikh/Code/Project-Janatha/.\"}
\`\`\`

## Fix

Replaced \`React.lazy(() => import(...))\` with a plain import. Removed the now-unneeded \`Suspense\` wrapper and \`ActivityIndicator\` import.

The original \"avoid loading heavy web dependencies on mobile\" rationale didn't actually apply on native: Metro platform-resolves \`Map.native.tsx\` at bundle time; mobile never pulls in \`Map.web.tsx\`. Lazy was just deferring a chunk that didn't contain anything heavy.

## Important: web is intentionally unchanged

\`explore.web.tsx\` still lazy-loads Map. There, \`Map.web.tsx\` pulls in \`maplibre-gl\` (~800 KB), and the lazy-chunk URL resolution bug is **Metro-specific** — webpack handles it correctly. Lazy loading still pays off for web.

## Verified

- [x] iOS bundle compiles cleanly post-fix (\`/node_modules/expo-router/entry.bundle\` → HTTP 200, 16.1 MB)
- [x] \`Map.native.tsx\` now bundled into the main iOS chunk (verified via grep on the bundle output)
- [x] \`npx vitest run\` → 153 / 153 pass
- [x] \`npx tsc --noEmit -p packages/frontend\` → no new errors introduced

## Long-term

If you ever want \`React.lazy\` to work in monorepo lazy bundles, add \`server.rewriteRequestUrl\` to \`packages/frontend/metro.config.js\` that prefixes lazy chunk URLs with the workspace path. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)