### PR TITLE
fix(forgot-password/web): use border longhand to silence React warning

### DIFF
--- a/packages/frontend/app/auth/forgot.web.tsx
+++ b/packages/frontend/app/auth/forgot.web.tsx
@@ -24,11 +24,18 @@ if (typeof document !== 'undefined') {
 
 type Step = 'enter-email' | 'enter-code-and-password' | 'done'
 
+// Use longhand border properties (borderWidth/borderStyle/borderColor) instead
+// of the `border` shorthand. React-DOM warns when a render diff removes a
+// longhand (borderColor) while a shorthand (border) is still set, which is
+// exactly what happens between focused and unfocused states. Keeping
+// everything in longhand reduces the diff to a single borderColor swap.
 const inputBase: React.CSSProperties = {
   width: '100%',
   height: 48,
   padding: '0 16px',
-  border: '1px solid #E7E5E4',
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: '#E7E5E4',
   borderRadius: 8,
   backgroundColor: '#FFFFFF',
   color: '#1C1917',


### PR DESCRIPTION
**Reopened from #236** (closed when its base `feat/v2-password-reset-ui` was deleted on merge of #239). Cherry-picked the one-file fix onto fresh v2.

## What

`forgot.web.tsx` toggled between two CSSProperties objects using a `border` shorthand on `inputBase` and a `borderColor` longhand on `focusedInput`. React-DOM warned every render:

> Removing a style property during rerender (borderColor) when a conflicting property is set (border) can lead to styling bugs.

Fix: replace `border` shorthand with three longhand props (`borderWidth`/`borderStyle`/`borderColor`) so the focus diff is just a borderColor swap. No visual change.

See original #236 for full discussion: https://github.com/Project-Janata/Janata/pull/236

🤖 Generated with [Claude Code](https://claude.com/claude-code)