### PR TITLE
[DRAFT] Add public signed-in feed posts

### DIFF
--- a/migrations/0026_board_post_visibility.sql
+++ b/migrations/0026_board_post_visibility.sql
@@ -1,0 +1,70 @@
+-- 0026_board_post_visibility.sql
+-- Adds public signed-in feed posts alongside existing center and event board posts.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE board_posts_new (
+  id          TEXT PRIMARY KEY,
+  board_id    TEXT REFERENCES boards(id) ON DELETE CASCADE,
+  author_id   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body        TEXT NOT NULL,
+  image_url   TEXT,
+  visibility  TEXT NOT NULL DEFAULT 'board'
+    CHECK (visibility IN ('board', 'public_signed_in', 'public_open')),
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at  TEXT,
+  pinned_at   TEXT,
+  pinned_by   TEXT REFERENCES users(id),
+  CHECK (
+    (visibility = 'board' AND board_id IS NOT NULL)
+    OR
+    (visibility IN ('public_signed_in', 'public_open') AND board_id IS NULL)
+  )
+);
+
+INSERT INTO board_posts_new (
+  id,
+  board_id,
+  author_id,
+  body,
+  image_url,
+  visibility,
+  created_at,
+  updated_at,
+  deleted_at,
+  pinned_at,
+  pinned_by
+)
+SELECT
+  id,
+  board_id,
+  author_id,
+  body,
+  image_url,
+  'board',
+  created_at,
+  updated_at,
+  deleted_at,
+  pinned_at,
+  pinned_by
+FROM board_posts;
+
+DROP TABLE board_posts;
+
+ALTER TABLE board_posts_new RENAME TO board_posts;
+
+CREATE INDEX IF NOT EXISTS idx_board_posts_board_created
+  ON board_posts(board_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_board_posts_author
+  ON board_posts(author_id);
+
+CREATE INDEX IF NOT EXISTS idx_board_posts_board_pinned_created
+  ON board_posts(board_id, pinned_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_board_posts_public_created
+  ON board_posts(visibility, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+PRAGMA foreign_keys = ON;

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -1609,6 +1609,58 @@ describe('GET /api/feed — aggregated cross-board feed', () => {
     expect(page1Ids.filter((id: string) => page2Ids.includes(id))).toEqual([])
   })
 
+  it('includes public signed-in posts for any authenticated user', async () => {
+    const { res: createRes, body: created } = await jsonPost(
+      '/api/feed/public',
+      { body: 'public hello' },
+      authHeader(memberToken),
+    )
+    expect(createRes.status).toBe(201)
+    expect(created.post.boardId).toBeNull()
+    expect(created.post.visibility).toBe('public_signed_in')
+
+    const { body: memberFeed } = await fetchJSON(
+      '/api/feed',
+      { headers: authHeader(memberToken) },
+    )
+    expect(memberFeed.posts.map((p: { body: string }) => p.body)).toContain('public hello')
+
+    const { body: strangerFeed } = await fetchJSON(
+      '/api/feed',
+      { headers: authHeader(strangerToken) },
+    )
+    expect(strangerFeed.posts.map((p: { body: string }) => p.body)).toEqual(['public hello'])
+  })
+
+  it('allows replies on public posts and excludes those replies from the top-level feed', async () => {
+    const { body: created } = await jsonPost(
+      '/api/feed/public',
+      { body: 'public parent' },
+      authHeader(memberToken),
+    )
+
+    const { res: replyRes, body: replyBody } = await jsonPost(
+      `/api/boards/posts/${created.post.id}/replies`,
+      { body: 'public reply' },
+      authHeader(strangerToken),
+    )
+    expect(replyRes.status).toBe(201)
+    expect(replyBody.reply.boardId).toBeNull()
+    expect(replyBody.reply.visibility).toBe('public_signed_in')
+
+    const { body: replies } = await fetchJSON(
+      `/api/boards/posts/${created.post.id}/replies`,
+      { headers: authHeader(memberToken) },
+    )
+    expect(replies.replies.map((p: { body: string }) => p.body)).toEqual(['public reply'])
+
+    const { body: feed } = await fetchJSON(
+      '/api/feed',
+      { headers: authHeader(strangerToken) },
+    )
+    expect(feed.posts.map((p: { body: string }) => p.body)).toEqual(['public parent'])
+  })
+
   it('returns 401 without authentication', async () => {
     const { res } = await fetchJSON('/api/feed')
     expect(res.status).toBe(401)

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -64,6 +64,7 @@ function boardPostToApi(post: db.BoardPostWithAuthor): BoardPostApiResponse {
   return {
     id: post.id,
     boardId: post.board_id,
+    visibility: post.visibility,
     body: post.body,
     imageUrl: post.image_url,
     createdAt: post.created_at,
@@ -1353,6 +1354,52 @@ app.post('/boards/:type/:id/posts', authMiddleware, async (c) => {
   return c.json({ post: boardPostToApi(post) }, 201)
 })
 
+app.post('/feed/public', authMiddleware, async (c) => {
+  const user = c.get('user')
+
+  const suspended = suspendedPostingResponse(c, user)
+  if (suspended) return suspended
+
+  const body: { body?: string; imageUrl?: string | null } = await c.req
+    .json<{ body?: string; imageUrl?: string | null }>()
+    .catch(() => ({}))
+  const text = typeof body.body === 'string' ? body.body.trim() : ''
+  if (!text) {
+    return c.json({ message: 'Post body is required' }, 400)
+  }
+  if (text.length > 2000) {
+    return c.json({ message: 'Post body must be 2000 characters or fewer' }, 400)
+  }
+
+  const imageUrl = body.imageUrl ?? null
+  const validImageUrl = validate.url(imageUrl || undefined)
+  if (validImageUrl === false) {
+    return c.json({ message: 'Image URL is invalid' }, 400)
+  }
+
+  const postId = crypto.randomUUID()
+  const created = await db.createBoardPost(c.env.DB, {
+    id: postId,
+    board_id: null,
+    author_id: user.id,
+    body: text,
+    image_url: validImageUrl ?? null,
+    visibility: 'public_signed_in',
+  })
+
+  if (!created.success) {
+    console.error('createPublicPost error:', created.error)
+    return c.json({ message: 'Failed to create public post' }, 500)
+  }
+
+  const post = await db.getBoardPostWithAuthorById(c.env.DB, postId)
+  if (!post) {
+    return c.json({ message: 'Public post created but could not be loaded' }, 500)
+  }
+
+  return c.json({ post: boardPostToApi(post) }, 201)
+})
+
 app.post('/boards/posts/:postId/reactions', authMiddleware, async (c) => {
   const user = c.get('user')
   const postId = c.req.param('postId')
@@ -1361,13 +1408,16 @@ app.post('/boards/posts/:postId/reactions', authMiddleware, async (c) => {
     return c.json({ message: 'Board post not found' }, 404)
   }
 
-  const board = await db.getBoardById(c.env.DB, post.board_id)
-  if (!board) {
-    return c.json({ message: 'Board not found' }, 404)
-  }
+  let board: Awaited<ReturnType<typeof db.getBoardById>> = null
+  if (post.board_id !== null) {
+    board = await db.getBoardById(c.env.DB, post.board_id)
+    if (!board) {
+      return c.json({ message: 'Board not found' }, 404)
+    }
 
-  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
-  if (accessError) return accessError
+    const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+    if (accessError) return accessError
+  }
 
   const body: { emoji?: string } = await c.req.json<{ emoji?: string }>().catch(() => ({}))
   if (!body.emoji || !BOARD_REACTIONS.has(body.emoji)) {
@@ -1391,7 +1441,9 @@ app.post('/boards/posts/:postId/reactions', authMiddleware, async (c) => {
           excludeUserId: user.id,
           actionUrl: `/feed/${post.id}`,
           relatedUserId: user.id,
-          data: { boardType: board.type, parentId: board.parent_id, postId: post.id },
+          data: board
+            ? { boardType: board.type, parentId: board.parent_id, postId: post.id }
+            : { boardType: 'public', parentId: 'public', postId: post.id },
         },
       ),
     )
@@ -1413,12 +1465,14 @@ app.patch('/boards/posts/:postId', authMiddleware, async (c) => {
   if (!post) {
     return c.json({ message: 'Board post not found' }, 404)
   }
-  const board = await db.getBoardById(c.env.DB, post.board_id)
-  if (!board) {
-    return c.json({ message: 'Board not found' }, 404)
+  if (post.board_id !== null) {
+    const board = await db.getBoardById(c.env.DB, post.board_id)
+    if (!board) {
+      return c.json({ message: 'Board not found' }, 404)
+    }
+    const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+    if (accessError) return accessError
   }
-  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
-  if (accessError) return accessError
 
   const body: { body?: string } = await c.req
     .json<{ body?: string }>()
@@ -1449,8 +1503,10 @@ app.patch('/boards/posts/:postId', authMiddleware, async (c) => {
   }
 
   // Return the updated post in the same shape as the create response.
-  const refreshed = await db.listBoardPosts(c.env.DB, post.board_id, { limit: 100 })
-  const updated = refreshed.find((p) => p.id === postId)
+  const updated = post.board_id === null
+    ? await db.getBoardPostWithAuthorById(c.env.DB, postId)
+    : (await db.listBoardPosts(c.env.DB, post.board_id, { limit: 100 }))
+        .find((p) => p.id === postId)
   if (!updated) {
     return c.json({ message: 'Post edited but could not be reloaded' }, 500)
   }
@@ -1469,14 +1525,16 @@ app.delete('/boards/posts/:postId', authMiddleware, async (c) => {
   if (!post) {
     return c.json({ message: 'Board post not found' }, 404)
   }
-  const board = await db.getBoardById(c.env.DB, post.board_id)
-  if (!board) {
-    return c.json({ message: 'Board not found' }, 404)
+  if (post.board_id !== null) {
+    const board = await db.getBoardById(c.env.DB, post.board_id)
+    if (!board) {
+      return c.json({ message: 'Board not found' }, 404)
+    }
+    // Read access (deletion gate is finer-grained inside softDeleteBoardPost,
+    // but we still want to 403 non-members of the board)
+    const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+    if (accessError) return accessError
   }
-  // Read access (deletion gate is finer-grained inside softDeleteBoardPost,
-  // but we still want to 403 non-members of the board)
-  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
-  if (accessError) return accessError
 
   const result = await db.softDeleteBoardPost(c.env.DB, postId, {
     id: user.id,
@@ -1510,6 +1568,9 @@ app.post('/boards/posts/:postId/pin', authMiddleware, async (c) => {
   const post = await db.getBoardPostById(c.env.DB, postId)
   if (!post) {
     return c.json({ message: 'Board post not found' }, 404)
+  }
+  if (post.board_id === null) {
+    return c.json({ message: 'Public posts cannot be pinned' }, 409)
   }
   const board = await db.getBoardById(c.env.DB, post.board_id)
   if (!board) {
@@ -1551,6 +1612,9 @@ app.post('/boards/posts/:postId/unpin', authMiddleware, async (c) => {
   if (!post) {
     return c.json({ message: 'Board post not found' }, 404)
   }
+  if (post.board_id === null) {
+    return c.json({ message: 'Public posts cannot be unpinned' }, 409)
+  }
   const board = await db.getBoardById(c.env.DB, post.board_id)
   if (!board) {
     return c.json({ message: 'Board not found' }, 404)
@@ -1591,12 +1655,15 @@ app.post('/boards/posts/:postId/replies', authMiddleware, async (c) => {
   if (!parent) {
     return c.json({ message: 'Board post not found' }, 404)
   }
-  const board = await db.getBoardById(c.env.DB, parent.board_id)
-  if (!board) {
-    return c.json({ message: 'Board not found' }, 404)
+  let board: Awaited<ReturnType<typeof db.getBoardById>> = null
+  if (parent.board_id !== null) {
+    board = await db.getBoardById(c.env.DB, parent.board_id)
+    if (!board) {
+      return c.json({ message: 'Board not found' }, 404)
+    }
+    const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+    if (accessError) return accessError
   }
-  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
-  if (accessError) return accessError
 
   const suspended = suspendedPostingResponse(c, user)
   if (suspended) return suspended
@@ -1658,7 +1725,9 @@ app.post('/boards/posts/:postId/replies', authMiddleware, async (c) => {
         excludeUserId: user.id,
         actionUrl: `/feed/${parentPostId}`,
         relatedUserId: user.id,
-        data: { boardType: board.type, parentId: board.parent_id, postId: parentPostId },
+        data: board
+          ? { boardType: board.type, parentId: board.parent_id, postId: parentPostId }
+          : { boardType: 'public', parentId: 'public', postId: parentPostId },
       },
     ),
   )
@@ -1674,12 +1743,14 @@ app.get('/boards/posts/:postId/replies', authMiddleware, async (c) => {
   if (!parent) {
     return c.json({ message: 'Board post not found' }, 404)
   }
-  const board = await db.getBoardById(c.env.DB, parent.board_id)
-  if (!board) {
-    return c.json({ message: 'Board not found' }, 404)
+  if (parent.board_id !== null) {
+    const board = await db.getBoardById(c.env.DB, parent.board_id)
+    if (!board) {
+      return c.json({ message: 'Board not found' }, 404)
+    }
+    const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+    if (accessError) return accessError
   }
-  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
-  if (accessError) return accessError
 
   const replies = await db.listBoardPostReplies(c.env.DB, parentPostId)
   return c.json({

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -17,6 +17,7 @@ import type {
   BoardPostRow,
   BoardReactionCount,
   BoardType,
+  PostVisibility,
   PostReportRow,
   ModerationActionRow,
 } from './types'
@@ -814,15 +815,15 @@ export async function ensureBoard(
 export async function createBoardPost(
   db: D1Database,
   post: Pick<BoardPostRow, 'id' | 'board_id' | 'author_id' | 'body'> &
-    Partial<Pick<BoardPostRow, 'image_url'>>,
+    Partial<Pick<BoardPostRow, 'image_url' | 'visibility'>>,
 ): Promise<{ success: boolean; id?: string; error?: string }> {
   try {
     const now = new Date().toISOString()
     await db
       .prepare(
         `INSERT INTO board_posts
-          (id, board_id, author_id, body, image_url, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+          (id, board_id, author_id, body, image_url, visibility, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
       )
       .bind(
         post.id,
@@ -830,6 +831,7 @@ export async function createBoardPost(
         post.author_id,
         post.body,
         post.image_url ?? null,
+        post.visibility ?? 'board',
         now,
         now,
       )
@@ -939,6 +941,30 @@ export async function listBoardPosts(
   )
 
   return hydrated.filter((post): post is BoardPostWithAuthor => post !== null)
+}
+
+export async function getBoardPostWithAuthorById(
+  db: D1Database,
+  postId: string,
+): Promise<BoardPostWithAuthor | null> {
+  const post = await getBoardPostById(db, postId)
+  if (!post) return null
+
+  const author = await getUserById(db, post.author_id)
+  if (!author) return null
+
+  const reactions = await getBoardPostReactionCounts(db, post.id)
+  const replyCount = await db
+    .prepare('SELECT COUNT(*) as count FROM board_post_replies WHERE parent_post_id = ?1')
+    .bind(post.id)
+    .first<{ count: number }>()
+
+  return {
+    ...post,
+    author,
+    reactions,
+    reply_count: replyCount?.count ?? 0,
+  }
 }
 
 export async function toggleBoardPostReaction(
@@ -1162,15 +1188,15 @@ export async function createBoardPostReply(
   args: {
     id: string
     parent_post_id: string
-    board_id: string
+    board_id: string | null
     author_id: string
     body: string
   },
 ): Promise<CreateBoardPostReplyResult> {
   const parent = await db
-    .prepare(`SELECT board_id, deleted_at FROM board_posts WHERE id = ?1`)
+    .prepare(`SELECT board_id, visibility, deleted_at FROM board_posts WHERE id = ?1`)
     .bind(args.parent_post_id)
-    .first<{ board_id: string; deleted_at: string | null }>()
+    .first<{ board_id: string | null; visibility: PostVisibility; deleted_at: string | null }>()
   if (!parent) return { ok: false, reason: 'parent_not_found' }
   if (parent.deleted_at) return { ok: false, reason: 'parent_deleted' }
 
@@ -1190,10 +1216,10 @@ export async function createBoardPostReply(
   const results = await db.batch([
     db
       .prepare(
-        `INSERT INTO board_posts (id, board_id, author_id, body, image_url)
-         VALUES (?1, ?2, ?3, ?4, NULL)`,
+        `INSERT INTO board_posts (id, board_id, author_id, body, image_url, visibility)
+         VALUES (?1, ?2, ?3, ?4, NULL, ?5)`,
       )
-      .bind(args.id, args.board_id, args.author_id, args.body),
+      .bind(args.id, args.board_id, args.author_id, args.body, parent.visibility),
     db
       .prepare(
         `INSERT INTO board_post_replies (post_id, parent_post_id) VALUES (?1, ?2)`,
@@ -1243,9 +1269,8 @@ export async function listBoardPostReplies(
 }
 
 /**
- * Aggregated cross-board feed: every top-level post on a board the user
- * has access to, reverse-chronological. Closes the last open acceptance
- * criterion on #205.
+ * Aggregated cross-board feed: every public signed-in post plus every
+ * top-level post on a board the user has access to, reverse-chronological.
  *
  * Access rules (mirrors the existing verifyBoardAccess in app.ts):
  *   - Center boards: user.center_id must match board.parent_id.
@@ -1267,22 +1292,30 @@ export async function listAggregatedFeed(
 
   const includeCenterBoards = user.center_id !== null
 
-  // The query unions (logically, via OR) the two access cases:
+  // The query unions (logically, via OR) the three access cases:
+  //   public post visible to every signed-in member
   //   center board the user is a member of (center_id match)
   //   event board the user has an event_attendees row for
   const result = await db
     .prepare(
       `SELECT bp.*
        FROM board_posts bp
-       JOIN boards b ON b.id = bp.board_id
+       LEFT JOIN boards b ON b.id = bp.board_id
        WHERE bp.deleted_at IS NULL
          AND bp.id NOT IN (SELECT post_id FROM board_post_replies)
          AND (
-           (?3 = 1 AND b.type = 'center' AND b.parent_id = ?2)
+           bp.visibility = 'public_signed_in'
            OR
-           (b.type = 'event' AND b.parent_id IN (
-             SELECT event_id FROM event_attendees WHERE user_id = ?1
-           ))
+           (
+             bp.visibility = 'board'
+             AND (
+               (?3 = 1 AND b.type = 'center' AND b.parent_id = ?2)
+               OR
+               (b.type = 'event' AND b.parent_id IN (
+                 SELECT event_id FROM event_attendees WHERE user_id = ?1
+               ))
+             )
+           )
          )
        ORDER BY bp.created_at DESC
        LIMIT ?4 OFFSET ?5`,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -151,6 +151,7 @@ export interface InviteCodeRow {
 }
 
 export type BoardType = 'center' | 'event'
+export type PostVisibility = 'board' | 'public_signed_in' | 'public_open'
 
 export interface BoardRow {
   id: string
@@ -161,10 +162,11 @@ export interface BoardRow {
 
 export interface BoardPostRow {
   id: string
-  board_id: string
+  board_id: string | null
   author_id: string
   body: string
   image_url: string | null
+  visibility: PostVisibility
   created_at: string
   updated_at: string
   deleted_at: string | null
@@ -266,7 +268,8 @@ export interface BoardApiResponse {
 
 export interface BoardPostApiResponse {
   id: string
-  boardId: string
+  boardId: string | null
+  visibility: PostVisibility
   body: string
   imageUrl: string | null
   createdAt: string

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -20,7 +20,7 @@ import { useCenterList, useMyEvents } from '../../hooks/useApiData'
 import { extractCityState } from '../../utils/addressParsing'
 import { CreatePostSheet, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { centerPickerStore } from '../../utils/centerPickerStore'
-import { createBoardPost, fetchBoard } from '../../utils/api'
+import { createBoardPost, createPublicPost, fetchAggregatedFeed, fetchBoard } from '../../utils/api'
 import {
   FeedHeader,
   NativeChatHeader,
@@ -140,6 +140,21 @@ function eventToGroup(event: EventDisplay, fallbackCenterName?: string, distance
   }
 }
 
+function publicToGroup(messages: BoardMessage[]): GroupBoard {
+  return {
+    id: 'public',
+    kind: 'public',
+    title: 'Public',
+    eyebrow: 'Public',
+    subtitle: 'Visible to all signed-in members',
+    meta: messages.length ? `${messages.length} posts` : 'No posts yet',
+    preview: 'Share updates, requests, and reflections with Janata.',
+    unreadCount: 0,
+    messages,
+    parentId: 'public',
+  }
+}
+
 function sortGroupsByDistance(groups: GroupBoard[]) {
   return [...groups].sort((a, b) => {
     const aDistance = a.distanceMi ?? Number.POSITIVE_INFINITY
@@ -228,7 +243,7 @@ export default function FeedScreen() {
   )
 
   const loadBoards = useCallback(async () => {
-    if (!canAccessBoards || groups.length === 0) {
+    if (!canAccessBoards) {
       setBoardMessagesByGroup({})
       setBoardsLoading(false)
       return
@@ -236,13 +251,25 @@ export default function FeedScreen() {
 
     setBoardsLoading(true)
     try {
-      const entries = await Promise.all(
-        groups.map(async (group) => {
-          const data = await fetchBoard(group.kind, group.parentId)
-          return [group.id, data.posts.map(boardPostToMessage)] as const
-        })
+      const boardGroups = groups.filter(
+        (group): group is GroupBoard & { kind: 'center' | 'event' } => group.kind !== 'public'
       )
-      setBoardMessagesByGroup(Object.fromEntries(entries))
+      const [entries, aggregatePosts] = await Promise.all([
+        Promise.all(
+          boardGroups.map(async (group) => {
+            const data = await fetchBoard(group.kind, group.parentId)
+            return [group.id, data.posts.map(boardPostToMessage)] as const
+          })
+        ),
+        fetchAggregatedFeed({ limit: 100 }),
+      ])
+      const publicMessages = aggregatePosts
+        .filter((post) => post.boardId === null || post.visibility === 'public_signed_in')
+        .map(boardPostToMessage)
+      setBoardMessagesByGroup({
+        ...Object.fromEntries(entries),
+        public: publicMessages,
+      })
     } finally {
       setBoardsLoading(false)
     }
@@ -253,12 +280,16 @@ export default function FeedScreen() {
   }, [loadBoards])
 
   const groupsWithMessages = useMemo<GroupBoard[]>(
-    () =>
-      groups.map((group) => ({
+    () => {
+      const boardGroups = groups.map((group) => ({
         ...group,
         messages: boardMessagesByGroup[group.id] ?? [],
-      })),
-    [boardMessagesByGroup, groups]
+      }))
+      return user
+        ? [publicToGroup(boardMessagesByGroup.public ?? []), ...boardGroups]
+        : boardGroups
+    },
+    [boardMessagesByGroup, groups, user]
   )
 
   const feedPosts = useMemo(() => buildFeedPosts(groupsWithMessages), [groupsWithMessages])
@@ -416,12 +447,16 @@ export default function FeedScreen() {
   }
 
   const handleCreatePost = async (
-    group: { kind: 'center' | 'event'; parentId: string },
+    group: { kind: 'center' | 'event' | 'public'; parentId: string },
     body: string,
     imageUrl?: string | null
   ) => {
     try {
-      await createBoardPost(group.kind, group.parentId, body, imageUrl)
+      if (group.kind === 'public') {
+        await createPublicPost(body, imageUrl)
+      } else {
+        await createBoardPost(group.kind, group.parentId, body, imageUrl)
+      }
       track('feed_post_created', { kind: group.kind, parentId: group.parentId, source: 'feed' })
       await loadBoards()
     } catch (err) {

--- a/packages/frontend/components/boards/CreatePostSheet.tsx
+++ b/packages/frontend/components/boards/CreatePostSheet.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { ActivityIndicator, Image, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
-import { Building2, CalendarDays, ChevronDown, ImagePlus, X } from 'lucide-react-native'
+import { Building2, CalendarDays, ChevronDown, Globe2, ImagePlus, X } from 'lucide-react-native'
 import { Avatar } from '../ui'
 import { useUser } from '../contexts'
 import type { AppColors } from '../../tokens'
 import { useAnalytics } from '../../utils/analytics'
 import { uploadBoardImage } from '../../utils/api'
+import type { GroupKind } from './types'
 
 let ImagePicker: typeof import('expo-image-picker') | null = null
 try {
@@ -14,9 +15,16 @@ try {
 
 type GroupOption = {
   id: string
-  kind: 'center' | 'event'
+  kind: GroupKind
   title: string
   parentId: string
+}
+
+const PUBLIC_GROUP: GroupOption = {
+  id: 'public',
+  kind: 'public',
+  title: 'Public',
+  parentId: '',
 }
 
 export function CreatePostSheet({
@@ -90,11 +98,19 @@ export function CreatePostSheet({
     track('board_post_image_added', { source: 'create_post_sheet' })
   }
 
-  const sortedGroups = useMemo(
-    () => [...groups].sort((a, b) => (a.kind !== b.kind ? (a.kind === 'center' ? -1 : 1) : a.title.localeCompare(b.title))),
-    [groups]
-  )
+  const sortedGroups = useMemo(() => {
+    const boardGroups = groups
+      .filter((group) => group.kind !== 'public')
+      .sort((a, b) => (a.kind !== b.kind ? (a.kind === 'center' ? -1 : 1) : a.title.localeCompare(b.title)))
+    return [PUBLIC_GROUP, ...boardGroups]
+  }, [groups])
   const selectedGroup = sortedGroups.find((g) => g.id === groupId) ?? sortedGroups[0]
+  const selectedGroupSubtitle =
+    selectedGroup?.kind === 'public'
+      ? 'Visible to all signed-in members'
+      : selectedGroup?.kind === 'event'
+        ? 'Event board'
+        : 'Center board'
 
   useEffect(() => {
     if (!visible) { setBody(''); setGroupPickerOpen(false); clearImage(); return }
@@ -171,6 +187,8 @@ export function CreatePostSheet({
               <View style={{ width: 28, height: 28, borderRadius: 9, backgroundColor: colors.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
                 {selectedGroup?.kind === 'event'
                   ? <CalendarDays size={14} color={colors.accent} strokeWidth={2.4} />
+                  : selectedGroup?.kind === 'public'
+                    ? <Globe2 size={14} color={colors.accent} strokeWidth={2.4} />
                   : <Building2 size={14} color={colors.accent} strokeWidth={2.4} />}
               </View>
               <View style={{ flex: 1, minWidth: 0 }}>
@@ -179,7 +197,7 @@ export function CreatePostSheet({
                 </Text>
                 {selectedGroup && (
                   <Text style={{ fontSize: 12, color: colors.textFaint }} numberOfLines={1}>
-                    {selectedGroup.kind === 'event' ? 'Event board' : 'Center board'}
+                    {selectedGroupSubtitle}
                   </Text>
                 )}
               </View>
@@ -199,6 +217,8 @@ export function CreatePostSheet({
                       <View style={{ width: 24, height: 24, borderRadius: 7, backgroundColor: colors.panel, alignItems: 'center', justifyContent: 'center' }}>
                         {group.kind === 'event'
                           ? <CalendarDays size={12} color={colors.textMuted} strokeWidth={2.3} />
+                          : group.kind === 'public'
+                            ? <Globe2 size={12} color={colors.textMuted} strokeWidth={2.3} />
                           : <Building2 size={12} color={colors.textMuted} strokeWidth={2.3} />}
                       </View>
                       <Text style={{ flex: 1, fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }} numberOfLines={1}>
@@ -219,7 +239,13 @@ export function CreatePostSheet({
               multiline
               value={body}
               onChangeText={setBody}
-              placeholder={selectedGroup?.kind === 'event' ? `Share something with ${selectedGroup.title}...` : 'Share something with your center...'}
+              placeholder={
+                selectedGroup?.kind === 'public'
+                  ? 'Share something with Janata...'
+                  : selectedGroup?.kind === 'event'
+                    ? `Share something with ${selectedGroup.title}...`
+                    : 'Share something with your center...'
+              }
               placeholderTextColor={colors.textFaint}
               style={{ flex: 1, minHeight: 160, fontFamily: 'Inclusive Sans', fontSize: 16, lineHeight: 23, color: colors.text, textAlignVertical: 'top', paddingTop: 6 }}
             />
@@ -253,7 +279,9 @@ export function CreatePostSheet({
           )}
 
           <Text style={{ marginTop: 16, fontSize: 12, lineHeight: 18, color: colors.textFaint }}>
-            Visible to members in {selectedGroup?.title || 'your group'}.
+            {selectedGroup?.kind === 'public'
+              ? 'Visible to signed-in Janata members.'
+              : `Visible to members in ${selectedGroup?.title || 'your group'}.`}
           </Text>
         </ScrollView>
       </KeyboardAvoidingView>

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
-import { Building2, CalendarDays, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
+import { Building2, CalendarDays, Globe2, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar, ImageLightbox } from '../ui'
 import { useUser } from '../contexts'
 import type { BoardMessage } from './__mocks__/mockData'
@@ -318,7 +318,9 @@ export function BoardPostCard({
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const isFeedCard = showSource || asCard
   const sourceIcon =
-    message.sourceKind === 'event' ? (
+    message.sourceKind === 'public' ? (
+      <Globe2 size={11} color={accent} strokeWidth={2.4} />
+    ) : message.sourceKind === 'event' ? (
       <CalendarDays size={11} color={accent} strokeWidth={2.4} />
     ) : (
       <Building2 size={11} color={colors.textSecondary} strokeWidth={2.3} />
@@ -328,6 +330,8 @@ export function BoardPostCard({
     <Pressable
       disabled={!onPress}
       onPress={onPress}
+      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityLabel={onPress ? `Open post by ${message.author.name}` : undefined}
       style={{
         marginHorizontal: isFeedCard ? 0 : 0,
         marginBottom: isFeedCard ? 12 : 0,
@@ -356,7 +360,7 @@ export function BoardPostCard({
               width: 20,
               height: 20,
               borderRadius: 6,
-              backgroundColor: message.sourceKind === 'event' ? accentSoft : colors.iconBoxBg,
+              backgroundColor: message.sourceKind === 'event' || message.sourceKind === 'public' ? accentSoft : colors.iconBoxBg,
               alignItems: 'center',
               justifyContent: 'center',
             }}
@@ -480,7 +484,11 @@ export function BoardPostCard({
                 active={index === 0}
               />
             ))}
-            <View
+            <Pressable
+              disabled={!onPress}
+              onPress={onPress}
+              accessibilityRole={onPress ? 'button' : undefined}
+              accessibilityLabel={onPress ? 'Open post to react' : undefined}
               style={{
                 borderRadius: 999,
                 borderWidth: 1,
@@ -493,8 +501,12 @@ export function BoardPostCard({
               <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textMuted }}>
                 + React
               </Text>
-            </View>
-            <View
+            </Pressable>
+            <Pressable
+              disabled={!onPress}
+              onPress={onPress}
+              accessibilityRole={onPress ? 'button' : undefined}
+              accessibilityLabel={onPress ? 'Open post replies' : undefined}
               style={{
                 marginLeft: isFeedCard ? 'auto' : 0,
                 flexDirection: 'row',
@@ -506,7 +518,7 @@ export function BoardPostCard({
               <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: accent }}>
                 {replies} {replies === 1 ? 'reply' : 'replies'}
               </Text>
-            </View>
+            </Pressable>
           </View>
         </View>
       </View>

--- a/packages/frontend/components/boards/__mocks__/mockData.ts
+++ b/packages/frontend/components/boards/__mocks__/mockData.ts
@@ -20,7 +20,7 @@ export interface BoardMessage {
   replyCount?: number
   pinned?: boolean
   sourceLabel?: string
-  sourceKind?: 'center' | 'event'
+  sourceKind?: 'center' | 'event' | 'public'
 }
 
 export interface EventBoard {

--- a/packages/frontend/components/boards/types.ts
+++ b/packages/frontend/components/boards/types.ts
@@ -1,6 +1,6 @@
 import type { AppColors } from '../../tokens'
 
-export type GroupKind = 'center' | 'event'
+export type GroupKind = 'center' | 'event' | 'public'
 
 /** Canonical color token set. Alias for AppColors. */
 export type ColorSet = AppColors

--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { View, Text, Image, ScrollView, Pressable, Linking } from 'react-native'
 import { MapPin, Globe, Phone, User, ChevronLeft, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import CopyLinkButton from '../ui/CopyLinkButton'
@@ -7,7 +7,11 @@ import { CenterAbout } from './CenterAbout'
 import { useBoard, type CenterDisplay } from '../../hooks/useApiData'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
+import { useColors } from '../../hooks/useColors'
 import { ThreadPanel, boardPostToMessage } from '../boards'
+import type { BoardMessage } from '../boards'
+import { PostThread, type FeedPost } from '../feed'
+import { buildFeedPostFromMessage } from '../feed/feedData'
 import { useUser } from '../contexts'
 
 // ── Props ────────────────────────────────────────────────────────────────
@@ -39,7 +43,9 @@ export default function CenterDetailPanel({
   onEventPress,
 }: CenterDetailPanelProps) {
   const colors = useDetailColors()
+  const appColors = useColors()
   const { user } = useUser()
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
 
   const handleAddressPress = () => {
     const query = encodeURIComponent(center.address)
@@ -75,6 +81,56 @@ export default function CenterDetailPanel({
   const handleCreateThreadPost = async (body: string) => {
     await createBoardPost('center', center.id, body)
     await refetchBoard()
+  }
+
+  const openThreadPost = (message: BoardMessage) => {
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `center-${center.id}`,
+        kind: 'center',
+        parentId: center.id,
+        title: center.name,
+        subtitle: center.address || 'Center board',
+      })
+    )
+  }
+
+  if (threadDetailPost) {
+    return (
+      <View
+        style={{
+          maxWidth: 440,
+          width: '100%',
+          height: '100%',
+          backgroundColor: appColors.bg,
+          borderLeftWidth: 1,
+          borderLeftColor: appColors.border,
+        }}
+      >
+        <View style={{ paddingTop: 12 }}>
+          <Pressable
+            onPress={() => setThreadDetailPost(null)}
+            accessibilityRole="button"
+            accessibilityLabel="Back to board"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
+          >
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              setThreadDetailPost(null)
+              refetchBoard()
+            }}
+          />
+        </View>
+      </View>
+    )
   }
 
   return (
@@ -458,6 +514,7 @@ export default function CenterDetailPanel({
             composerPlaceholder="Write to the board..."
             composerState={canPostToThread ? 'open' : 'locked'}
             onSubmitPost={handleCreateThreadPost}
+            onMessagePress={openThreadPost}
           />
         </DetailSection>
       </ScrollView>

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { View, Text, Image, ScrollView, Pressable, ActivityIndicator, Linking } from 'react-native'
 import { MapPin, Users, User, Clock, CheckCircle, ChevronLeft, Pencil, ExternalLink, Trash2, CalendarPlus } from 'lucide-react-native'
 import CopyLinkButton from '../ui/CopyLinkButton'
@@ -8,9 +8,12 @@ import Avatar from '../ui/Avatar'
 import PrimaryButton from '../ui/buttons/PrimaryButton'
 import DestructiveButton from '../ui/buttons/DestructiveButton'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import { useColors } from '../../hooks/useColors'
 import { useBoard } from '../../hooks/useApiData'
 import { createBoardPost } from '../../utils/api'
 import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../boards'
+import { PostThread, type FeedPost } from '../feed'
+import { buildFeedPostFromMessage } from '../feed/feedData'
 import { useUser } from '../contexts'
 
 // ---------------------------------------------------------------------------
@@ -672,6 +675,7 @@ function RegisteredContent({
   canPostToThread,
   boardMessages,
   onSubmitPost,
+  onMessagePress,
 }: {
   event: EventDetailPanelProps['event']
   attendees: Attendee[]
@@ -679,6 +683,7 @@ function RegisteredContent({
   canPostToThread: boolean
   boardMessages: BoardMessage[]
   onSubmitPost: (body: string) => Promise<void>
+  onMessagePress: (message: BoardMessage) => void
 }) {
   return (
     <View style={{ flex: 1 }}>
@@ -723,6 +728,7 @@ function RegisteredContent({
             composerPlaceholder="Write to the group..."
             composerState={canPostToThread ? 'open' : 'locked'}
             onSubmitPost={onSubmitPost}
+            onMessagePress={onMessagePress}
           />
         </DetailSection>
       </ScrollView>
@@ -956,7 +962,9 @@ export default function EventDetailPanel({
   onDelete,
 }: EventDetailPanelProps) {
   const colors = useDetailColors()
+  const appColors = useColors()
   const { user } = useUser()
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const isRegistered = event.isRegistered && !isPast
   const canPostToThread = !!user && (!!isRegistered || !!isAdmin)
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('event', event.id, canPostToThread)
@@ -965,6 +973,56 @@ export default function EventDetailPanel({
   const handleCreateThreadPost = async (body: string) => {
     await createBoardPost('event', event.id, body)
     await refetchBoard()
+  }
+
+  const openThreadPost = (message: BoardMessage) => {
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `event-${event.id}`,
+        kind: 'event',
+        parentId: event.id,
+        title: event.title,
+        subtitle: event.location || `${event.attendees ?? 0} going`,
+      })
+    )
+  }
+
+  if (threadDetailPost) {
+    return (
+      <View
+        style={{
+          maxWidth: 440,
+          width: '100%',
+          height: '100%',
+          backgroundColor: appColors.bg,
+          borderLeftWidth: 1,
+          borderLeftColor: appColors.border,
+        }}
+      >
+        <View style={{ paddingTop: 12 }}>
+          <Pressable
+            onPress={() => setThreadDetailPost(null)}
+            accessibilityRole="button"
+            accessibilityLabel="Back to discussion"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
+          >
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontSize: 14, color: appColors.accent }}>Back to discussion</Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              setThreadDetailPost(null)
+              refetchBoard()
+            }}
+          />
+        </View>
+      </View>
+    )
   }
 
   return (
@@ -1000,6 +1058,7 @@ export default function EventDetailPanel({
           canPostToThread={canPostToThread}
           boardMessages={boardMessages}
           onSubmitPost={handleCreateThreadPost}
+          onMessagePress={openThreadPost}
         />
       ) : (
         <DefaultContent

--- a/packages/frontend/components/feed/FeedContextRail.tsx
+++ b/packages/frontend/components/feed/FeedContextRail.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Pressable, Text, TextInput, View } from 'react-native'
-import { Building2, CalendarDays, Search } from 'lucide-react-native'
+import { Building2, CalendarDays, Globe2, Search } from 'lucide-react-native'
 import type { AppColors } from '../../tokens'
 import type { GroupBoard } from './types'
 
@@ -89,7 +89,8 @@ function RailBoardRow({
   onPress: () => void
 }) {
   const isCenter = group.kind === 'center'
-  const Icon = isCenter ? Building2 : CalendarDays
+  const isPublic = group.kind === 'public'
+  const Icon = isPublic ? Globe2 : isCenter ? Building2 : CalendarDays
   return (
     <Pressable
       onPress={onPress}
@@ -127,6 +128,10 @@ function RailBoardRow({
                 YOUR CENTER
               </Text>
             </View>
+          ) : isPublic ? (
+            <Text style={{ fontSize: 11.5, color: colors.textFaint }} numberOfLines={1}>
+              Signed-in members
+            </Text>
           ) : null}
           <Text style={{ fontSize: 12, color: colors.textFaint }} numberOfLines={1}>
             {group.eyebrow}

--- a/packages/frontend/components/feed/FeedEmptyState.tsx
+++ b/packages/frontend/components/feed/FeedEmptyState.tsx
@@ -40,9 +40,10 @@ export function FeedEmptyState({
   onCompose?: () => void
   onOpenGroup: (group: GroupBoard) => void
 }) {
+  const boardGroups = groups.filter((group) => group.kind !== 'public')
   const state: 'guest' | 'joinCenter' | 'firstPost' = !isSignedIn
     ? 'guest'
-    : groups.length > 0
+    : boardGroups.length > 0
       ? 'firstPost'
       : 'joinCenter'
 

--- a/packages/frontend/components/feed/FeedList.tsx
+++ b/packages/frontend/components/feed/FeedList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Pressable, Text, View } from 'react-native'
-import { Building2, CalendarDays, ChevronRight } from 'lucide-react-native'
+import { Building2, CalendarDays, ChevronRight, Globe2 } from 'lucide-react-native'
 import type { ThreadPanelColors } from '../boards'
 import type { AppColors } from '../../tokens'
 import type { FeedPost, GroupBoard } from './types'
@@ -106,7 +106,8 @@ function BoardEmptyRow({
   colors: AppColors
   onPress: () => void
 }) {
-  const Icon = group.kind === 'event' ? CalendarDays : Building2
+  const Icon = group.kind === 'public' ? Globe2 : group.kind === 'event' ? CalendarDays : Building2
+  const isAccent = group.kind !== 'center'
 
   return (
     <Pressable
@@ -127,14 +128,14 @@ function BoardEmptyRow({
           width: 38,
           height: 38,
           borderRadius: 12,
-          backgroundColor: group.kind === 'event' ? colors.accentSoft : colors.panel,
+          backgroundColor: isAccent ? colors.accentSoft : colors.panel,
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
         <Icon
           size={18}
-          color={group.kind === 'event' ? colors.accent : colors.textMuted}
+          color={isAccent ? colors.accent : colors.textMuted}
           strokeWidth={2.3}
         />
       </View>
@@ -146,7 +147,7 @@ function BoardEmptyRow({
           {group.eyebrow}
         </Text>
         <Text style={{ fontSize: 13, lineHeight: 18, color: colors.textMuted }} numberOfLines={2}>
-          Open to start the conversation
+          {group.kind === 'public' ? 'Share with signed-in members' : 'Open to start the conversation'}
         </Text>
       </View>
       <ChevronRight size={18} color={colors.textFaint} />

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Image, Pressable, Text, View } from 'react-native'
-import { Building2, CalendarDays, MessageCircle } from 'lucide-react-native'
+import { Building2, CalendarDays, Globe2, MessageCircle } from 'lucide-react-native'
 import { Avatar, ImageLightbox } from '../ui'
 import type { AppColors } from '../../tokens'
 import type { FeedPost } from './types'
@@ -17,6 +17,8 @@ export function FeedPostCard({
   const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
   const replies = post.replyCount ?? 2
   const [lightboxOpen, setLightboxOpen] = useState(false)
+  const isEvent = post.sourceKind === 'event'
+  const isPublic = post.sourceKind === 'public'
 
   return (
     <Pressable
@@ -33,12 +35,14 @@ export function FeedPostCard({
             width: 18,
             height: 18,
             borderRadius: 5,
-            backgroundColor: post.sourceKind === 'event' ? colors.accentSoft : colors.panel,
+            backgroundColor: isEvent || isPublic ? colors.accentSoft : colors.panel,
             alignItems: 'center',
             justifyContent: 'center',
           }}
         >
-          {post.sourceKind === 'event' ? (
+          {isPublic ? (
+            <Globe2 size={10} color={colors.accent} strokeWidth={2.4} />
+          ) : isEvent ? (
             <CalendarDays size={10} color={colors.accent} strokeWidth={2.4} />
           ) : (
             <Building2 size={10} color={colors.textMuted} strokeWidth={2.3} />

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -4,6 +4,7 @@ import {
   Building2,
   CalendarDays,
   ChevronUp,
+  Globe2,
   MoreHorizontal,
   Pencil,
   Pin,
@@ -84,7 +85,7 @@ export function PostThread({
   const [actionBusy, setActionBusy] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
 
-  const canPin = canPinPosts(user)
+  const canPin = post.groupKind !== 'public' && canPinPosts(user)
   const isAuthor = canModifyPost(user, post.author.id)
   const hasMenu = canPin || isAuthor
 
@@ -429,6 +430,7 @@ export function PostThread({
 
 function SourceBoardChip({ post, colors }: { post: FeedPost; colors: AppColors }) {
   const isEvent = post.groupKind === 'event'
+  const isPublic = post.groupKind === 'public'
   return (
     <View
       style={{
@@ -443,13 +445,15 @@ function SourceBoardChip({ post, colors }: { post: FeedPost; colors: AppColors }
         gap: 6,
       }}
     >
-      {isEvent ? (
+      {isPublic ? (
+        <Globe2 size={13} color={colors.accent} strokeWidth={2.3} />
+      ) : isEvent ? (
         <CalendarDays size={13} color={colors.accent} strokeWidth={2.3} />
       ) : (
         <Building2 size={13} color={colors.accent} strokeWidth={2.3} />
       )}
       <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.accent }}>
-        {post.sourceTitle} - Board
+        {isPublic ? post.sourceTitle : `${post.sourceTitle} - Board`}
       </Text>
     </View>
   )

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -83,6 +83,7 @@ export interface MapPoint {
 }
 
 export type BoardType = 'center' | 'event'
+export type PostVisibility = 'board' | 'public_signed_in' | 'public_open'
 
 export interface BoardData {
   id: string
@@ -93,7 +94,8 @@ export interface BoardData {
 
 export interface BoardPostData {
   id: string
-  boardId: string
+  boardId: string | null
+  visibility: PostVisibility
   body: string
   imageUrl: string | null
   createdAt: string
@@ -537,6 +539,22 @@ export async function createBoardPost(
   if (!response.ok) {
     const err = await response.json().catch(() => ({ message: 'Failed to create board post' }))
     throw new Error(err.message || 'Failed to create board post')
+  }
+  const data = await response.json()
+  return data.post
+}
+
+export async function createPublicPost(
+  body: string,
+  imageUrl?: string | null
+): Promise<BoardPostData> {
+  const response = await authFetch('/feed/public', {
+    method: 'POST',
+    body: JSON.stringify({ body, imageUrl: imageUrl ?? null }),
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ message: 'Failed to create public post' }))
+    throw new Error(err.message || 'Failed to create public post')
   }
   const data = await response.json()
   return data.post
@@ -1051,7 +1069,8 @@ export async function reportBoardPost(postId: string, reason?: string): Promise<
 
 export interface ModerationQueuePost {
   id: string
-  boardId: string
+  boardId: string | null
+  visibility?: PostVisibility
   body: string
   imageUrl: string | null
   createdAt: string

--- a/scripts/dev/setup-local-demo.sh
+++ b/scripts/dev/setup-local-demo.sh
@@ -12,7 +12,7 @@ cd "$(git rev-parse --show-toplevel)"
 CFG="packages/backend/wrangler.toml"
 DB="chinmaya-janata-db"            # --local sandboxes this; nothing remote is touched
 PW="PreviewTest2026!"
-CENTER="c1000001-0000-0000-0000-000000000001"   # Chinmaya Mission Boston (seeded)
+CENTER="c0000001-0000-0000-0000-000000000008"   # Chinmaya Sandeepany, San Jose (seeded)
 # Data-only migrations assume mid-history column orders; skip them (same as the
 # preview setup) and let seed_preview_data.sql provide the demo data.
 SKIP="0002 0007 0008 0010 0012 0013"


### PR DESCRIPTION
## Summary
- add board post visibility support and a migration that allows signed-in public feed posts without a board
- add the authenticated `POST /api/feed/public` endpoint and include public posts in the aggregated feed
- reuse the shared thread flow for public, center, and event posts, including Explore side-panel boards
- keep pinning scoped to center/event board posts and update local demo seeding for the current center id

## Validation
- `npm run typecheck`
- `npm run test:backend` (413 passed)
- local manual QA on `http://localhost:8081`: public posting, center board posting/thread reactions/replies, event board posting/thread reactions/replies, pinning, and sign out/sign in

## Notes
- `cd packages/frontend && npx tsc --noEmit` still has pre-existing unrelated frontend type errors in explore/auth/notifications/onboarding/EventCard/WebBottomNav test files.