### PR TITLE
fix(forgot-password/web): use border longhand to silence React warning

### DIFF
--- a/migrations/0018_password_reset_codes.sql
+++ b/migrations/0018_password_reset_codes.sql
@@ -1,0 +1,22 @@
+-- 0018_password_reset_codes.sql
+-- One-time codes for the self-serve password reset flow.
+--
+-- See docs/plans/2026-05-24-password-reset.md.
+--
+-- The token-version mechanism mentioned in the design doc is not needed:
+-- JWTs now embed a fingerprint of users.password (auth.ts `passwordFingerprint`),
+-- so updating password in the reset handler invalidates every live JWT for
+-- that user on the next authenticated request.
+
+CREATE TABLE IF NOT EXISTS password_reset_codes (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  code_hash   TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  used_at     TEXT,
+  attempts    INTEGER NOT NULL DEFAULT 0,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_prc_user_active
+  ON password_reset_codes(user_id, expires_at);

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { SignJWT } from 'jose'
 import { applyMigration, dropAllTables, TEST_INVITE_CODE } from './setup'
 import { app } from '../app'
 import { hashPassword } from '../auth'
@@ -292,6 +293,46 @@ describe('GET /api/auth/verify', () => {
       headers: { Authorization: 'Bearer invalidtoken' },
     })
     expect(res.status).toBe(403)
+  })
+
+  it('rejects token after password rotation (401, tv mismatch)', async () => {
+    // Mint a token, then rotate the password directly in the DB to simulate
+    // a password reset. The old token's tv claim should no longer match.
+    const { token } = await registerAndLogin('rotatepw', 'password123')
+    const newHash = await hashPassword('different-password')
+    await env.DB.prepare('UPDATE users SET password = ? WHERE username = ?')
+      .bind(newHash, 'rotatepw')
+      .run()
+
+    const { res, body } = await fetchJSON('/api/auth/verify', {
+      headers: authHeader(token),
+    })
+    expect(res.status).toBe(401)
+    expect(body.message).toMatch(/sign in again/i)
+  })
+
+  it('accepts legacy tokens that pre-date the tv claim', async () => {
+    // Register so the user row exists, then mint a JWT directly without a
+    // `tv` claim — same shape as tokens issued before this rollout.
+    await jsonPost('/api/auth/register', {
+      username: 'legacyuser',
+      password: 'password123',
+      inviteCode: TEST_INVITE_CODE,
+    })
+    const legacy = await new SignJWT({
+      id: 'ignored-by-middleware',
+      username: 'legacyuser',
+      type: 'access',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('30d')
+      .sign(new TextEncoder().encode(env.JWT_SECRET))
+
+    const { res } = await fetchJSON('/api/auth/verify', {
+      headers: authHeader(legacy),
+    })
+    expect(res.status).toBe(200)
   })
 })
 

--- a/packages/backend/src/__tests__/auth.test.ts
+++ b/packages/backend/src/__tests__/auth.test.ts
@@ -5,6 +5,7 @@
  * legacy bcrypt detection, and timing-safe comparison.
  */
 import { describe, it, expect } from 'vitest'
+import { SignJWT } from 'jose'
 import {
   hashPassword,
   verifyPassword,
@@ -12,12 +13,17 @@ import {
   generateRefreshToken,
   verifyToken,
   verifyRefreshToken,
+  passwordFingerprint,
 } from '../auth'
 
 const TEST_SECRET = 'test-jwt-secret-for-testing-only'
 const TEST_REFRESH_SECRET = 'test-jwt-refresh-secret-for-testing-only'
 
-const testUser = { id: 'u-test-1', username: 'testuser' }
+// Tokens are now fingerprinted off the password hash, so test fixtures need
+// a stored password too. The actual value doesn't matter for most tests —
+// only that the same hash is reused across calls that expect the same `tv`.
+const TEST_PASSWORD_HASH = '100000:c2FsdHNhbHRzYWx0c2FsdA==:aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaGhhc2g='
+const testUser = { id: 'u-test-1', username: 'testuser', password: TEST_PASSWORD_HASH }
 
 // ═══════════════════════════════════════════════════════════════════════
 // PASSWORD HASHING (PBKDF2)
@@ -207,8 +213,8 @@ describe('cross-verification', () => {
   })
 
   it('tokens with different users produce different payloads', async () => {
-    const user1 = { id: 'u-1', username: 'alice' }
-    const user2 = { id: 'u-2', username: 'bob' }
+    const user1 = { id: 'u-1', username: 'alice', password: TEST_PASSWORD_HASH }
+    const user2 = { id: 'u-2', username: 'bob', password: TEST_PASSWORD_HASH }
 
     const token1 = await generateToken(user1, TEST_SECRET)
     const token2 = await generateToken(user2, TEST_SECRET)
@@ -220,5 +226,76 @@ describe('cross-verification', () => {
     expect(payload1!.username).toBe('alice')
     expect(payload2!.id).toBe('u-2')
     expect(payload2!.username).toBe('bob')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// PASSWORD FINGERPRINT (tv claim)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('passwordFingerprint', () => {
+  it('returns 16 hex chars (64 bits)', async () => {
+    const fp = await passwordFingerprint(TEST_PASSWORD_HASH)
+    expect(fp).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('is deterministic for the same hash', async () => {
+    const fp1 = await passwordFingerprint(TEST_PASSWORD_HASH)
+    const fp2 = await passwordFingerprint(TEST_PASSWORD_HASH)
+    expect(fp1).toBe(fp2)
+  })
+
+  it('differs across different password hashes', async () => {
+    const hashA = await hashPassword('password-a')
+    const hashB = await hashPassword('password-b')
+    const fpA = await passwordFingerprint(hashA)
+    const fpB = await passwordFingerprint(hashB)
+    expect(fpA).not.toBe(fpB)
+  })
+
+  it('differs even when the same plaintext is rehashed (salt changes)', async () => {
+    const hash1 = await hashPassword('samepassword')
+    const hash2 = await hashPassword('samepassword')
+    const fp1 = await passwordFingerprint(hash1)
+    const fp2 = await passwordFingerprint(hash2)
+    expect(fp1).not.toBe(fp2)
+  })
+})
+
+describe('JWT tv claim', () => {
+  it('access token embeds tv matching the password fingerprint', async () => {
+    const token = await generateToken(testUser, TEST_SECRET)
+    const payload = await verifyToken(token, TEST_SECRET)
+    expect(payload!.tv).toBe(await passwordFingerprint(TEST_PASSWORD_HASH))
+  })
+
+  it('refresh token embeds tv matching the password fingerprint', async () => {
+    const token = await generateRefreshToken(testUser, TEST_REFRESH_SECRET)
+    const payload = await verifyRefreshToken(token, TEST_REFRESH_SECRET)
+    expect(payload!.tv).toBe(await passwordFingerprint(TEST_PASSWORD_HASH))
+  })
+
+  it('tokens for users with different passwords carry different tv', async () => {
+    const userA = { id: 'a', username: 'a', password: await hashPassword('one') }
+    const userB = { id: 'b', username: 'b', password: await hashPassword('two') }
+    const tokenA = await generateToken(userA, TEST_SECRET)
+    const tokenB = await generateToken(userB, TEST_SECRET)
+    const payloadA = await verifyToken(tokenA, TEST_SECRET)
+    const payloadB = await verifyToken(tokenB, TEST_SECRET)
+    expect(payloadA!.tv).not.toBe(payloadB!.tv)
+  })
+
+  it('JWT minted without tv claim still verifies (legacy compatibility)', async () => {
+    // Older tokens were issued before the rollout and don't carry tv.
+    // verifyToken should still accept them; the middleware's mismatch check
+    // skips when the claim is absent.
+    const legacy = await new SignJWT({ id: 'legacy', username: 'oldie', type: 'access' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('30d')
+      .sign(new TextEncoder().encode(TEST_SECRET))
+    const payload = await verifyToken(legacy, TEST_SECRET)
+    expect(payload).not.toBeNull()
+    expect(payload!.tv).toBeUndefined()
   })
 })

--- a/packages/backend/src/__tests__/passwordReset.test.ts
+++ b/packages/backend/src/__tests__/passwordReset.test.ts
@@ -1,0 +1,383 @@
+/**
+ * passwordReset.test.ts — coverage for the v2 self-serve reset flow.
+ *
+ * The flow is split across two endpoints. Tests against /request exercise
+ * the side effects (row inserted, prior codes invalidated) since the
+ * plaintext code is opaque after generation. Tests against /verify use
+ * manually-inserted rows with a known code so we can exercise the full
+ * matching path.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { applyMigration, dropAllTables, TEST_INVITE_CODE } from './setup'
+import { app } from '../app'
+import { hashPassword } from '../auth'
+import { clearRateLimits } from '../middleware'
+
+interface ResetRow {
+  id: string
+  user_id: string
+  code_hash: string
+  expires_at: string
+  used_at: string | null
+  attempts: number
+  created_at: string
+}
+
+async function fetchJSON(path: string, init?: RequestInit) {
+  const req = new Request(`http://localhost${path}`, init)
+  const ctx = createExecutionContext()
+  const res = await app.fetch(req, env, ctx)
+  await waitOnExecutionContext(ctx)
+  const text = await res.text()
+  let body: any = {}
+  try {
+    body = text ? JSON.parse(text) : {}
+  } catch {
+    body = { raw: text }
+  }
+  return { res, body }
+}
+
+function jsonPost(path: string, data: unknown) {
+  return fetchJSON(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+async function register(username: string, password = 'initialpw123') {
+  await jsonPost('/api/auth/register', {
+    username,
+    password,
+    inviteCode: TEST_INVITE_CODE,
+  })
+  const user = await env.DB.prepare(
+    'SELECT id, email FROM users WHERE username = ?',
+  )
+    .bind(username.toLowerCase())
+    .first<{ id: string; email: string }>()
+  return user!
+}
+
+async function loadActiveRow(userId: string): Promise<ResetRow | null> {
+  return await env.DB.prepare(
+    `SELECT id, user_id, code_hash, expires_at, used_at, attempts, created_at
+     FROM password_reset_codes
+     WHERE user_id = ? AND used_at IS NULL
+     ORDER BY created_at DESC LIMIT 1`,
+  )
+    .bind(userId)
+    .first<ResetRow>()
+}
+
+async function insertKnownCode(
+  userId: string,
+  code: string,
+  opts: { expiresInMs?: number; attempts?: number; used?: boolean } = {},
+): Promise<string> {
+  const id = crypto.randomUUID()
+  const expiresAt = new Date(
+    Date.now() + (opts.expiresInMs ?? 15 * 60 * 1000),
+  ).toISOString()
+  const codeHash = await hashPassword(code)
+  await env.DB.prepare(
+    `INSERT INTO password_reset_codes
+       (id, user_id, code_hash, expires_at, used_at, attempts, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      userId,
+      codeHash,
+      expiresAt,
+      opts.used ? new Date().toISOString() : null,
+      opts.attempts ?? 0,
+      new Date().toISOString(),
+    )
+    .run()
+  return id
+}
+
+beforeEach(async () => {
+  await dropAllTables()
+  await applyMigration()
+  clearRateLimits()
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// REQUEST endpoint
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('POST /api/auth/password-reset/request', () => {
+  it('always returns ok:true even for an unknown email (no enumeration)', async () => {
+    const { res, body } = await jsonPost('/api/auth/password-reset/request', {
+      username: 'nobody@nowhere.test',
+    })
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+
+    // No row created for a phantom user
+    const rows = await env.DB.prepare(
+      'SELECT COUNT(*) as c FROM password_reset_codes',
+    ).first<{ c: number }>()
+    expect(rows!.c).toBe(0)
+  })
+
+  it('inserts a row with attempts=0 and ~15min expiry for a real user', async () => {
+    const user = await register('alice@reset.test')
+    const before = Date.now()
+    const { res, body } = await jsonPost('/api/auth/password-reset/request', {
+      username: 'alice@reset.test',
+    })
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+
+    const row = await loadActiveRow(user.id)
+    expect(row).not.toBeNull()
+    expect(row!.attempts).toBe(0)
+    expect(row!.used_at).toBeNull()
+    const ttl = new Date(row!.expires_at).getTime() - before
+    // Should be within 15 minutes ± a small fudge for clock + test runtime.
+    expect(ttl).toBeGreaterThan(14 * 60 * 1000)
+    expect(ttl).toBeLessThan(16 * 60 * 1000)
+  })
+
+  it('invalidates prior active codes when a new request comes in', async () => {
+    const user = await register('rotate@reset.test')
+    await jsonPost('/api/auth/password-reset/request', {
+      username: 'rotate@reset.test',
+    })
+    const first = await loadActiveRow(user.id)
+    expect(first).not.toBeNull()
+
+    await jsonPost('/api/auth/password-reset/request', {
+      username: 'rotate@reset.test',
+    })
+
+    // Exactly one active row should remain, and it should be a new one.
+    const activeCount = await env.DB.prepare(
+      `SELECT COUNT(*) as c FROM password_reset_codes
+       WHERE user_id = ? AND used_at IS NULL`,
+    )
+      .bind(user.id)
+      .first<{ c: number }>()
+    expect(activeCount!.c).toBe(1)
+
+    const second = await loadActiveRow(user.id)
+    expect(second!.id).not.toBe(first!.id)
+
+    // The first row should be marked used.
+    const firstNow = await env.DB.prepare(
+      'SELECT used_at FROM password_reset_codes WHERE id = ?',
+    )
+      .bind(first!.id)
+      .first<{ used_at: string | null }>()
+    expect(firstNow!.used_at).not.toBeNull()
+  })
+
+  it('returns ok:true even on a malformed body', async () => {
+    const { res, body } = await fetchJSON('/api/auth/password-reset/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    })
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// VERIFY endpoint
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('POST /api/auth/password-reset/verify', () => {
+  it('rotates the password on the correct code and marks the code used', async () => {
+    const user = await register('happy@reset.test', 'oldpw12345')
+    await insertKnownCode(user.id, '123456')
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'happy@reset.test',
+      code: '123456',
+      newPassword: 'brandNewPw99',
+    })
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+
+    // Login with old password must now fail
+    const loginOld = await jsonPost('/api/auth/authenticate', {
+      username: 'happy@reset.test',
+      password: 'oldpw12345',
+    })
+    expect(loginOld.res.status).toBe(401)
+
+    // Login with new password works
+    const loginNew = await jsonPost('/api/auth/authenticate', {
+      username: 'happy@reset.test',
+      password: 'brandNewPw99',
+    })
+    expect(loginNew.res.status).toBe(200)
+    expect(loginNew.body.token).toBeDefined()
+
+    // The code row should be marked used
+    const row = await env.DB.prepare(
+      'SELECT used_at FROM password_reset_codes WHERE user_id = ?',
+    )
+      .bind(user.id)
+      .first<{ used_at: string | null }>()
+    expect(row!.used_at).not.toBeNull()
+  })
+
+  it('rejects a wrong code with a generic error and increments attempts', async () => {
+    const user = await register('wrong@reset.test')
+    await insertKnownCode(user.id, '654321')
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'wrong@reset.test',
+      code: '000000',
+      newPassword: 'anotherNewPw99',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error).toMatch(/invalid or expired/i)
+
+    const row = await loadActiveRow(user.id)
+    expect(row!.attempts).toBe(1)
+    expect(row!.used_at).toBeNull()
+  })
+
+  it('hard-invalidates after 5 attempts even if the 5th is correct', async () => {
+    const user = await register('burn@reset.test')
+    // Insert with attempts already at 4 -- next bump puts it at 5 → burn.
+    await insertKnownCode(user.id, '111111', { attempts: 4 })
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'burn@reset.test',
+      code: '111111',
+      newPassword: 'shouldNotApply',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+
+    const row = await env.DB.prepare(
+      'SELECT used_at, attempts FROM password_reset_codes WHERE user_id = ?',
+    )
+      .bind(user.id)
+      .first<{ used_at: string | null; attempts: number }>()
+    expect(row!.used_at).not.toBeNull()
+    expect(row!.attempts).toBe(5)
+
+    // Password unchanged
+    const login = await jsonPost('/api/auth/authenticate', {
+      username: 'burn@reset.test',
+      password: 'initialpw123',
+    })
+    expect(login.res.status).toBe(200)
+  })
+
+  it('rejects an already-used code', async () => {
+    const user = await register('reuse@reset.test')
+    await insertKnownCode(user.id, '222222', { used: true })
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'reuse@reset.test',
+      code: '222222',
+      newPassword: 'shouldNotApply',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+  })
+
+  it('rejects an expired code', async () => {
+    const user = await register('expired@reset.test')
+    await insertKnownCode(user.id, '333333', { expiresInMs: -1000 })
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'expired@reset.test',
+      code: '333333',
+      newPassword: 'shouldNotApply',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+  })
+
+  it('rejects when newPassword is too short', async () => {
+    const user = await register('short@reset.test')
+    await insertKnownCode(user.id, '444444')
+
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'short@reset.test',
+      code: '444444',
+      newPassword: 'abc',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error).toMatch(/at least 8/i)
+
+    // Code should still be usable (we don't burn on validation failure)
+    const row = await loadActiveRow(user.id)
+    expect(row!.used_at).toBeNull()
+  })
+
+  it('returns a generic error for an unknown username (no enumeration on verify)', async () => {
+    const { res, body } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'ghost@reset.test',
+      code: '555555',
+      newPassword: 'someNewPw99',
+    })
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error).toMatch(/invalid or expired/i)
+  })
+
+  it('returns 400 when required fields are missing', async () => {
+    const { res } = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'x@reset.test',
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// COMPOSITION WITH JWT INVALIDATION (Phase 1.1)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('reset composes with JWT invalidation', () => {
+  it('JWT issued before the reset is rejected afterwards (401)', async () => {
+    await register('compose@reset.test', 'oldpw12345')
+    const { body: loginBody } = await jsonPost('/api/auth/authenticate', {
+      username: 'compose@reset.test',
+      password: 'oldpw12345',
+    })
+    const oldToken = loginBody.token
+    expect(oldToken).toBeDefined()
+
+    // Sanity: token works pre-reset
+    const verifyPre = await fetchJSON('/api/auth/verify', {
+      headers: { Authorization: `Bearer ${oldToken}` },
+    })
+    expect(verifyPre.res.status).toBe(200)
+
+    // Reset the password
+    const user = await env.DB.prepare(
+      'SELECT id FROM users WHERE username = ?',
+    )
+      .bind('compose@reset.test')
+      .first<{ id: string }>()
+    await insertKnownCode(user!.id, '777777')
+
+    const resetResult = await jsonPost('/api/auth/password-reset/verify', {
+      username: 'compose@reset.test',
+      code: '777777',
+      newPassword: 'brandNewPw99',
+    })
+    expect(resetResult.res.status).toBe(200)
+
+    // Old token now fails with tv mismatch
+    const verifyPost = await fetchJSON('/api/auth/verify', {
+      headers: { Authorization: `Bearer ${oldToken}` },
+    })
+    expect(verifyPost.res.status).toBe(401)
+  })
+})

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -62,6 +62,17 @@ CREATE TABLE IF NOT EXISTS email_verification_tokens (
 );
 CREATE INDEX IF NOT EXISTS idx_email_tokens_user ON email_verification_tokens(user_id);
 
+CREATE TABLE IF NOT EXISTS password_reset_codes (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT NOT NULL,
+  code_hash   TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  used_at     TEXT,
+  attempts    INTEGER NOT NULL DEFAULT 0,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_prc_user_active ON password_reset_codes(user_id, expires_at);
+
 CREATE TABLE IF NOT EXISTS centers (
   id              TEXT PRIMARY KEY,
   name            TEXT NOT NULL,
@@ -161,6 +172,7 @@ export async function dropAllTables(): Promise<void> {
     'event_attendees',
     'events',
     'email_verification_tokens',
+    'password_reset_codes',
     'invite_codes',
     'users',
     'centers',

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -24,6 +24,7 @@ import {
 import * as db from './db'
 import * as inviteCodes from './inviteCodes'
 import * as notifications from './notifications'
+import * as passwordReset from './passwordReset'
 import { sendVerificationEmail } from './email'
 import { ADMIN_EMAIL, NORMAL_USER, SEVAK, BRAHMACHARI, TIER_DESCALE, ADMIN_CUTOFF, DEVELOPER_EMAILS, UNVERIFIED_USER } from './constants'
 import { rateLimit, cacheControl, securityHeaders, validate } from './middleware'
@@ -482,6 +483,50 @@ app.get('/auth/verify-email', async (c) => {
     message: 'Email verified',
     user: updated ? userRowToApi(updated) : null,
   })
+})
+
+// ── Password reset (v2) ───────────────────────────────────────────────
+//
+// Self-serve flow: user requests a 6-digit code (always returns ok to
+// avoid enumeration), then submits the code + new password to /verify.
+// On success, every live JWT for the user dies via the password-hash
+// fingerprint in auth.ts. See docs/plans/2026-05-24-password-reset.md.
+
+app.post('/auth/password-reset/request', rateLimit(5, 60_000), async (c) => {
+  let body: { username?: string } = {}
+  try {
+    body = await c.req.json<{ username: string }>()
+  } catch {
+    // empty body -- still return ok so attackers learn nothing
+  }
+  if (body.username && typeof body.username === 'string') {
+    await passwordReset.handlePasswordResetRequest(c.env, body.username)
+  }
+  return c.json({ ok: true })
+})
+
+app.post('/auth/password-reset/verify', rateLimit(10, 60_000), async (c) => {
+  let body: { username?: string; code?: string; newPassword?: string } = {}
+  try {
+    body = await c.req.json()
+  } catch {
+    // fall through to validation below
+  }
+  if (
+    typeof body.username !== 'string' ||
+    typeof body.code !== 'string' ||
+    typeof body.newPassword !== 'string'
+  ) {
+    return c.json({ ok: false, error: 'Missing required fields' }, 400)
+  }
+
+  const result = await passwordReset.handlePasswordResetVerify(
+    c.env,
+    body.username,
+    body.code,
+    body.newPassword,
+  )
+  return c.json(result, result.ok ? 200 : 400)
 })
 
 // ── User-issued invite codes (v2) ─────────────────────────────────────

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -19,6 +19,7 @@ import {
   generateRefreshToken,
   verifyToken,
   verifyRefreshToken,
+  passwordFingerprint,
 } from './auth'
 import * as db from './db'
 import * as inviteCodes from './inviteCodes'
@@ -119,6 +120,18 @@ async function authMiddleware(c: any, next: () => Promise<void>): Promise<Respon
   const userData = await db.getUserByUsername(c.env.DB, decoded.username)
   if (!userData) {
     return c.json({ message: 'User not found' }, 403)
+  }
+
+  // Session-kill on password change: tokens minted after the rollout carry a
+  // `tv` claim fingerprinting the password hash at issue time. If the password
+  // has rotated since (reset flow), the fingerprints diverge and the token
+  // dies. JWTs without a `tv` claim were issued before this check existed —
+  // accept them so existing users aren't logged out at deploy.
+  if (typeof decoded.tv === 'string') {
+    const expected = await passwordFingerprint(userData.password)
+    if (decoded.tv !== expected) {
+      return c.json({ message: 'Session expired, please sign in again' }, 401)
+    }
   }
 
   c.set('user', userData)

--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -82,17 +82,41 @@ interface TokenPayload extends JWTPayload {
   id: string
   username: string
   type?: 'access' | 'refresh'
+  // Fingerprint of users.password at issue time. When the password changes
+  // (reset flow, "change password" future), the fingerprint shifts and all
+  // outstanding JWTs fail the authMiddleware check. Optional so JWTs issued
+  // before this rollout still verify.
+  tv?: string
 }
 
 function secretToKey(secret: string): Uint8Array {
   return new TextEncoder().encode(secret)
 }
 
+/**
+ * Derives a short, stable fingerprint of a stored password hash.
+ * Used as the `tv` (token version) claim on JWTs so that rotating a user's
+ * password invalidates every live JWT for that user.
+ *
+ * Hashing the already-hashed password keeps us from putting raw hash bytes
+ * into the token. 16 hex chars = 64 bits, plenty to detect any change.
+ */
+export async function passwordFingerprint(passwordHash: string): Promise<string> {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(passwordHash))
+  const arr = new Uint8Array(bytes)
+  let hex = ''
+  for (let i = 0; i < 8; i++) {
+    hex += arr[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
 export async function generateToken(
-  user: { id: string; username: string },
+  user: { id: string; username: string; password: string },
   secret: string,
 ): Promise<string> {
-  return new SignJWT({ id: user.id, username: user.username, type: 'access' })
+  const tv = await passwordFingerprint(user.password)
+  return new SignJWT({ id: user.id, username: user.username, type: 'access', tv })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
     .setExpirationTime('30d')
@@ -100,10 +124,11 @@ export async function generateToken(
 }
 
 export async function generateRefreshToken(
-  user: { id: string; username: string },
+  user: { id: string; username: string; password: string },
   secret: string,
 ): Promise<string> {
-  return new SignJWT({ id: user.id, username: user.username, type: 'refresh' })
+  const tv = await passwordFingerprint(user.password)
+  return new SignJWT({ id: user.id, username: user.username, type: 'refresh', tv })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
     .setExpirationTime('90d')

--- a/packages/backend/src/email.ts
+++ b/packages/backend/src/email.ts
@@ -80,3 +80,49 @@ export async function sendVerificationEmail(
     html,
   })
 }
+
+/**
+ * Send a 6-digit password-reset code to the user. Called from the
+ * /auth/password-reset/request handler.
+ */
+export async function sendPasswordResetEmail(
+  env: Env,
+  user: { email: string },
+  code: string,
+): Promise<void> {
+  const html = [
+    '<p>Hari Om,</p>',
+    '<p>Use this code to reset your Chinmaya Janata password:</p>',
+    `<p style="font-size:28px; font-weight:bold; letter-spacing:6px; font-family:monospace;">${code}</p>`,
+    '<p>This code expires in 15 minutes.</p>',
+    '<p>If you didn\'t request a password reset, you can safely ignore this email — your password is unchanged.</p>',
+    '<p>We will never ask you for this code. Do not share it with anyone.</p>',
+  ].join('\n')
+
+  await sendEmail(env, {
+    to: user.email,
+    subject: 'Your Chinmaya Janata password reset code',
+    html,
+  })
+}
+
+/**
+ * Confirmation email after a successful password reset. Sent fire-and-forget.
+ */
+export async function sendPasswordChangedEmail(
+  env: Env,
+  user: { email: string },
+): Promise<void> {
+  const html = [
+    '<p>Hari Om,</p>',
+    '<p>Your Chinmaya Janata password was just changed.</p>',
+    '<p>If this was you, no further action is needed.</p>',
+    '<p>If you did not change your password, please reply to this email immediately — your account may be compromised.</p>',
+  ].join('\n')
+
+  await sendEmail(env, {
+    to: user.email,
+    subject: 'Your Chinmaya Janata password was changed',
+    html,
+  })
+}

--- a/packages/backend/src/passwordReset.ts
+++ b/packages/backend/src/passwordReset.ts
@@ -1,0 +1,233 @@
+/**
+ * passwordReset.ts
+ *
+ * Om Sri Chinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
+ *
+ * Self-serve password reset via a 6-digit code emailed to the user.
+ *
+ * Design highlights (see docs/plans/2026-05-24-password-reset.md):
+ *   - 6-digit code, expires in 15 minutes
+ *   - PBKDF2-hashed in the DB (never plaintext)
+ *   - Request always returns { ok: true } so attackers can't enumerate accounts
+ *   - 5 verify attempts per code, then hard-invalidated
+ *   - Issuing a new request invalidates all prior active codes for the user
+ *   - On successful reset, every live JWT for the user dies on next request
+ *     (via the password-hash fingerprint in auth.ts — no token_version column
+ *     needed)
+ */
+
+import type { Env, UserRow } from './types'
+import { hashPassword, verifyPassword } from './auth'
+import * as db from './db'
+import { sendPasswordResetEmail, sendPasswordChangedEmail } from './email'
+
+const CODE_TTL_MS = 15 * 60 * 1000
+const MAX_ATTEMPTS = 5
+const MIN_PASSWORD_LENGTH = 8
+
+interface ResetCodeRow {
+  id: string
+  user_id: string
+  code_hash: string
+  expires_at: string
+  used_at: string | null
+  attempts: number
+  created_at: string
+}
+
+/**
+ * Generate a cryptographically random 6-digit code, zero-padded.
+ *
+ * Uses crypto.getRandomValues for an unbiased draw across [0, 1_000_000).
+ * Sampling a Uint32 (range 2^32 = 4_294_967_296) and taking modulo 1_000_000
+ * has negligible bias: the cycle 1_000_000 divides into 2^32 with a remainder
+ * of 967_296, which biases the values [0, 967_295] by ~2.25e-7 relative to
+ * the rest. Below detection threshold for a 6-digit OTP.
+ */
+function generateResetCode(): string {
+  const buf = new Uint32Array(1)
+  crypto.getRandomValues(buf)
+  const n = buf[0] % 1_000_000
+  return n.toString().padStart(6, '0')
+}
+
+/** Look up the most-recent active reset code for a user. */
+async function findActiveCode(
+  env: Env,
+  userId: string,
+): Promise<ResetCodeRow | null> {
+  const nowISO = new Date().toISOString()
+  const row = await env.DB.prepare(
+    `SELECT id, user_id, code_hash, expires_at, used_at, attempts, created_at
+     FROM password_reset_codes
+     WHERE user_id = ?1
+       AND used_at IS NULL
+       AND expires_at > ?2
+     ORDER BY created_at DESC
+     LIMIT 1`,
+  )
+    .bind(userId, nowISO)
+    .first<ResetCodeRow>()
+  return row ?? null
+}
+
+/** Mark every active code for a user as used. */
+async function invalidateActiveCodes(
+  env: Env,
+  userId: string,
+): Promise<void> {
+  const nowISO = new Date().toISOString()
+  await env.DB.prepare(
+    `UPDATE password_reset_codes
+     SET used_at = ?1
+     WHERE user_id = ?2 AND used_at IS NULL`,
+  )
+    .bind(nowISO, userId)
+    .run()
+}
+
+/** Mark a single code as used. */
+async function markCodeUsed(env: Env, id: string): Promise<void> {
+  const nowISO = new Date().toISOString()
+  await env.DB.prepare(
+    `UPDATE password_reset_codes SET used_at = ?1 WHERE id = ?2`,
+  )
+    .bind(nowISO, id)
+    .run()
+}
+
+/** Bump the attempts counter on a code by one. */
+async function incrementAttempts(env: Env, id: string): Promise<void> {
+  await env.DB.prepare(
+    `UPDATE password_reset_codes SET attempts = attempts + 1 WHERE id = ?1`,
+  )
+    .bind(id)
+    .run()
+}
+
+/**
+ * Insert a fresh reset code for the user. Returns the plaintext code so
+ * the caller can email it. Hashed copy goes to the DB.
+ */
+async function createResetCode(env: Env, userId: string): Promise<string> {
+  const code = generateResetCode()
+  const codeHash = await hashPassword(code)
+  const id = crypto.randomUUID()
+  const now = Date.now()
+  const expiresAt = new Date(now + CODE_TTL_MS).toISOString()
+  const createdAt = new Date(now).toISOString()
+
+  await env.DB.prepare(
+    `INSERT INTO password_reset_codes (id, user_id, code_hash, expires_at, attempts, created_at)
+     VALUES (?1, ?2, ?3, ?4, 0, ?5)`,
+  )
+    .bind(id, userId, codeHash, expiresAt, createdAt)
+    .run()
+
+  return code
+}
+
+/**
+ * Public entry point for POST /auth/password-reset/request.
+ *
+ * Always succeeds from the caller's perspective. If the user exists we
+ * invalidate any prior codes, mint a new one, and fire the email. If the
+ * user doesn't exist we silently no-op so attackers can't differentiate
+ * known vs unknown accounts.
+ *
+ * Email send errors are logged but never surfaced — same enumeration
+ * concern applies (a Resend outage would otherwise leak the existence of
+ * the email).
+ */
+export async function handlePasswordResetRequest(
+  env: Env,
+  rawUsername: string,
+): Promise<void> {
+  const username = rawUsername.trim().toLowerCase()
+  if (!username) return
+
+  const user = await db.getUserByUsername(env.DB, username)
+  if (!user || !user.email) return
+
+  await invalidateActiveCodes(env, user.id)
+  const code = await createResetCode(env, user.id)
+
+  try {
+    await sendPasswordResetEmail(env, { email: user.email }, code)
+  } catch (err) {
+    console.error('password-reset email send failed:', err)
+  }
+}
+
+export type ResetVerifyResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+/**
+ * Public entry point for POST /auth/password-reset/verify.
+ *
+ * Validates input, finds the active code (if any), checks attempt budget,
+ * verifies the code, then rotates the password. On success the user's
+ * existing JWTs are implicitly invalidated by the auth.ts fingerprint
+ * mechanism — no extra bookkeeping here.
+ *
+ * Returns a generic error message on every failure path so callers can't
+ * distinguish "wrong code" from "code already used" from "user not found".
+ */
+export async function handlePasswordResetVerify(
+  env: Env,
+  rawUsername: string,
+  rawCode: string,
+  rawNewPassword: string,
+): Promise<ResetVerifyResult> {
+  const GENERIC_ERROR: ResetVerifyResult = {
+    ok: false,
+    error: 'Code invalid or expired',
+  }
+
+  const username = rawUsername.trim().toLowerCase()
+  const code = rawCode.trim()
+  const newPassword = rawNewPassword
+
+  if (!username || !code || !newPassword) return GENERIC_ERROR
+  if (newPassword.length < MIN_PASSWORD_LENGTH) {
+    return { ok: false, error: 'Password must be at least 8 characters long' }
+  }
+
+  const user: UserRow | null = await db.getUserByUsername(env.DB, username)
+  if (!user) return GENERIC_ERROR
+
+  const row = await findActiveCode(env, user.id)
+  if (!row) return GENERIC_ERROR
+
+  await incrementAttempts(env, row.id)
+  const newAttempts = row.attempts + 1
+  if (newAttempts >= MAX_ATTEMPTS) {
+    // Burn the code so no further guesses can hit it, even if this attempt
+    // happens to be correct.
+    await markCodeUsed(env, row.id)
+    return GENERIC_ERROR
+  }
+
+  const matched = await verifyPassword(code, row.code_hash)
+  if (!matched) return GENERIC_ERROR
+
+  const newHash = await hashPassword(newPassword)
+  const updated = await db.updateUser(env.DB, user.id, { password: newHash })
+  if (!updated.success) {
+    // Don't burn the code on a server failure — let the user retry.
+    return { ok: false, error: 'Failed to update password' }
+  }
+
+  await markCodeUsed(env, row.id)
+
+  if (user.email) {
+    try {
+      await sendPasswordChangedEmail(env, { email: user.email })
+    } catch (err) {
+      console.error('password-changed email send failed:', err)
+    }
+  }
+
+  return { ok: true }
+}

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -7,7 +7,6 @@ import {
   KeyboardAvoidingView,
   Pressable,
   TouchableOpacity,
-  Alert,
 } from 'react-native'
 import { useRouter, useLocalSearchParams } from 'expo-router'
 import { Code, ArrowLeft } from 'lucide-react-native'
@@ -380,12 +379,7 @@ export default function AuthScreen() {
               {authStep === 'login' && (
                 <Pressable
                   className="items-center mt-2"
-                  onPress={() =>
-                    Alert.alert(
-                      'Reset Password',
-                      'Please contact info@chinmayajanata.org to reset your password.'
-                    )
-                  }
+                  onPress={() => router.push('/auth/forgot')}
                 >
                   <Text className="text-primary font-sans font-medium">Forgot password?</Text>
                 </Pressable>

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -667,16 +667,12 @@ export default function AuthScreen() {
               <span
                 role="button"
                 tabIndex={0}
-                onClick={() =>
-                  window.alert(
-                    'Please contact info@chinmayajanata.org to reset your password.'
-                  )
-                }
+                onClick={() => router.push('/auth/forgot')}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ')
-                    window.alert(
-                      'Please contact info@chinmayajanata.org to reset your password.'
-                    )
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    router.push('/auth/forgot')
+                  }
                 }}
                 style={{
                   color: '#C2410C',

--- a/packages/frontend/app/auth/forgot.tsx
+++ b/packages/frontend/app/auth/forgot.tsx
@@ -1,0 +1,299 @@
+import React, { useCallback, useState } from 'react'
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { ArrowLeft } from 'lucide-react-native'
+import { useRouter } from 'expo-router'
+import { AuthInput, Logo, PrimaryButton } from '../../components/ui'
+import { useTheme } from '../../components/contexts'
+import { PasswordStrength } from '../../components'
+import { authClient } from '../../src/auth/authClient'
+import { validateEmail, validatePassword } from '../../utils'
+
+type Step = 'enter-email' | 'enter-code-and-password' | 'done'
+
+export default function ForgotPasswordScreen() {
+  const router = useRouter()
+  const { isDark } = useTheme()
+
+  const [step, setStep] = useState<Step>('enter-email')
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [errors, setErrors] = useState<{ [k: string]: string }>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [resendBusy, setResendBusy] = useState(false)
+  const [resendNotice, setResendNotice] = useState<string | null>(null)
+
+  const goBack = useCallback(() => {
+    if (step === 'enter-code-and-password') {
+      setStep('enter-email')
+      setCode('')
+      setPassword('')
+      setConfirmPassword('')
+      setErrors({})
+      setResendNotice(null)
+      return
+    }
+    router.back()
+  }, [step, router])
+
+  const submitEmail = useCallback(async () => {
+    setErrors({})
+    const trimmed = email.trim()
+    if (!trimmed) {
+      setErrors({ email: 'Please enter your email.' })
+      return
+    }
+    if (!validateEmail(trimmed)) {
+      setErrors({ email: 'You must enter a valid email address.' })
+      return
+    }
+
+    setSubmitting(true)
+    const result = await authClient.requestPasswordReset(trimmed)
+    setSubmitting(false)
+
+    if (!result.success) {
+      setErrors({ form: result.error.message || 'Could not send a reset code. Please try again.' })
+      return
+    }
+    // Server always returns ok — advance regardless of whether the email
+    // exists. Anti-enumeration design.
+    setStep('enter-code-and-password')
+  }, [email])
+
+  const resend = useCallback(async () => {
+    setResendNotice(null)
+    setErrors({})
+    setResendBusy(true)
+    const result = await authClient.requestPasswordReset(email.trim())
+    setResendBusy(false)
+    if (!result.success) {
+      setErrors({ form: result.error.message || 'Could not resend the code. Please try again.' })
+      return
+    }
+    setResendNotice('We sent a new code. Check your inbox.')
+  }, [email])
+
+  const submitReset = useCallback(async () => {
+    setErrors({})
+    const trimmedCode = code.trim()
+    if (!trimmedCode || trimmedCode.length !== 6 || !/^\d{6}$/.test(trimmedCode)) {
+      setErrors({ code: 'Enter the 6-digit code from your email.' })
+      return
+    }
+    if (!password) {
+      setErrors({ password: 'Please choose a new password.' })
+      return
+    }
+    const pw = validatePassword(password)
+    if (!pw.isValid) {
+      setErrors({ password: pw.errors[0] || 'Password does not meet complexity requirements.' })
+      return
+    }
+    if (password !== confirmPassword) {
+      setErrors({ confirmPassword: 'Passwords do not match.' })
+      return
+    }
+
+    setSubmitting(true)
+    const result = await authClient.confirmPasswordReset(email.trim(), trimmedCode, password)
+    setSubmitting(false)
+
+    if (!result.success) {
+      setErrors({ form: result.error.message || 'Code invalid or expired.' })
+      return
+    }
+    setStep('done')
+  }, [code, password, confirmPassword, email])
+
+  const goToLogin = useCallback(() => {
+    router.replace('/auth?mode=login')
+  }, [router])
+
+  const errorMessages = Object.values(errors).filter(Boolean)
+  const buttonDisabled =
+    submitting ||
+    (step === 'enter-email' && !email) ||
+    (step === 'enter-code-and-password' && (!code || !password || !confirmPassword))
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1"
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1 }}
+        className="flex-1 bg-[#FAFAF7] dark:bg-background-dark"
+        keyboardShouldPersistTaps="handled"
+      >
+        <View
+          className="flex-1 justify-center items-center w-full px-6"
+          style={{ paddingTop: 60, paddingBottom: 48 }}
+        >
+          <View className="w-full" style={{ maxWidth: 400 }}>
+            {/* Back */}
+            <TouchableOpacity
+              onPress={goBack}
+              activeOpacity={0.7}
+              className="flex-row items-center gap-2 mb-6 rounded-xl px-3 py-2 self-start"
+              style={{ alignSelf: 'flex-start' }}
+              accessibilityRole="button"
+              accessibilityLabel="Go back"
+            >
+              <ArrowLeft size={20} className={isDark ? 'text-white' : 'text-content'} />
+              <Text className="font-sans font-medium text-content dark:text-content-dark">
+                Back
+              </Text>
+            </TouchableOpacity>
+
+            <Pressable onPress={() => router.push('/landing')}>
+              <Logo size={32} style={{ marginBottom: 32 }} />
+            </Pressable>
+
+            {/* Heading */}
+            <View className="mb-6">
+              <Text
+                style={{ fontFamily: '"Inclusive Sans"', fontSize: 36, fontWeight: '400' }}
+                className="text-content dark:text-content-dark"
+              >
+                {step === 'enter-email'
+                  ? 'Reset your password.'
+                  : step === 'enter-code-and-password'
+                  ? 'Check your email.'
+                  : 'Password updated.'}
+              </Text>
+              <Text className="text-base font-sans mt-2" style={{ color: '#78716C' }}>
+                {step === 'enter-email'
+                  ? 'Enter the email on your account. We\'ll send you a 6-digit code.'
+                  : step === 'enter-code-and-password'
+                  ? `We sent a code to ${email.trim().toLowerCase()}. It expires in 15 minutes.`
+                  : 'Your password has been reset. Sign in with your new password.'}
+              </Text>
+            </View>
+
+            {/* Errors */}
+            {errorMessages.length > 0 && (
+              <View className="w-full font-sans bg-red-50 dark:bg-red-900/20 rounded-xl px-4 py-3 mb-4">
+                {errorMessages.map((m, i) => (
+                  <Text key={i} className="text-red-500 text-sm font-sans">
+                    {m}
+                  </Text>
+                ))}
+              </View>
+            )}
+
+            {/* Resend notice (non-error) */}
+            {resendNotice && (
+              <View className="w-full font-sans bg-green-50 dark:bg-green-900/20 rounded-xl px-4 py-3 mb-4">
+                <Text className="text-green-700 dark:text-green-300 text-sm font-sans">
+                  {resendNotice}
+                </Text>
+              </View>
+            )}
+
+            {/* Forms */}
+            {step === 'enter-email' && (
+              <View className="gap-4">
+                <AuthInput
+                  placeholder="Email"
+                  onChangeText={(t: string) => {
+                    setEmail(t)
+                    setErrors((prev) => ({ ...prev, email: '' }))
+                  }}
+                  value={email}
+                  autoCapitalize="none"
+                  autoComplete="email"
+                  keyboardType="email-address"
+                />
+                <PrimaryButton
+                  onPress={submitEmail}
+                  disabled={buttonDisabled}
+                  loading={submitting}
+                  style={{ marginTop: 8 }}
+                >
+                  Send code
+                </PrimaryButton>
+              </View>
+            )}
+
+            {step === 'enter-code-and-password' && (
+              <View className="gap-4">
+                <AuthInput
+                  placeholder="6-digit code"
+                  onChangeText={(t: string) => {
+                    setCode(t.replace(/\D/g, '').slice(0, 6))
+                    setErrors((prev) => ({ ...prev, code: '' }))
+                  }}
+                  value={code}
+                  keyboardType="number-pad"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                />
+                <View>
+                  <PasswordStrength password={password} show={password.length > 0} />
+                  <AuthInput
+                    placeholder="New password"
+                    onChangeText={(t: string) => {
+                      setPassword(t)
+                      setErrors((prev) => ({ ...prev, password: '' }))
+                    }}
+                    value={password}
+                    secureTextEntry
+                    autoComplete="password-new"
+                  />
+                </View>
+                <AuthInput
+                  placeholder="Confirm new password"
+                  onChangeText={(t: string) => {
+                    setConfirmPassword(t)
+                    setErrors((prev) => ({ ...prev, confirmPassword: '' }))
+                  }}
+                  value={confirmPassword}
+                  secureTextEntry
+                  autoComplete="password-new"
+                />
+                <PrimaryButton
+                  onPress={submitReset}
+                  disabled={buttonDisabled}
+                  loading={submitting}
+                  style={{ marginTop: 8 }}
+                >
+                  Reset password
+                </PrimaryButton>
+
+                <Pressable
+                  className="items-center mt-2"
+                  onPress={resend}
+                  disabled={resendBusy}
+                  accessibilityRole="button"
+                  accessibilityLabel="Resend code"
+                >
+                  <Text className="text-primary font-sans font-medium">
+                    {resendBusy ? 'Sending…' : "Didn't get it? Resend code"}
+                  </Text>
+                </Pressable>
+              </View>
+            )}
+
+            {step === 'done' && (
+              <View className="gap-4">
+                <PrimaryButton onPress={goToLogin} disabled={false} style={{ marginTop: 8 }}>
+                  Back to sign in
+                </PrimaryButton>
+              </View>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/packages/frontend/app/auth/forgot.web.tsx
+++ b/packages/frontend/app/auth/forgot.web.tsx
@@ -1,0 +1,468 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'expo-router'
+import Logo from '../../components/ui/Logo'
+import PasswordStrength from '../../components/auth/PasswordStrength'
+import { authClient } from '../../src/auth/authClient'
+import { validateEmail, validatePassword } from '../../utils'
+
+// One-time CSS injection for placeholder + hover + iOS zoom prevention.
+if (typeof document !== 'undefined') {
+  const id = 'auth-forgot-web-styles'
+  if (!document.getElementById(id)) {
+    const style = document.createElement('style')
+    style.id = id
+    style.textContent = `
+      .auth-input::placeholder { color: #9CA3AF; }
+      .auth-input:disabled { opacity: 0.6; cursor: not-allowed; }
+      .auth-input { font-size: 16px !important; }
+      .auth-submit:hover:not(:disabled) { background-color: #B91C1C !important; }
+      .auth-link:hover { text-decoration: underline; }
+    `
+    document.head.appendChild(style)
+  }
+}
+
+type Step = 'enter-email' | 'enter-code-and-password' | 'done'
+
+const inputBase: React.CSSProperties = {
+  width: '100%',
+  height: 48,
+  padding: '0 16px',
+  border: '1px solid #E7E5E4',
+  borderRadius: 8,
+  backgroundColor: '#FFFFFF',
+  color: '#1C1917',
+  fontFamily: 'Inclusive Sans, sans-serif',
+  outline: 'none',
+  boxSizing: 'border-box',
+}
+
+const focusedInput: React.CSSProperties = {
+  ...inputBase,
+  borderColor: '#C2410C',
+}
+
+export default function ForgotPasswordScreen() {
+  const router = useRouter()
+
+  const [step, setStep] = useState<Step>('enter-email')
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [errors, setErrors] = useState<{ [k: string]: string }>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [resendBusy, setResendBusy] = useState(false)
+  const [resendNotice, setResendNotice] = useState<string | null>(null)
+
+  const [emailFocused, setEmailFocused] = useState(false)
+  const [codeFocused, setCodeFocused] = useState(false)
+  const [pwFocused, setPwFocused] = useState(false)
+  const [pw2Focused, setPw2Focused] = useState(false)
+
+  const [viewportWidth, setViewportWidth] = useState(
+    typeof window !== 'undefined' ? window.innerWidth : 1024,
+  )
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  const isMobile = viewportWidth < 640
+
+  const goBack = useCallback(() => {
+    if (step === 'enter-code-and-password') {
+      setStep('enter-email')
+      setCode('')
+      setPassword('')
+      setConfirmPassword('')
+      setErrors({})
+      setResendNotice(null)
+      return
+    }
+    router.replace('/auth?mode=login')
+  }, [step, router])
+
+  const submitEmail = useCallback(async () => {
+    setErrors({})
+    const trimmed = email.trim()
+    if (!trimmed) {
+      setErrors({ email: 'Please enter your email.' })
+      return
+    }
+    if (!validateEmail(trimmed)) {
+      setErrors({ email: 'You must enter a valid email address.' })
+      return
+    }
+    setSubmitting(true)
+    const result = await authClient.requestPasswordReset(trimmed)
+    setSubmitting(false)
+    if (!result.success) {
+      setErrors({
+        form: result.error.message || 'Could not send a reset code. Please try again.',
+      })
+      return
+    }
+    setStep('enter-code-and-password')
+  }, [email])
+
+  const resend = useCallback(async () => {
+    setResendNotice(null)
+    setErrors({})
+    setResendBusy(true)
+    const result = await authClient.requestPasswordReset(email.trim())
+    setResendBusy(false)
+    if (!result.success) {
+      setErrors({
+        form: result.error.message || 'Could not resend the code. Please try again.',
+      })
+      return
+    }
+    setResendNotice('We sent a new code. Check your inbox.')
+  }, [email])
+
+  const submitReset = useCallback(async () => {
+    setErrors({})
+    const trimmedCode = code.trim()
+    if (!/^\d{6}$/.test(trimmedCode)) {
+      setErrors({ code: 'Enter the 6-digit code from your email.' })
+      return
+    }
+    if (!password) {
+      setErrors({ password: 'Please choose a new password.' })
+      return
+    }
+    const pw = validatePassword(password)
+    if (!pw.isValid) {
+      setErrors({ password: pw.errors[0] || 'Password does not meet complexity requirements.' })
+      return
+    }
+    if (password !== confirmPassword) {
+      setErrors({ confirmPassword: 'Passwords do not match.' })
+      return
+    }
+    setSubmitting(true)
+    const result = await authClient.confirmPasswordReset(email.trim(), trimmedCode, password)
+    setSubmitting(false)
+    if (!result.success) {
+      setErrors({ form: result.error.message || 'Code invalid or expired.' })
+      return
+    }
+    setStep('done')
+  }, [code, password, confirmPassword, email])
+
+  const onSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (step === 'enter-email') submitEmail()
+      else if (step === 'enter-code-and-password') submitReset()
+    },
+    [step, submitEmail, submitReset],
+  )
+
+  const errorMessages = Object.values(errors).filter(Boolean)
+  const buttonDisabled =
+    submitting ||
+    (step === 'enter-email' && !email) ||
+    (step === 'enter-code-and-password' && (!code || !password || !confirmPassword))
+
+  const heading =
+    step === 'enter-email'
+      ? 'Reset your password.'
+      : step === 'enter-code-and-password'
+        ? 'Check your email.'
+        : 'Password updated.'
+
+  const subtitle =
+    step === 'enter-email'
+      ? "Enter the email on your account. We'll send you a 6-digit code."
+      : step === 'enter-code-and-password'
+        ? `We sent a code to ${email.trim().toLowerCase()}. It expires in 15 minutes.`
+        : 'Your password has been reset. Sign in with your new password.'
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        backgroundColor: '#FAFAF7',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <nav
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: isMobile ? '16px 16px' : '24px 32px',
+        }}
+      >
+        <button
+          onClick={goBack}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '8px 4px',
+            margin: '-8px -4px',
+            fontSize: 14,
+            fontFamily: 'Inclusive Sans, sans-serif',
+            color: '#78716C',
+            minHeight: 44,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+          aria-label="Back"
+        >
+          &larr; Back
+        </button>
+      </nav>
+
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          padding: isMobile ? '8px 16px 24px' : '0 20px 32px',
+        }}
+      >
+        <div style={{ maxWidth: 400, width: '100%' }}>
+          <div
+            onClick={() => router.push('/landing')}
+            role="link"
+            style={{ marginBottom: isMobile ? 32 : 48, cursor: 'pointer' }}
+          >
+            <Logo size={isMobile ? 28 : 32} />
+          </div>
+
+          <h1
+            style={{
+              fontFamily: '"Inclusive Sans", sans-serif',
+              fontSize: isMobile ? 28 : 36,
+              fontWeight: 400,
+              color: '#1C1917',
+              marginBottom: 8,
+              marginTop: 0,
+            }}
+          >
+            {heading}
+          </h1>
+          <p
+            style={{
+              fontFamily: 'Inclusive Sans, sans-serif',
+              fontSize: 16,
+              color: '#78716C',
+              marginBottom: 32,
+              marginTop: 0,
+            }}
+          >
+            {subtitle}
+          </p>
+
+          {errorMessages.length > 0 && (
+            <div
+              style={{
+                backgroundColor: '#FEF2F2',
+                borderRadius: 12,
+                padding: '12px 16px',
+                marginBottom: 16,
+              }}
+            >
+              {errorMessages.map((m, i) => (
+                <p
+                  key={i}
+                  style={{
+                    color: '#EF4444',
+                    fontSize: 14,
+                    fontFamily: 'Inclusive Sans, sans-serif',
+                    margin: 0,
+                  }}
+                >
+                  {m}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {resendNotice && (
+            <div
+              style={{
+                backgroundColor: '#ECFDF5',
+                borderRadius: 12,
+                padding: '12px 16px',
+                marginBottom: 16,
+              }}
+            >
+              <p
+                style={{
+                  color: '#047857',
+                  fontSize: 14,
+                  fontFamily: 'Inclusive Sans, sans-serif',
+                  margin: 0,
+                }}
+              >
+                {resendNotice}
+              </p>
+            </div>
+          )}
+
+          {step === 'done' ? (
+            <button
+              className="auth-submit"
+              onClick={() => router.replace('/auth?mode=login')}
+              style={{
+                width: '100%',
+                height: 48,
+                backgroundColor: '#C2410C',
+                color: '#FFFFFF',
+                border: 'none',
+                borderRadius: 8,
+                fontSize: 16,
+                fontFamily: 'Inclusive Sans, sans-serif',
+                fontWeight: 500,
+                cursor: 'pointer',
+                marginTop: 8,
+              }}
+            >
+              Back to sign in
+            </button>
+          ) : (
+            <form
+              onSubmit={onSubmit}
+              style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+            >
+              {step === 'enter-email' && (
+                <input
+                  className="auth-input"
+                  type="email"
+                  placeholder="Email"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                    setErrors((p) => ({ ...p, email: '' }))
+                  }}
+                  autoComplete="email"
+                  onFocus={() => setEmailFocused(true)}
+                  onBlur={() => setEmailFocused(false)}
+                  style={emailFocused ? focusedInput : inputBase}
+                />
+              )}
+
+              {step === 'enter-code-and-password' && (
+                <>
+                  <input
+                    className="auth-input"
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    placeholder="6-digit code"
+                    value={code}
+                    onChange={(e) => {
+                      setCode(e.target.value.replace(/\D/g, '').slice(0, 6))
+                      setErrors((p) => ({ ...p, code: '' }))
+                    }}
+                    maxLength={6}
+                    onFocus={() => setCodeFocused(true)}
+                    onBlur={() => setCodeFocused(false)}
+                    style={{
+                      ...(codeFocused ? focusedInput : inputBase),
+                      letterSpacing: '6px',
+                      fontFamily: 'monospace',
+                    }}
+                  />
+
+                  <input
+                    className="auth-input"
+                    type="password"
+                    placeholder="New password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value)
+                      setErrors((p) => ({ ...p, password: '' }))
+                    }}
+                    autoComplete="new-password"
+                    onFocus={() => setPwFocused(true)}
+                    onBlur={() => setPwFocused(false)}
+                    style={pwFocused ? focusedInput : inputBase}
+                  />
+
+                  <PasswordStrength password={password} show={password.length > 0} />
+
+                  <input
+                    className="auth-input"
+                    type="password"
+                    placeholder="Confirm new password"
+                    value={confirmPassword}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value)
+                      setErrors((p) => ({ ...p, confirmPassword: '' }))
+                    }}
+                    autoComplete="new-password"
+                    onFocus={() => setPw2Focused(true)}
+                    onBlur={() => setPw2Focused(false)}
+                    style={pw2Focused ? focusedInput : inputBase}
+                  />
+                </>
+              )}
+
+              <button
+                className="auth-submit"
+                type="submit"
+                disabled={buttonDisabled}
+                style={{
+                  width: '100%',
+                  height: 48,
+                  backgroundColor: '#C2410C',
+                  color: '#FFFFFF',
+                  border: 'none',
+                  borderRadius: 8,
+                  fontSize: 16,
+                  fontFamily: 'Inclusive Sans, sans-serif',
+                  fontWeight: 500,
+                  cursor: buttonDisabled ? 'not-allowed' : 'pointer',
+                  marginTop: 8,
+                  opacity: buttonDisabled ? 0.4 : 1,
+                }}
+              >
+                {submitting
+                  ? 'Please wait…'
+                  : step === 'enter-email'
+                    ? 'Send code'
+                    : 'Reset password'}
+              </button>
+
+              {step === 'enter-code-and-password' && (
+                <p style={{ textAlign: 'center', marginTop: 8, marginBottom: 0 }}>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                      if (!resendBusy) resend()
+                    }}
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && !resendBusy) {
+                        e.preventDefault()
+                        resend()
+                      }
+                    }}
+                    className="auth-link"
+                    style={{
+                      color: '#C2410C',
+                      cursor: resendBusy ? 'not-allowed' : 'pointer',
+                      fontFamily: 'Inclusive Sans, sans-serif',
+                      fontSize: 14,
+                      fontWeight: 500,
+                      opacity: resendBusy ? 0.6 : 1,
+                    }}
+                  >
+                    {resendBusy ? 'Sending…' : "Didn't get it? Resend code"}
+                  </span>
+                </p>
+              )}
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/app/auth/forgot.web.tsx
+++ b/packages/frontend/app/auth/forgot.web.tsx
@@ -24,11 +24,18 @@ if (typeof document !== 'undefined') {
 
 type Step = 'enter-email' | 'enter-code-and-password' | 'done'
 
+// Use longhand border properties (borderWidth/borderStyle/borderColor) instead
+// of the `border` shorthand. React-DOM warns when a render diff removes a
+// longhand (borderColor) while a shorthand (border) is still set, which is
+// exactly what happens between focused and unfocused states. Keeping
+// everything in longhand reduces the diff to a single borderColor swap.
 const inputBase: React.CSSProperties = {
   width: '100%',
   height: 48,
   padding: '0 16px',
-  border: '1px solid #E7E5E4',
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: '#E7E5E4',
   borderRadius: 8,
   backgroundColor: '#FFFFFF',
   color: '#1C1917',

--- a/packages/frontend/src/__tests__/authClient.test.ts
+++ b/packages/frontend/src/__tests__/authClient.test.ts
@@ -394,3 +394,115 @@ describe('authClient.deleteAccount', () => {
     }
   })
 })
+
+// ── Password reset ────────────────────────────────────────────────────
+
+describe('authClient.requestPasswordReset', () => {
+  it('returns success when server says ok', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true }))
+
+    const result = await authClient.requestPasswordReset('user@example.com')
+    expect(result.success).toBe(true)
+  })
+
+  it('normalizes the email (trim + lowercase) before posting', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true }))
+
+    await authClient.requestPasswordReset('  USER@Example.com  ')
+    const call = mockFetch.mock.calls[0]
+    const body = JSON.parse(call[1].body)
+    expect(body.username).toBe('user@example.com')
+  })
+
+  it('returns error when the server rejects (e.g. rate limit)', async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse({ message: 'Too many requests' }, false, 429),
+    )
+
+    const result = await authClient.requestPasswordReset('user@example.com')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.status).toBe(429)
+    }
+  })
+
+  it('returns network error on fetch failure', async () => {
+    mockFetch.mockRejectedValue(new Error('fetch failed'))
+
+    const result = await authClient.requestPasswordReset('user@example.com')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.message).toBe('Network error. Please try again.')
+    }
+  })
+})
+
+describe('authClient.confirmPasswordReset', () => {
+  it('returns success when server confirms', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true }))
+
+    const result = await authClient.confirmPasswordReset(
+      'user@example.com',
+      '123456',
+      'newSecret99',
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('posts the trimmed code and the new password', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ ok: true }))
+
+    await authClient.confirmPasswordReset(
+      '  USER@Example.com  ',
+      '  123456 ',
+      'newSecret99',
+    )
+    const call = mockFetch.mock.calls[0]
+    const body = JSON.parse(call[1].body)
+    expect(body.username).toBe('user@example.com')
+    expect(body.code).toBe('123456')
+    expect(body.newPassword).toBe('newSecret99')
+  })
+
+  it('returns the server error when ok=false (e.g. wrong code)', async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse({ ok: false, error: 'Code invalid or expired' }, false, 400),
+    )
+
+    const result = await authClient.confirmPasswordReset(
+      'user@example.com',
+      '999999',
+      'newSecret99',
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.message).toMatch(/invalid or expired/i)
+    }
+  })
+
+  it('treats a 200 with ok:false as failure', async () => {
+    // Defensive: server should always pair ok:false with 400, but if it
+    // ever returns 200 + ok:false we should still surface the error.
+    mockFetch.mockResolvedValue(
+      mockResponse({ ok: false, error: 'something went wrong' }, true, 200),
+    )
+
+    const result = await authClient.confirmPasswordReset(
+      'user@example.com',
+      '000000',
+      'newSecret99',
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('returns network error on fetch failure', async () => {
+    mockFetch.mockRejectedValue(new Error('fetch failed'))
+
+    const result = await authClient.confirmPasswordReset(
+      'user@example.com',
+      '123456',
+      'newSecret99',
+    )
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/frontend/src/auth/authClient.ts
+++ b/packages/frontend/src/auth/authClient.ts
@@ -388,6 +388,84 @@ export const authClient = {
     }
   },
 
+  /**
+   * Start the password-reset flow. Always returns success from the
+   * server's perspective — we don't reveal whether the email is on file
+   * (anti-enumeration). Rate-limited 5/min per IP server-side.
+   */
+  async requestPasswordReset(email: string): AsyncResult<GenericSuccessResponse> {
+    try {
+      const username = normalizeUsername(email)
+      const response = await withTimeout(
+        buildUrl('/auth/password-reset/request'),
+        {
+          method: 'POST',
+          body: JSON.stringify({ username }),
+        },
+        API_TIMEOUTS.auth,
+      )
+
+      const data = await safeJson<GenericSuccessResponse & { ok?: boolean }>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to send reset code', response.status),
+        }
+      }
+
+      return { success: true, data: { success: true, message: data?.message } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
+  /**
+   * Submit the 6-digit code and the new password. On success the server
+   * rotates users.password, which kills every live JWT for the user via
+   * the tv-claim mechanism. Caller should treat that as a sign-out and
+   * redirect to login.
+   */
+  async confirmPasswordReset(
+    email: string,
+    code: string,
+    newPassword: string,
+  ): AsyncResult<GenericSuccessResponse> {
+    try {
+      const username = normalizeUsername(email)
+      const response = await withTimeout(
+        buildUrl('/auth/password-reset/verify'),
+        {
+          method: 'POST',
+          body: JSON.stringify({ username, code: code.trim(), newPassword }),
+        },
+        API_TIMEOUTS.auth,
+      )
+
+      const data = await safeJson<{ ok?: boolean; error?: string; message?: string }>(response)
+
+      if (!response.ok || data?.ok === false) {
+        return {
+          success: false,
+          error: toError(
+            data?.error || data?.message || 'Code invalid or expired',
+            response.status,
+          ),
+        }
+      }
+
+      return { success: true, data: { success: true, message: data?.message } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+
   async deleteAccount(token: string): AsyncResult<GenericSuccessResponse> {
     try {
       const response = await withTimeout(


### PR DESCRIPTION
## The warning

Triggered every render of the forgot-password input fields:

> Removing a style property during rerender (borderColor) when a conflicting property is set (border) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.

Pointing at \`packages/frontend/app/auth/forgot.web.tsx:335\`.

## Why

The component toggles between two CSSProperties objects:

\`\`\`ts
const inputBase = { border: '1px solid #E7E5E4', ... }
const focusedInput = { ...inputBase, borderColor: '#C2410C' }
\`\`\`

When an input focuses, \`borderColor\` is added on top of the \`border\` shorthand. When it un-focuses, \`borderColor\` is removed but \`border\` is still set. React-DOM doesn't know how to safely diff a shorthand against a longhand of the same property, so it warns.

## Fix

Drop the \`border\` shorthand. Define the three longhand props on \`inputBase\`:

\`\`\`ts
const inputBase = {
  borderWidth: 1,
  borderStyle: 'solid',
  borderColor: '#E7E5E4',
  ...
}
\`\`\`

Now the focus→unfocus diff is just a borderColor swap. No visual change, no warning.

## Base branch

This PR is stacked on \`feat/v2-password-reset-ui\` (PR #225) because \`forgot.web.tsx\` only exists there. It'll auto-retarget to \`v2\` when #225 merges. Alternatively the maintainer can squash it into #225 directly.

## Verified

- [x] No visual change — same border in both focused and unfocused states
- [x] Web console warning gone after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)