### PR TITLE
fix(auth): /auth?mode=login with no email is a dead-end

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -29,16 +29,21 @@ export default function AuthScreen() {
   const { checkUserExists, login, signup, loading } = useUser()
   const posthog = usePostHog()
 
-  // Read params for deep-link support (e.g. from AuthPromptModal)
-  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string }>()
+  // Read params for deep-link support (e.g. from AuthPromptModal, or
+  // /auth/forgot's "Back to sign in" button).
+  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string }>()
   const urlInviteCode = params.inviteCode
+  const urlEmail = typeof params.email === 'string' ? params.email : ''
 
+  // mode=login is meaningful only when we also have an email — otherwise we'd
+  // render a login screen with a disabled empty email field that the user
+  // can't edit, which is a dead-end. Fall back to the initial step instead.
   const [authStep, setAuthStep] = useState<AuthStep>(
-    params.mode === 'login' ? 'login'
+    params.mode === 'login' && urlEmail ? 'login'
       : params.mode === 'signup' && urlInviteCode ? 'signup'
       : 'initial'
   )
-  const [username, setUsername] = useState('')
+  const [username, setUsername] = useState(urlEmail)
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [inviteCode, setInviteCode] = useState(urlInviteCode || '')

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -46,20 +46,24 @@ export default function AuthScreen() {
   const router = useRouter()
   const { checkUserExists, login, signup, loading } = useUser()
 
-  // Read mode, returnTo, and inviteCode from URL params
+  // Read mode, returnTo, inviteCode, and email from URL params
   const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null
   const initialMode = urlParams?.get('mode')
   const returnTo = urlParams?.get('returnTo')
   const urlInviteCode = urlParams?.get('inviteCode')
+  const urlEmail = urlParams?.get('email') ?? ''
 
   // When inviteCode is provided via URL (e.g. from public explore flow),
-  // skip the invite-code step and go straight to signup
+  // skip the invite-code step and go straight to signup.
+  // mode=login is meaningful only when we also have an email — otherwise we'd
+  // render a login screen with a disabled empty email field that the user
+  // can't edit, which is a dead-end. Fall back to the initial step instead.
   const [authStep, setAuthStep] = useState<AuthStep>(
-    initialMode === 'login' ? 'login'
+    initialMode === 'login' && urlEmail ? 'login'
       : initialMode === 'signup' && urlInviteCode ? 'signup'
       : 'initial'
   )
-  const [username, setUsername] = useState('')
+  const [username, setUsername] = useState(urlEmail)
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [inviteCode, setInviteCode] = useState(urlInviteCode || '')


### PR DESCRIPTION
## Repro

Navigate to \`/auth?mode=login\` (e.g. from \"Back to sign in\" on the forgot-password done screen).

**Result:** the auth screen jumps straight to the **Login** step with an empty, disabled email field. User can't type the email, can't sign in, can't proceed — only the Back button works. Screenshot from Kish's testing in the [chat thread](#).

## Fix

\`mode=login\` is now honored only when an email is also supplied. Two changes on native + web:

1. **Email URL param.** \`/auth?mode=login&email=foo@bar.com\` now prefills the email field and jumps to the password step (still locked, but the email is visible). One tap from signing in.
2. **No-email guard.** \`/auth?mode=login\` without an email falls back to the **initial** step — email field is editable again, no dead-end.

Files:
- \`packages/frontend/app/auth.tsx\` (native)
- \`packages/frontend/app/auth.web.tsx\` (web)

No callsite of \`/auth?mode=login\` in the repo currently passes \`&email=...\`, so this PR's behavior today is purely a no-broken-state guard. A separate follow-up could update those callers (forgot-password's \"Back to sign in\" button, AuthPromptModal) to also pass the email for a faster sign-in path, but that's optional now that the guard exists.

## Verified

- [x] \`npx tsc --noEmit -p packages/frontend\` → 0 errors
- [x] \`npx vitest run\` → 153/153 pass
- [x] Manual web: \`/auth?mode=login\` → renders initial step (was: dead-end login step)
- [x] Manual web: \`/auth?mode=login&email=foo@bar.com\` → renders login step with email prefilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)