### PR TITLE
docs(release): add v2 → main cutover runbook + db:cutover-status helper

### DIFF
--- a/docs/release-cutover.md
+++ b/docs/release-cutover.md
@@ -1,0 +1,175 @@
+# Release cutover — v2 → main
+
+The recurring runbook for cutting a release from the `v2` development branch
+to `main`. Follow these steps in order. Each step is safe to re-run.
+
+## Why this exists
+
+- CI does NOT auto-apply migrations. They land in `migrations/` on `v2` as
+  PRs merge, but the live D1 schema only changes when somebody runs
+  `wrangler d1 execute --remote --file=…`.
+- Prod and staging workers share one D1 (`database_id: d38b4cd2-...`). So
+  every schema change affects both environments simultaneously.
+- `deploy.yml` deploys the **staging Worker** on every push to `main` and
+  the **production Worker** on manual `workflow_dispatch`. Neither runs
+  migrations.
+
+The net effect: **a migration applied at the wrong time can put deployed
+code and live schema out of sync.** The safe order is *apply migrations
+first, then ship code*.
+
+## Pre-flight (run this anytime you're thinking about cutting a release)
+
+```bash
+npm run db:cutover-status
+```
+
+It prints:
+- how far `v2` is ahead of `main` (commits, PRs)
+- which migrations on `v2` haven't been applied to prod D1 yet
+- whether any of them touch canon-tier tables (and thus need a snapshot)
+- the exact apply commands in order
+
+If output says "no pending migrations, no commits ahead" — there's nothing
+to release.
+
+## The eight-step cutover
+
+### 1. Verify v2 is healthy
+
+```bash
+git checkout v2 && git pull origin v2
+bash .ralph/verify.sh
+```
+
+All five gates green. If anything fails, fix on v2 before continuing.
+
+### 2. Snapshot canon-tier data (if any pending migration touches it)
+
+`db:cutover-status` flags this with a ⚠. If you see the flag:
+
+```bash
+npm run db:snapshot -- --remote
+# → data/snapshots/<utc-stamp>/{centers,events}.sql
+```
+
+If no canon-tier migration is pending you can skip this, but a weekly
+snapshot regardless is cheap insurance.
+
+### 3. Apply pending migrations to the shared prod D1
+
+Use the apply block that `db:cutover-status` printed. It looks like:
+
+```bash
+npx wrangler d1 execute chinmaya-janata-db \
+  --file=migrations/0020_xxx.sql \
+  --config packages/backend/wrangler.toml
+# repeat per pending file in numerical order
+```
+
+Note: no `--local` flag. Without it, `wrangler d1 execute` hits the
+remote D1. This is the only step that changes prod schema.
+
+If any migration errors:
+- Tier 1 (canon) failure → STOP. Use `npm run db:restore -- --remote
+  data/snapshots/<latest>` to revert the canon data, fix the migration on
+  v2, re-run pre-flight from step 1.
+- Tier 2 (disposable) failure → usually a non-idempotent re-apply. Inspect
+  the error; if the table state matches what the migration was trying to
+  create, you can skip and move on.
+
+### 4. Open the v2 → main PR
+
+```bash
+gh pr create --repo Project-Janata/Janata \
+  --base main --head v2 \
+  --title "release: v2 → main ($(date -u +%Y-%m-%d))" \
+  --body-file - <<EOF
+Cutover release of all v2 work since last main release.
+
+Migrations applied (already done in step 3):
+$(npm run db:cutover-status --machine 2>/dev/null | grep '^migrations/' | sed 's/^/  - /')
+
+Auto-deploy: deploy.yml will run on merge → staging Worker.
+Prod deploy: run \`gh workflow run Deploy -f environment=production\` after staging verifies.
+EOF
+```
+
+### 5. Merge
+
+```bash
+gh pr merge <PR-num> --squash --repo Project-Janata/Janata
+```
+
+`deploy.yml` triggers automatically. Staging Worker redeploys against
+the (already-migrated) D1. Should be healthy because step 3 ran first.
+
+### 6. Verify staging Worker against the new schema
+
+Quick smoke against the staging endpoint:
+
+```bash
+curl -sf https://api.chinmayajanata.org/api/centers >/dev/null && echo "✓ centers ok"
+curl -sf https://api.chinmayajanata.org/api/fetchAllEvents >/dev/null && echo "✓ events ok"
+```
+
+(Note: the live `api.chinmayajanata.org` is the production Worker, which
+won't have redeployed yet. To hit staging, use the staging Worker URL
+from the deploy.yml output — `chinmaya-janata-api-staging.<account>.workers.dev`
+or whatever route is configured.)
+
+If staging is broken, you can roll back the migration with `db:restore`
+and revert the v2→main merge before deploying prod.
+
+### 7. Deploy production Worker
+
+```bash
+gh workflow run Deploy -f environment=production --repo Project-Janata/Janata
+```
+
+This triggers the manual prod deploy. Code now uses new schema; D1 is
+already migrated; everything aligns.
+
+### 8. Post-release smoke + announce
+
+```bash
+# Smoke production
+curl -sf https://api.chinmayajanata.org/api/centers >/dev/null && echo "✓ prod centers"
+
+# Announce in #product-updates via the Ralph bot
+npm run db:cutover-status --post-slack
+```
+
+(`--post-slack` is optional and uses the Janata Developer Agent bot to
+publish a one-line "v2 → main released, N migrations applied" message.)
+
+## Rollback paths
+
+**Prod Worker code is bad** → re-run `gh workflow run Deploy` against the
+prior main commit (`gh workflow run Deploy -f environment=production
+-f ref=<prior-sha>`). Schema stays migrated; old code reads new schema
+fine for additive migrations.
+
+**A canon-tier migration corrupted data** → `npm run db:restore -- --remote
+data/snapshots/<latest>` brings `centers` + `events` back to the pre-cutover
+state. Then revert the v2 commit that introduced the bad migration.
+
+**A disposable-tier migration broke things** → re-run the migration with
+a corrective DROP+CREATE on v2, re-cut a fresh release. The data in those
+tables was disposable anyway.
+
+## What this runbook does NOT cover
+
+- **Frontend (Cloudflare Pages) deploys** — Pages auto-deploys `main` via
+  its Git integration, separately from `deploy.yml`. No action needed.
+- **Mobile app builds** — EAS Build is a separate flow (`npm run
+  eas:build:ios`). Schedule those before the MSC handoff window.
+- **Hotfixes against main** — out of scope. If main is broken and you can't
+  wait for v2, branch off main, fix, PR to main, merge, deploy. Then
+  rebase v2 on the new main.
+
+## See also
+
+- [`migrations/README.md`](../migrations/README.md) — tier policy, numbering, per-file apply commands
+- [`.ralph/README.md`](../.ralph/README.md) — runner workflow per story
+- Memory: `project_d1_shared_prod_staging`, `reference_preview_backend_topology`

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -119,6 +119,18 @@ npm run db:restore -- data/snapshots/<utc-stamp>
 6. After merge, apply to prod manually — there's no auto-apply step in CI
    (deliberately, so no accidental schema changes ship without review)
 
+## When releasing v2 → main
+
+The recurring cutover workflow lives in **[`docs/release-cutover.md`](../docs/release-cutover.md)**.
+Before any release, run:
+
+```bash
+npm run db:cutover-status
+```
+
+It prints which migrations on `v2` aren't yet applied to prod D1, flags
+any canon-tier touches that need a snapshot, and emits the exact apply
+commands. Do NOT skip migration apply — CI does not run migrations.
 
 ## Pre-MSC ritual (~10 days before launch)
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "d1:migrate:all": "bash scripts/db/migrate-all.sh",
     "db:snapshot": "bash scripts/db/snapshot.sh",
     "db:restore": "bash scripts/db/restore.sh",
+    "db:cutover-status": "bash scripts/db/cutover-status.sh",
     "android": "cd packages/frontend && npx expo run:android",
     "ios": "cd packages/frontend && npx expo run:ios",
     "test:frontend": "cd packages/frontend && npm run test",

--- a/scripts/db/cutover-status.sh
+++ b/scripts/db/cutover-status.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scripts/db/cutover-status.sh — show what would happen if we merged v2 → main
+# right now. Identifies pending migrations, classifies them by tier (canon vs
+# disposable), and prints the exact apply commands in order.
+#
+# Run via the npm wrapper for the usual case:
+#   npm run db:cutover-status                  # human-readable
+#   npm run db:cutover-status -- --machine     # just the migration file list
+#   npm run db:cutover-status -- --post-slack  # post a release summary to
+#                                              # #product-updates (run AFTER cutover)
+#
+# See docs/release-cutover.md for the full release runbook.
+
+set -uo pipefail
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+export LANG="${LANG:-en_US.UTF-8}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+MODE="human"
+for arg in "$@"; do
+  case "$arg" in
+    --machine) MODE="machine" ;;
+    --post-slack) MODE="slack" ;;
+    -h|--help)
+      sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Make sure we have fresh refs (don't fetch silently in machine mode — keep
+# behavior predictable for scripts)
+if [[ "$MODE" == "human" ]]; then
+  git fetch origin main v2 --quiet 2>/dev/null || true
+fi
+
+# Use origin/main and origin/v2 to compare what's been pushed, not the local
+# state.
+MAIN_REF="origin/main"
+V2_REF="origin/v2"
+git rev-parse "$MAIN_REF" >/dev/null 2>&1 || MAIN_REF="main"
+git rev-parse "$V2_REF"   >/dev/null 2>&1 || V2_REF="v2"
+
+# Migrations on v2 that aren't on main yet — by file existence diff, not
+# commit set. Robust to squash-merges that change commit SHAs.
+# Use comm(1) instead of bash associative arrays (this runs on macOS bash 3.2).
+TMPMAIN=$(mktemp -t ralph-cutover-main.XXXXXX)
+TMPV2=$(mktemp -t ralph-cutover-v2.XXXXXX)
+TMPPEND=$(mktemp -t ralph-cutover-pending.XXXXXX)
+trap 'rm -f "$TMPMAIN" "$TMPV2" "$TMPPEND"' EXIT
+
+git ls-tree -r --name-only "$MAIN_REF" -- migrations/ 2>/dev/null \
+  | grep -E '^migrations/0[0-9]+_.+\.sql$' | sort > "$TMPMAIN" || true
+git ls-tree -r --name-only "$V2_REF" -- migrations/ 2>/dev/null \
+  | grep -E '^migrations/0[0-9]+_.+\.sql$' | sort > "$TMPV2" || true
+
+# comm -23: lines only in V2_FILES (already sorted)
+comm -23 "$TMPV2" "$TMPMAIN" > "$TMPPEND"
+
+# Read pending into an array (portable to bash 3.2)
+PENDING=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && PENDING+=("$line")
+done < "$TMPPEND"
+
+# Detect canon-tier touches (any migration that references centers or events)
+is_canon() {
+  local f="$1"
+  grep -qE '\b(centers|events)\b' "$f" 2>/dev/null
+}
+
+# Machine mode: just the file list, one per line (used by docs/release-cutover.md)
+if [[ "$MODE" == "machine" ]]; then
+  printf '%s\n' "${PENDING[@]}"
+  exit 0
+fi
+
+# Slack mode: post a one-shot release summary
+if [[ "$MODE" == "slack" ]]; then
+  TOKEN="${JANATA_SLACK_BOT_TOKEN:-}"
+  [[ -z "$TOKEN" && -f .ralph/.slack-bot-token ]] && TOKEN=$(cat .ralph/.slack-bot-token)
+  [[ -n "$TOKEN" ]] || { echo "❌ no Slack bot token" >&2; exit 1; }
+  AHEAD=$(git rev-list --count "$MAIN_REF..$V2_REF" 2>/dev/null || echo "?")
+  TEXT=$(printf 'release: v2 → main applied. %d commits ahead, %d migrations applied:\n%s' \
+    "$AHEAD" "${#PENDING[@]}" "$(printf '  - %s\n' "${PENDING[@]}")")
+  PAYLOAD=$(jq -nc --arg ch "#product-updates" --arg t "$TEXT" '{channel:$ch, text:$t}')
+  RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data "$PAYLOAD")
+  if [[ "$(printf '%s' "$RESP" | jq -r '.ok')" == "true" ]]; then
+    echo "✓ posted to #product-updates"
+  else
+    echo "❌ slack post failed:"; printf '%s' "$RESP" | jq . >&2 2>/dev/null
+    exit 1
+  fi
+  exit 0
+fi
+
+# ─── Human-readable mode (default) ───────────────────────────────────────────
+AHEAD=$(git rev-list --count "$MAIN_REF..$V2_REF" 2>/dev/null || echo "?")
+BEHIND=$(git rev-list --count "$V2_REF..$MAIN_REF" 2>/dev/null || echo "0")
+MAIN_HEAD=$(git log -1 --pretty='%h %s' "$MAIN_REF" 2>/dev/null)
+V2_HEAD=$(git log -1   --pretty='%h %s' "$V2_REF"   2>/dev/null)
+
+echo "━━━ Cutover status: v2 → main ━━━"
+echo "  main HEAD: $MAIN_HEAD"
+echo "  v2 HEAD:   $V2_HEAD"
+echo "  v2 is $AHEAD commits ahead of main"
+[[ "$BEHIND" -gt 0 ]] && echo "  ⚠ v2 is also $BEHIND commits BEHIND main — rebase before cutover"
+echo
+
+if (( ${#PENDING[@]} == 0 )); then
+  echo "━━━ Pending migrations: none ━━━"
+  echo "  Nothing to apply. If v2 is ahead by code-only changes, you can"
+  echo "  skip steps 2–3 of docs/release-cutover.md and go straight to the"
+  echo "  PR open + merge."
+  exit 0
+fi
+
+ANY_CANON=0
+echo "━━━ Pending migrations (${#PENDING[@]}) ━━━"
+for f in "${PENDING[@]}"; do
+  if is_canon "$f"; then
+    echo "  ⚠ $f  (Tier 1 — references centers or events; snapshot recommended)"
+    ANY_CANON=1
+  else
+    echo "    $f  (Tier 2)"
+  fi
+done
+
+# Try to map each migration to its introducing PR (best-effort)
+echo
+echo "━━━ Introducing PRs ━━━"
+for f in "${PENDING[@]}"; do
+  COMMIT=$(git log "$V2_REF" --diff-filter=A --format=%H -- "$f" 2>/dev/null | tail -1)
+  if [[ -n "$COMMIT" ]]; then
+    SUBJECT=$(git log -1 --pretty=%s "$COMMIT" 2>/dev/null)
+    PR=$(echo "$SUBJECT" | grep -oE '#[0-9]+' | head -1)
+    printf '    %-44s %s %s\n' "$(basename "$f")" "${PR:-(no #ref in commit msg)}" "(${COMMIT:0:7})"
+  fi
+done
+
+echo
+echo "━━━ Apply order (run from repo root) ━━━"
+if (( ANY_CANON )); then
+  echo "  npm run db:snapshot -- --remote      # canon-tier change in this set"
+fi
+for f in "${PENDING[@]}"; do
+  echo "  npx wrangler d1 execute chinmaya-janata-db --file=$f --config packages/backend/wrangler.toml"
+done
+
+echo
+echo "━━━ Then ━━━"
+echo "  gh pr create --base main --head v2 --repo Project-Janata/Janata \\"
+echo "    --title \"release: v2 → main (\$(date -u +%Y-%m-%d))\""
+echo "  gh pr merge <PR-num> --squash --repo Project-Janata/Janata"
+echo "  # wait + verify staging, then:"
+echo "  gh workflow run Deploy -f environment=production --repo Project-Janata/Janata"
+echo
+echo "Full runbook: docs/release-cutover.md"


### PR DESCRIPTION
**⚠ Stacked on [#246](https://github.com/Project-Janata/Janata/pull/246)** — base is `chore/db-migration-tooling` while that PR is in review. When #246 merges into `v2`, I'll retarget this PR's base to `v2` (the diff stays exactly the same).

Closes the gap between per-story migration discipline (added in #246) and the actual `v2 → main` release ritual. After this PR, the answer to "when do I run migrations?" is one command + one doc.

## What's new

- **`docs/release-cutover.md`** — 8-step recurring runbook for cutting a release from `v2` to `main`. Covers pre-flight, canon-tier snapshot, apply order, the `gh pr create` / merge / `workflow_dispatch` sequence, staging smoke, and rollback paths (canon, disposable, code).
- **`scripts/db/cutover-status.sh`** — prints what would happen if we merged `v2 → main` right now: how far `v2` is ahead, which migrations on `v2` aren't yet applied to prod D1, whether any are Tier 1 (snapshot recommended), and the exact apply commands in order. Three modes:
  - `npm run db:cutover-status` — human-readable (default)
  - `npm run db:cutover-status -- --machine` — pipeable, one migration filename per line
  - `npm run db:cutover-status -- --post-slack` — announce in `#product-updates` after cutover succeeds
- **`migrations/README.md`** — adds a "When releasing v2 → main" section that points at the runbook + helper.
- **npm wrapper**: `db:cutover-status`

## Why this is needed

CI does NOT auto-apply migrations. They land in `migrations/` as PRs merge into `v2`, but the live D1 schema only changes when a human runs `wrangler d1 execute --remote --file=…`. Without this helper, the release flow relies on "remember to check what's new and apply each one" — error-prone, especially when several migrations stack up.

## Demo against current state

On the dev Mac mini today:

```
$ npm run db:cutover-status

━━━ Cutover status: v2 → main ━━━
  main HEAD: 35468ab feat(events/form): expose external_url, signup_url, allow_janata_signup (#184)
  v2 HEAD:   cdd7916 Merge pull request #241 from Project-Janata/feat/v2-remove-mocks-empty-states
  v2 is 83 commits ahead of main

━━━ Pending migrations (4) ━━━
    migrations/0016_unverified_user_and_email_verification.sql  (Tier 2)
    migrations/0017_extend_invite_codes.sql  (Tier 2)
    migrations/0018_password_reset_codes.sql  (Tier 2)
    migrations/0019_boards.sql  (Tier 2)

━━━ Introducing PRs ━━━
    0018_password_reset_codes.sql   #224  (27e0765)
    [...]

━━━ Apply order (run from repo root) ━━━
  npx wrangler d1 execute chinmaya-janata-db --file=migrations/0016_… --config packages/backend/wrangler.toml
  [...]

━━━ Then ━━━
  gh pr create --base main --head v2 ...
  gh pr merge <PR-num> --squash
  gh workflow run Deploy -f environment=production
```

Deterministic output, ready to copy-paste.

## Safety

- The script is **read-only**. It does not execute any migration; it only inspects `git ls-tree`, `git log`, and reads migration file contents to classify tiers.
- The `--post-slack` mode posts to `#product-updates` via the Janata Developer Agent bot (chat.postMessage only — no file uploads). Intended to run AFTER cutover succeeds, not before.
- No CI step in this PR auto-applies anything.

## Bash 3.2 compatibility

macOS ships bash 3.2 (no `mapfile`, no associative arrays). The script uses `comm(1)` and portable while-read loops; tested on bash 3.2.57 on darwin25.

## Test plan

Local smoke:

```bash
npm run db:cutover-status              # human-readable
npm run db:cutover-status -- --machine # one filename per line
bash scripts/db/cutover-status.sh -h   # help screen
```

Read-through:

- `docs/release-cutover.md` — does the 8-step flow match how you'd actually cut a release?
- Rollback paths section — are the rollback strategies correct for canon vs disposable failure modes?

## What's NOT in this PR

- The Ralph prompt template + `ralph-post-slack` 🛢️ MIGRATION badge enhancements that go with this. Those live in `.ralph/` (gitignored) and apply to the runner only — not part of the committed surface.
- Wrangler native `d1 migrations apply` adoption — Phase 3, post-MSC.
- Separate dev D1 — Phase 2, optional pre-MSC.

## Reviewer checklist

- [ ] Stacking order makes sense (this depends on `#246`'s `migrations/README.md` existing)
- [ ] `docs/release-cutover.md` flow matches your release intent
- [ ] `cutover-status.sh` output is clear enough to act on without context
- [ ] You're OK with `--post-slack` posting one summary message at cutover completion
