### PR TITLE
chore: add Ralph runner setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ lerna-debug.log*
 *.sublime-workspace
 .claude/
 
+# Local agent/runtime state. These are intentionally machine-local and must
+# not be pushed from the Mac Mini Ralph runner.
+.context/
+.ralph/
+local-notes/
+
 # OS
 .DS_Store
 .DS_Store?
@@ -128,6 +134,12 @@ docs/plans/2026-02-27-auth-page-redesign.md
 /playwright/.cache/
 /playwright/.auth/
 /.playwright-mcp/
+
+# Ralph runner evidence videos/screenshots are posted to Slack and linked from
+# PRs; keep raw local captures out of Git.
+evidence/
+*.mov
+*.mp4
 
 .wrangler/
 

--- a/docs/ralph-runner.md
+++ b/docs/ralph-runner.md
@@ -1,0 +1,103 @@
+# Ralph Runner
+
+This repo includes a lightweight setup for running Ralph Loop locally on the Mac Mini.
+
+Runtime state is intentionally local-only:
+
+- `.ralph/`
+- `.context/`
+- `local-notes/`
+- raw evidence videos/screenshots
+
+Do not commit those files. The reusable setup scripts are committed under `scripts/ralph/`.
+
+## One-Time Setup
+
+From a clean checkout on the Mac Mini:
+
+```bash
+git checkout v2
+git pull origin v2
+npm install
+npm run ralph:setup
+```
+
+`npm run ralph:setup` creates:
+
+- `.ralph/prd.json` from the GitHub milestone `MSC v2 Beta`
+- `.ralph/learnings.md`
+- `.ralph/verify.sh`
+- `.context/evidence/`
+
+It also adds local Git excludes for Ralph runtime state.
+
+## Required Tools
+
+The Mac Mini needs:
+
+- Xcode and iOS Simulator
+- Homebrew
+- Node/npm
+- GitHub CLI authenticated with repo access
+- Codex
+- `ralph-loop` on `PATH`
+- EAS CLI for build preparation only
+
+Do not run App Store submit or publish commands from the runner.
+
+## Sprint Board
+
+Ralph pulls stories from:
+
+- Repo: `Project-Janata/Janata`
+- Milestone: `MSC v2 Beta`
+- Target branch: `v2`
+- Slack channel: `#priduct-updates`
+
+Use labels to manage the board:
+
+- `status:todo`, `status:in-progress`, `status:review`, `status:blocked`, `status:done`
+- `priority:p0`, `priority:p1`, `priority:p2`, `priority:p3`
+- `area:*`
+- `ralph:story`
+
+## Running One Story
+
+Prefer one story at a time:
+
+```bash
+npm run ralph:status
+npm run ralph:run-one
+```
+
+After a story:
+
+1. Push the feature branch.
+2. Open or update the PR.
+3. Run automated checks.
+4. Run end-to-end UI testing.
+5. Record browser/iOS simulator evidence.
+6. Post video evidence to `#priduct-updates`.
+7. Link or reference the evidence in the PR.
+8. Merge to `v2` only if the gate passes.
+
+## Merge Gate
+
+A PR may merge into `v2` only after:
+
+- `.ralph/verify.sh` passes
+- end-to-end UI smoke passes
+- design review passes
+- recorded video evidence is posted to `#priduct-updates`
+- PR includes test evidence and known residual risk
+
+## Refreshing The Local PRD
+
+When GitHub Issues change:
+
+```bash
+npm run ralph:setup
+```
+
+This regenerates `.ralph/prd.json` from the milestone. Do this before starting a new Ralph session.
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   ],
   "scripts": {
     "setup": "npm install && npm run d1:migrate:local && npm run d1:seed",
+    "ralph:setup": "bash scripts/ralph/setup-local.sh",
+    "ralph:status": "ralph-loop status",
+    "ralph:run-one": "ralph-loop run --one",
+    "ralph:run": "ralph-loop run",
     "postinstall": "node scripts/patch-css.cjs",
     "dev": "pkill -f wrangler 2>/dev/null; pkill -f expo 2>/dev/null; pkill -f react-native 2>/dev/null; sleep 1; concurrently -n api,web -c blue,green \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "cd packages/backend && npm run dev",

--- a/scripts/ralph/setup-local.sh
+++ b/scripts/ralph/setup-local.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+mkdir -p .ralph .context/evidence
+
+EXCLUDE_FILE="$(git rev-parse --git-path info/exclude)"
+touch "$EXCLUDE_FILE"
+for pattern in ".ralph/" ".context/" "local-notes/" "evidence/" "*.mov" "*.mp4"; do
+  if ! grep -qxF "$pattern" "$EXCLUDE_FILE"; then
+    printf '%s\n' "$pattern" >> "$EXCLUDE_FILE"
+  fi
+done
+
+if ! command -v ralph-loop >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Missing `ralph-loop` on PATH.
+
+Install it first on this Mac Mini, then rerun:
+  npm run ralph:setup
+EOF
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Missing GitHub CLI (`gh`) on PATH." >&2
+  exit 1
+fi
+
+gh auth status >/dev/null
+
+node scripts/ralph/write-prd-from-github.cjs
+
+if [ ! -f .ralph/learnings.md ]; then
+  cat > .ralph/learnings.md <<'EOF'
+# Ralph Learnings
+
+Append factual execution observations below. Do not edit previous entries.
+EOF
+fi
+
+cat > .ralph/verify.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+npm run typecheck
+npm run test:frontend
+npm run test:backend
+npm run build
+EOF
+chmod +x .ralph/verify.sh
+
+echo "Ralph local state is ready."
+echo
+ralph-loop status
+

--- a/scripts/ralph/write-prd-from-github.cjs
+++ b/scripts/ralph/write-prd-from-github.cjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repo = process.env.RALPH_REPO || 'Project-Janata/Janata';
+const milestoneTitle = process.env.RALPH_MILESTONE || 'MSC v2 Beta';
+const targetBranch = process.env.RALPH_TARGET_BRANCH || 'v2';
+const branchName = process.env.RALPH_BRANCH || 'ralph/msc-v2-train';
+const slackChannel = process.env.RALPH_SLACK_CHANNEL || '#priduct-updates';
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function api(pathname) {
+  return JSON.parse(gh(['api', pathname]));
+}
+
+function labelNames(item) {
+  return (item.labels || []).map((label) => label.name);
+}
+
+function firstLabel(labels, prefix) {
+  return labels.find((label) => label.startsWith(prefix)) || '';
+}
+
+function priorityRank(item) {
+  const labels = labelNames(item);
+  const label = firstLabel(labels, 'priority:');
+  if (label === 'priority:p0') return 0;
+  if (label === 'priority:p1') return 1;
+  if (label === 'priority:p2') return 2;
+  if (label === 'priority:p3') return 3;
+  return 9;
+}
+
+function areaRank(item) {
+  const labels = labelNames(item);
+  const order = [
+    'area:ops',
+    'area:feed',
+    'area:navigation',
+    'area:trust',
+    'area:ios',
+    'area:moderation',
+    'area:beta',
+    'area:profile',
+    'area:performance',
+    'area:accessibility',
+    'area:presentation',
+    'area:docs',
+  ];
+  const index = order.findIndex((area) => labels.includes(area));
+  return index === -1 ? order.length : index;
+}
+
+function storyTitle(item) {
+  return item.pull_request ? `PR #${item.number}: ${item.title}` : `Issue #${item.number}: ${item.title}`;
+}
+
+function storyDescription(item) {
+  const kind = item.pull_request ? 'pull request' : 'issue';
+  return `Work through GitHub ${kind} #${item.number}: ${item.title}`;
+}
+
+function criteriaFor(item) {
+  const labels = labelNames(item);
+  const criteria = [
+    `GitHub item #${item.number} is updated with implementation status`,
+    'Automated verification passes through .ralph/verify.sh',
+    `If UI-facing, end-to-end UI smoke is recorded and posted to ${slackChannel}`,
+    'PR includes test evidence, residual risk, and links to the GitHub issue or sprint item',
+  ];
+
+  if (item.pull_request) {
+    criteria.unshift('PR is reviewed as merge, split, rebase, hold, or close');
+  }
+  if (labels.includes('area:ios')) {
+    criteria.push('No App Store submit or publish command is run');
+  }
+  if (labels.includes('area:ops')) {
+    criteria.push('Production secret changes are documented for human handoff if required');
+  }
+  if (labels.includes('area:feed')) {
+    criteria.push('Empty, loading, error, signed-out, and signed-in states are checked where relevant');
+  }
+  if (labels.includes('area:trust')) {
+    criteria.push('Unauthorized, expired, duplicate, and invalid-token edge cases are checked where relevant');
+  }
+  return criteria;
+}
+
+const milestones = api(`repos/${repo}/milestones?state=open&per_page=100`);
+const milestone = milestones.find((entry) => entry.title === milestoneTitle);
+if (!milestone) {
+  throw new Error(`Milestone not found: ${milestoneTitle}`);
+}
+
+const items = api(`repos/${repo}/issues?milestone=${milestone.number}&state=open&per_page=100`);
+items.sort((a, b) => {
+  return (
+    priorityRank(a) - priorityRank(b) ||
+    areaRank(a) - areaRank(b) ||
+    a.number - b.number
+  );
+});
+
+const userStories = items.map((item, index) => {
+  const labels = labelNames(item);
+  return {
+    id: `GH-${String(item.number).padStart(3, '0')}`,
+    githubNumber: item.number,
+    githubUrl: item.html_url,
+    githubType: item.pull_request ? 'pull_request' : 'issue',
+    title: storyTitle(item),
+    description: storyDescription(item),
+    labels,
+    acceptanceCriteria: criteriaFor(item),
+    priority: index + 1,
+    passes: false,
+    notes: '',
+    requiredForBeta: true,
+    mergeGate: `E2E UI test pass plus recorded video posted to ${slackChannel} before merge to ${targetBranch}`,
+  };
+});
+
+const prd = {
+  project: 'Project Janata MSC v2',
+  branchName,
+  targetBranch,
+  sourceContext: {
+    repo,
+    milestone: milestoneTitle,
+    milestoneNumber: milestone.number,
+    milestoneUrl: milestone.html_url,
+    generatedAt: new Date().toISOString(),
+    slackChannel,
+    launchWindow: 'MSC 2026, July 30-August 4',
+    presentationSlot: '2026-08-01 20:30-20:45',
+  },
+  executionPolicy: {
+    targetBranch,
+    prdPersistence: 'local-only; do not commit .ralph/prd.json',
+    mergePolicy: `A feature PR may be merged into ${targetBranch} only after automated checks, end-to-end UI testing, design review, and recorded video evidence posted to ${slackChannel}.`,
+    appStorePolicy: 'Do not submit or publish to the iOS App Store. Prepare everything up to the handoff point for a human submission.',
+    slackPolicy: `Use the Janata developer agent Slack bot in ${slackChannel} for daily updates and video evidence.`,
+    secretsPolicy: 'Investigate, document, and prepare safe changes, but human owns any manual production secret cleanup.',
+    betaScope: 'All listed stories are required for beta unless the user explicitly changes scope.',
+  },
+  verificationCommand: 'bash .ralph/verify.sh',
+  userStories,
+};
+
+fs.mkdirSync(path.join(process.cwd(), '.ralph'), { recursive: true });
+fs.writeFileSync(path.join(process.cwd(), '.ralph', 'prd.json'), `${JSON.stringify(prd, null, 2)}\n`);
+console.log(`Wrote .ralph/prd.json with ${userStories.length} stories from ${milestoneTitle}.`);
+


### PR DESCRIPTION
Adds a repo-local Ralph runner scaffold for the Mac Mini.\n\nWhat this includes:\n- npm scripts: ralph:setup, ralph:status, ralph:run-one, ralph:run\n- scripts/ralph/setup-local.sh to generate local-only .ralph state\n- scripts/ralph/write-prd-from-github.cjs to build .ralph/prd.json from the MSC v2 Beta milestone\n- docs/ralph-runner.md runbook\n- .gitignore coverage for .ralph, .context, local-notes, and raw evidence videos\n\nRuntime state remains local-only and should not be committed.\n\nVerified:\n- npm run ralph:setup generated 36 local Ralph stories from the GitHub milestone\n- .ralph/prd.json, .context/evidence, and local-notes are ignored\n- package.json parses\n\nNo app runtime code changes.