### PR TITLE
[codex] Remove Seva tab from Explore

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -45,7 +45,6 @@ import Map from '../../components/map/Map'
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'Events' },
   { label: 'Centers' },
-  { label: 'Seva' },
 ]
 
 /**
@@ -569,13 +568,10 @@ export default function DiscoverScreen() {
             scrollEnabled={true}
             stickyHeaderIndices={stickyHeaderIndices}
           >
-            {!loading && activeFilter === 'Seva' && (
-              <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
-            )}
-            {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
+            {!loading && displayItems.length === 0 && (
               <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
-            {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
+            {displayItems.map((item, idx) => {
               if (item.type === 'section') {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -48,7 +48,6 @@ import { ADMIN_EMAIL, isLocal } from '../../utils/admin'
 const FILTERS: { label: DiscoverFilter }[] = [
   { label: 'Events' },
   { label: 'Centers' },
-  { label: 'Seva' },
 ]
 
 function formatDatePill(dateStr: string): { month: string; day: string } {
@@ -884,13 +883,10 @@ function MobileDiscoverFallback() {
                 </Text>
               </View>
             )}
-            {!loading && activeFilter === 'Seva' && (
-              <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
-            )}
-            {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
+            {!loading && displayItems.length === 0 && (
               <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
             )}
-            {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
+            {displayItems.map((item, idx) => {
               if (item.type === 'section') {
                 const label = item.data.label
                 const isCollapsed = collapsedSections.has(label)
@@ -1371,13 +1367,10 @@ export default function DiscoverScreenWeb() {
               contentContainerStyle={{ paddingHorizontal: 4, paddingTop: 12, paddingBottom: 24, gap: 4 }}
               showsVerticalScrollIndicator={false}
             >
-              {!loading && activeFilter === 'Seva' && (
-                <EmptyState message="Seva — coming soon" subtitle="Service opportunities will be listed here." />
-              )}
-              {!loading && activeFilter !== 'Seva' && displayItems.length === 0 && (
+              {!loading && displayItems.length === 0 && (
                 <EmptyState variant={selectedDate ? 'date' : searchQuery ? 'search' : 'events'} />
               )}
-              {activeFilter !== 'Seva' && displayItems.map((item, idx) => {
+              {displayItems.map((item, idx) => {
                 if (item.type === 'section') {
                   const label = item.data.label
                   const isCollapsed = collapsedSections.has(label)

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -148,7 +148,7 @@ export type DiscoverItem =
   | { type: 'center'; data: DiscoverCenter }
   | { type: 'section'; data: { label: string } }
 
-export type DiscoverFilter = 'Events' | 'Centers' | 'Seva'
+export type DiscoverFilter = 'Events' | 'Centers'
 
 // ── Fetch helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Removes the Seva filter tab from the Explore page on both web and native. Deletes the unused Seva placeholder empty state branches and narrows the shared DiscoverFilter type to Events and Centers.

---

**Ralph runner E2E smoke (2026-05-27):**
- Verify gate: ✅ all 5 checks — `git diff --check`, `npm run typecheck` (backend), `test:frontend` (34.5s), `test:backend` (8.2s), `npm run build`.
- UI smoke: ✅ headless chromium DOM check on `/explore` — Events ✓, Centers ✓, Seva ✗.
- Screenshot evidence: `.context/evidence/GH-242-explore-20260527T151848Z.png` (377K, on Mac mini runner).
- Codex original note re. pre-existing frontend type errors in `CenterDetailPanel.web.tsx` + `WebBottomNav.test.tsx`: those exist on `v2` itself and are out of scope for this PR. Current `verify.sh` only typechecks the backend, so they did not block this gate.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779896648804269