### PR TITLE
fix(ui): PrimaryButton.native renders invisible on light bg

### DIFF
--- a/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
+++ b/packages/frontend/components/ui/buttons/PrimaryButton.native.tsx
@@ -1,14 +1,21 @@
 import React from 'react'
-import { ActivityIndicator, Pressable, Text } from 'react-native'
+import { ActivityIndicator, Pressable, Text, type StyleProp, type ViewStyle } from 'react-native'
 
 interface PrimaryButtonProps {
   children: React.ReactNode
   onPress?: () => void
   disabled?: boolean
   loading?: boolean
-  style?: object
+  style?: StyleProp<ViewStyle>
 }
 
+// Pressable supports a function-style `style={({pressed}) => ...}` callback,
+// but NativeWind's CssInterop doesn't process that form — the inline
+// backgroundColor gets stripped, leaving white-on-white text on the cream
+// auth background. Visible since the project moved to NativeWind 4.
+// Fix: drive static styling via className (which IS interop-processed) and
+// use `active:` for press feedback. Same pattern as the Developer Mode
+// button in app/auth.tsx that has always rendered correctly.
 export default function PrimaryButton({ children, onPress, disabled, loading, style }: PrimaryButtonProps) {
   const isDisabled = disabled || loading
 
@@ -16,23 +23,19 @@ export default function PrimaryButton({ children, onPress, disabled, loading, st
     <Pressable
       onPress={!isDisabled ? onPress : undefined}
       disabled={isDisabled}
-      style={({ pressed }) => [
-        {
-          backgroundColor: pressed ? '#D97520' : '#E8862A',
-          paddingHorizontal: 16,
-          paddingVertical: 14,
-          borderRadius: 999,
-          alignItems: 'center',
-          justifyContent: 'center',
-          opacity: isDisabled ? 0.5 : 1,
-        },
-        style,
-      ]}
+      className={[
+        'bg-primary',
+        'px-4 py-3.5 rounded-full',
+        'items-center justify-center',
+        'active:bg-primary-press',
+        isDisabled ? 'opacity-50' : '',
+      ].join(' ')}
+      style={style}
     >
       {loading ? (
         <ActivityIndicator size="small" color="#FFFFFF" />
       ) : (
-        <Text style={{ fontWeight: '500', fontSize: 15, lineHeight: 20, color: '#FFFFFF', textAlign: 'center' }}>
+        <Text className="text-white font-medium text-[15px] leading-5">
           {children}
         </Text>
       )}


### PR DESCRIPTION
## Summary

\`PrimaryButton.native.tsx\` used Pressable's function-style callback for inline styling:

\`\`\`tsx
style={({ pressed }) => [
  { backgroundColor: '#E8862A', ... },
  style,
]}
\`\`\`

NativeWind's CssInterop doesn't process the function-style form of \`Pressable.style\` — it strips the inline \`backgroundColor\` entirely. Result: the button renders as just white text floating on whatever the parent background is.

## Visible on every iOS-native screen using PrimaryButton

- \`app/auth.tsx\` — Continue / Log In / Verify Code / Sign Up
- \`app/auth/forgot.tsx\` — Send code / Reset password / Back to sign in (this PR's bug is what made the new password-reset UI in #225 look broken)
- \`app/events/[id].tsx\` — Attend on Janata / external signup
- \`app/events/form.tsx\` — Save
- \`components/ui/AuthPromptModal.tsx\` — primary CTA

The bug was hidden on dark backgrounds (white-on-dark is readable even without the orange pill), which is why nobody caught it during dark-mode iOS testing.

## Fix

Drive static styling via \`className\` (which CssInterop DOES process) and use the \`active:\` variant for press feedback. Same pattern as the Developer Mode button in \`app/auth.tsx\` that has always rendered correctly.

\`\`\`tsx
className=\"bg-primary px-4 py-3.5 rounded-full
           items-center justify-center
           active:bg-primary-press
           [opacity-50 when disabled]\"
\`\`\`

\`bg-primary\` resolves to \`#E8862A\` and \`bg-primary-press\` to \`#D97520\` from \`tailwind.config.js\` — identical visual to the previous inline hex values.

Also tightened the prop type: \`style?: object\` → \`StyleProp<ViewStyle>\`.

## Verified

- [x] \`npx tsc --noEmit -p packages/frontend\` → 0 errors
- [x] \`npx vitest run\` → 153/153 pass
- [x] iOS simulator: orange pill renders on auth Continue button (was invisible white-on-cream pre-fix, screenshots in PR thread for #225)

## Out of scope

\`PrimaryButton.web.tsx\` doesn't have this bug — web uses its own \`<button>\` styling and isn't subject to CssInterop. Not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)