### PR TITLE
feat(boards): edit + soft-delete routes, fix reaction race

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -11,6 +11,7 @@ import { applyMigration, dropAllTables, TEST_INVITE_CODE } from './setup'
 import { app } from '../app'
 import { hashPassword } from '../auth'
 import { clearRateLimits } from '../middleware'
+import { ADMIN_EMAIL } from '../constants'
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -45,6 +46,14 @@ function jsonPost(path: string, data: unknown, headers: Record<string, string> =
 function jsonPut(path: string, data: unknown, headers: Record<string, string> = {}) {
   return fetchJSON(path, {
     method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(data),
+  })
+}
+
+function jsonPatch(path: string, data: unknown, headers: Record<string, string> = {}) {
+  return fetchJSON(path, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(data),
   })
@@ -918,6 +927,191 @@ describe('board routes', () => {
     expect(res.status).toBe(200)
     expect(body.active).toBe(true)
     expect(body.reactions).toEqual([{ emoji: '🙏', count: 1 }])
+  })
+
+  // ── Edit + soft-delete + idempotent reactions (issue #205) ────────────
+  describe('PATCH /api/boards/posts/:postId — edit', () => {
+    let postId: string
+
+    beforeEach(async () => {
+      const { body } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'Original body' },
+        authHeader(memberToken),
+      )
+      postId = body.post.id
+    })
+
+    it('lets the author edit their post within the window', async () => {
+      const { res, body } = await jsonPatch(
+        `/api/boards/posts/${postId}`,
+        { body: 'Edited body' },
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(200)
+      expect(body.post.body).toBe('Edited body')
+    })
+
+    it('rejects non-author edit attempts with 403', async () => {
+      const other = await registerAndLogin('boardotherauthor', 'password123')
+      // Place the other user at the same center so the access gate passes —
+      // the 403 we want to surface is from the author check, not membership.
+      await env.DB.prepare('UPDATE users SET center_id = ? WHERE username = ?')
+        .bind(centerId, 'boardotherauthor')
+        .run()
+
+      const { res, body } = await jsonPatch(
+        `/api/boards/posts/${postId}`,
+        { body: 'Hijacked' },
+        authHeader(other.token),
+      )
+      expect(res.status).toBe(403)
+      expect(body.message).toMatch(/author/i)
+    })
+
+    it('rejects edit attempts on a soft-deleted post', async () => {
+      await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(memberToken),
+      })
+
+      const { res } = await jsonPatch(
+        `/api/boards/posts/${postId}`,
+        { body: 'Necromancy' },
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(410)
+    })
+
+    it('rejects an empty body', async () => {
+      const { res } = await jsonPatch(
+        `/api/boards/posts/${postId}`,
+        { body: '   ' },
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('DELETE /api/boards/posts/:postId — soft delete', () => {
+    let postId: string
+
+    beforeEach(async () => {
+      const { body } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'To be deleted' },
+        authHeader(memberToken),
+      )
+      postId = body.post.id
+    })
+
+    it('lets the author soft-delete their post', async () => {
+      const { res } = await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(memberToken),
+      })
+      expect(res.status).toBe(200)
+
+      const { body } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(body.posts.find((p: { id: string }) => p.id === postId)).toBeUndefined()
+    })
+
+    it('lets an admin soft-delete a member post', async () => {
+      // Admin needs to be a center member to pass verifyBoardAccess (the read
+      // gate is the same for all users). The createAdmin helper already places
+      // the admin in a center, but it may not be THIS center — re-bind them
+      // to the board's center for this test.
+      await env.DB.prepare('UPDATE users SET center_id = ? WHERE email = ?')
+        .bind(centerId, ADMIN_EMAIL)
+        .run()
+
+      const { res } = await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(adminToken),
+      })
+      expect(res.status).toBe(200)
+    })
+
+    it('rejects non-author non-admin deletion with 403', async () => {
+      const other = await registerAndLogin('boardotherdeleter', 'password123')
+      await env.DB.prepare('UPDATE users SET center_id = ? WHERE username = ?')
+        .bind(centerId, 'boardotherdeleter')
+        .run()
+
+      const { res, body } = await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(other.token),
+      })
+      expect(res.status).toBe(403)
+      expect(body.message).toMatch(/author|admin/i)
+    })
+
+    it('returns 410 on double-delete', async () => {
+      await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(memberToken),
+      })
+      const { res } = await fetchJSON(`/api/boards/posts/${postId}`, {
+        method: 'DELETE',
+        headers: authHeader(memberToken),
+      })
+      expect(res.status).toBe(410)
+    })
+  })
+
+  describe('POST /api/boards/posts/:postId/reactions — idempotent on rapid duplicates', () => {
+    it('two concurrent identical reactions land deterministically', async () => {
+      const { body: createBody } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'Race target' },
+        authHeader(memberToken),
+      )
+      const postId = createBody.post.id
+
+      // Fire two reaction toggles concurrently; the previous SELECT-then-INSERT
+      // code surfaced a 500 here from the PK constraint. With the optimistic
+      // DELETE + INSERT OR IGNORE pattern, both requests succeed and the
+      // final DB state is deterministic.
+      const [a, b] = await Promise.all([
+        jsonPost(
+          `/api/boards/posts/${postId}/reactions`,
+          { emoji: '🙏' },
+          authHeader(memberToken),
+        ),
+        jsonPost(
+          `/api/boards/posts/${postId}/reactions`,
+          { emoji: '🙏' },
+          authHeader(memberToken),
+        ),
+      ])
+
+      expect(a.res.status).toBe(200)
+      expect(b.res.status).toBe(200)
+
+      // Whatever order they landed in, the final count is 0 or 1 (never 2,
+      // never errored). We accept either net-on (one toggled on, one no-op
+      // ignored) or net-off (one toggled on, one toggled it back off).
+      const finalCount =
+        (a.body.reactions[0]?.count ?? 0) + (b.body.reactions[0]?.count ?? 0)
+      expect([0, 1, 2]).toContain(finalCount)
+
+      // Most importantly, the DB never holds more than one row for this
+      // (post, user, emoji) — the primary key guarantees that. Re-query
+      // the board to confirm a clean state.
+      const { body } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      const dbPost = body.posts.find((p: { id: string }) => p.id === postId)
+      const ownReaction = (dbPost?.reactions ?? []).find(
+        (r: { emoji: string }) => r.emoji === '🙏',
+      )
+      // Either 0 (net-off) or 1 (net-on) — never 2.
+      expect([undefined, { emoji: '🙏', count: 1 }]).toContainEqual(ownReaction)
+    })
   })
 })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1182,6 +1182,105 @@ app.post('/boards/posts/:postId/reactions', authMiddleware, async (c) => {
   return c.json(result)
 })
 
+// Edit a post body. Author only; only within BOARD_POST_EDIT_WINDOW_MS of
+// creation; soft-deleted posts can't be edited.
+app.patch('/boards/posts/:postId', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const postId = c.req.param('postId')
+
+  // Need the post to enforce access (the board the post belongs to) — we use
+  // the same membership/RSVP gate as posting. Include deleted rows so we
+  // can return 410 Gone instead of 404 for already-deleted posts.
+  const post = await db.getBoardPostByIdIncludingDeleted(c.env.DB, postId)
+  if (!post) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, post.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  const body: { body?: string } = await c.req
+    .json<{ body?: string }>()
+    .catch(() => ({}))
+  const text = typeof body.body === 'string' ? body.body.trim() : ''
+  if (!text) {
+    return c.json({ message: 'Post body is required' }, 400)
+  }
+  if (text.length > 2000) {
+    return c.json({ message: 'Post body must be 2000 characters or fewer' }, 400)
+  }
+
+  const result = await db.editBoardPost(c.env.DB, postId, user.id, text)
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'not_found':
+        return c.json({ message: 'Board post not found' }, 404)
+      case 'deleted':
+        return c.json({ message: 'Cannot edit a deleted post' }, 410)
+      case 'not_author':
+        return c.json({ message: 'Only the author can edit this post' }, 403)
+      case 'window_expired':
+        return c.json(
+          { message: 'Edit window has expired (posts are editable for 5 minutes after creation)' },
+          409,
+        )
+    }
+  }
+
+  // Return the updated post in the same shape as the create response.
+  const refreshed = await db.listBoardPosts(c.env.DB, post.board_id, { limit: 100 })
+  const updated = refreshed.find((p) => p.id === postId)
+  if (!updated) {
+    return c.json({ message: 'Post edited but could not be reloaded' }, 500)
+  }
+  return c.json({ post: boardPostToApi(updated) })
+})
+
+// Soft-delete a post. Author or admin only. The row stays in the table
+// so M1 (moderation) can still surface it; listBoardPosts already filters
+// deleted_at IS NULL.
+app.delete('/boards/posts/:postId', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const postId = c.req.param('postId')
+
+  // Include deleted rows so we can return 410 Gone for an already-deleted post.
+  const post = await db.getBoardPostByIdIncludingDeleted(c.env.DB, postId)
+  if (!post) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, post.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+  // Read access (deletion gate is finer-grained inside softDeleteBoardPost,
+  // but we still want to 403 non-members of the board)
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  const result = await db.softDeleteBoardPost(c.env.DB, postId, {
+    id: user.id,
+    isAdmin: isAdmin(user),
+  })
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'not_found':
+        return c.json({ message: 'Board post not found' }, 404)
+      case 'already_deleted':
+        return c.json({ message: 'Post is already deleted' }, 410)
+      case 'forbidden':
+        return c.json(
+          { message: 'Only the author or an admin can delete this post' },
+          403,
+        )
+    }
+  }
+
+  return c.json({ ok: true })
+})
+
 // ═══════════════════════════════════════════════════════════════════════
 // EVENT ROUTES
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -677,6 +677,22 @@ export async function getBoardPostById(
   return result ?? null
 }
 
+/**
+ * Like getBoardPostById but ALSO returns soft-deleted rows. Used by edit /
+ * delete routes that need to distinguish "never existed" (404) from
+ * "previously existed but is gone" (410 Gone).
+ */
+export async function getBoardPostByIdIncludingDeleted(
+  db: D1Database,
+  postId: string,
+): Promise<BoardPostRow | null> {
+  const result = await db
+    .prepare('SELECT * FROM board_posts WHERE id = ?1')
+    .bind(postId)
+    .first<BoardPostRow>()
+  return result ?? null
+}
+
 export async function getBoardById(
   db: D1Database,
   boardId: string,
@@ -748,31 +764,127 @@ export async function toggleBoardPostReaction(
   userId: string,
   emoji: string,
 ): Promise<{ active: boolean; reactions: BoardReactionCount[] }> {
-  const existing = await db
+  // Race-safe toggle. The previous SELECT-then-INSERT pattern threw 500 on
+  // rapid duplicate clicks because the second INSERT collided with the
+  // (post_id, user_id, emoji) primary key. We now:
+  //   1. Optimistically DELETE — succeeds if the reaction existed, else no-op
+  //   2. If something was deleted, the toggle is OFF
+  //   3. Else INSERT OR IGNORE — if a concurrent click already inserted, this
+  //      is a deterministic no-op and the reaction stays ON
+  const del = await db
     .prepare(
-      `SELECT 1 FROM board_post_reactions
+      `DELETE FROM board_post_reactions
        WHERE post_id = ?1 AND user_id = ?2 AND emoji = ?3`,
     )
     .bind(postId, userId, emoji)
-    .first()
+    .run()
 
-  if (existing) {
-    await db
-      .prepare(
-        `DELETE FROM board_post_reactions
-         WHERE post_id = ?1 AND user_id = ?2 AND emoji = ?3`,
-      )
-      .bind(postId, userId, emoji)
-      .run()
+  if ((del.meta?.changes ?? 0) > 0) {
     return { active: false, reactions: await getBoardPostReactionCounts(db, postId) }
   }
 
   await db
     .prepare(
-      `INSERT INTO board_post_reactions (post_id, user_id, emoji, created_at)
+      `INSERT OR IGNORE INTO board_post_reactions (post_id, user_id, emoji, created_at)
        VALUES (?1, ?2, ?3, ?4)`,
     )
     .bind(postId, userId, emoji, new Date().toISOString())
     .run()
   return { active: true, reactions: await getBoardPostReactionCounts(db, postId) }
+}
+
+// Window during which a post author can edit their own post (milliseconds).
+// Per PRD §5.2 + #205 acceptance criteria — TBD with team; default 5 min.
+export const BOARD_POST_EDIT_WINDOW_MS = 5 * 60 * 1000
+
+export type BoardPostEditResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'deleted' | 'not_author' | 'window_expired' }
+
+/**
+ * Edit a board post body in place. Caller must be the author and the post
+ * must be within the edit window. Soft-deleted posts are not editable.
+ *
+ * Returns a discriminated union so the route layer can map reasons to
+ * appropriate HTTP statuses without inspecting raw DB state.
+ */
+export async function editBoardPost(
+  db: D1Database,
+  postId: string,
+  authorId: string,
+  body: string,
+): Promise<BoardPostEditResult> {
+  const post = await db
+    .prepare(
+      `SELECT author_id, deleted_at, created_at FROM board_posts WHERE id = ?1`,
+    )
+    .bind(postId)
+    .first<{ author_id: string; deleted_at: string | null; created_at: string }>()
+
+  if (!post) return { ok: false, reason: 'not_found' }
+  if (post.deleted_at) return { ok: false, reason: 'deleted' }
+  if (post.author_id !== authorId) return { ok: false, reason: 'not_author' }
+
+  // SQLite's datetime('now') returns 'YYYY-MM-DD HH:MM:SS' (space separator,
+  // UTC). Normalize to ISO 8601 before parsing so engines reliably treat it
+  // as UTC. Plain `new Date('YYYY-MM-DD HH:MM:SS')` may parse as local time.
+  const isoCreated = post.created_at.includes('T')
+    ? post.created_at + (post.created_at.endsWith('Z') ? '' : 'Z')
+    : post.created_at.replace(' ', 'T') + 'Z'
+  const createdMs = new Date(isoCreated).getTime()
+  if (!Number.isFinite(createdMs)) {
+    // Fallback: if the timestamp can't be parsed, fail closed.
+    return { ok: false, reason: 'window_expired' }
+  }
+  if (Date.now() - createdMs > BOARD_POST_EDIT_WINDOW_MS) {
+    return { ok: false, reason: 'window_expired' }
+  }
+
+  await db
+    .prepare(
+      `UPDATE board_posts
+       SET body = ?1, updated_at = datetime('now')
+       WHERE id = ?2`,
+    )
+    .bind(body, postId)
+    .run()
+
+  return { ok: true }
+}
+
+export type BoardPostDeleteResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'already_deleted' | 'forbidden' }
+
+/**
+ * Soft-delete a board post. The author OR an admin may delete. The post
+ * stays in the table (deleted_at set) so moderation can still inspect it
+ * via the admin queue.
+ */
+export async function softDeleteBoardPost(
+  db: D1Database,
+  postId: string,
+  actor: { id: string; isAdmin: boolean },
+): Promise<BoardPostDeleteResult> {
+  const post = await db
+    .prepare(`SELECT author_id, deleted_at FROM board_posts WHERE id = ?1`)
+    .bind(postId)
+    .first<{ author_id: string; deleted_at: string | null }>()
+
+  if (!post) return { ok: false, reason: 'not_found' }
+  if (post.deleted_at) return { ok: false, reason: 'already_deleted' }
+  if (post.author_id !== actor.id && !actor.isAdmin) {
+    return { ok: false, reason: 'forbidden' }
+  }
+
+  await db
+    .prepare(
+      `UPDATE board_posts
+       SET deleted_at = datetime('now')
+       WHERE id = ?1`,
+    )
+    .bind(postId)
+    .run()
+
+  return { ok: true }
 }


### PR DESCRIPTION
Backend-only chunk of [#205 (Boards backend B1)](https://github.com/Project-Janata/Janata/issues/205). Closes 3 of the 7 outstanding acceptance criteria. Pinning, replies, aggregated feed, and admin-deleted view stay as follow-up PRs.

## What this adds

### `PATCH /boards/posts/:postId` — edit your own post
- Author can edit body within 5 min of creation (`BOARD_POST_EDIT_WINDOW_MS`).
- Mapped error states: `404` (not found), `410` (already deleted), `403` (not author), `409` (window expired), `400` (empty/oversize body).

### `DELETE /boards/posts/:postId` — soft-delete
- `deleted_at = datetime('now')`. Row stays so M1 moderation can audit it; `listBoardPosts` already filters `deleted_at IS NULL`, so deleted posts disappear from user-facing feeds.
- Author OR admin can delete. Non-author non-admin gets `403`. Re-deleting returns `410 Gone`.

### `POST /boards/posts/:postId/reactions` — race-condition fix
Previous SELECT-then-INSERT pattern: two concurrent identical clicks raced into a `(post_id, user_id, emoji)` PK violation and returned **500**. This is the exact "Reaction race condition (same user, same emoji, two rapid clicks)" edge case called out in the issue body. Now uses optimistic `DELETE` + `INSERT OR IGNORE` so the final DB state is always deterministic regardless of timing.

## Schema impact

**None.** Existing `deleted_at` and `updated_at` columns on `board_posts` cover both routes. Tier 2 (disposable) table per [`migrations/README.md`](../blob/chore/db-migration-tooling/migrations/README.md) (from #246).

## Tests

9 new cases under `describe('board routes', …)`:

| | |
|---|---|
| `PATCH … — edit` | author within window 200; non-author 403; on deleted 410; empty body 400 |
| `DELETE … — soft delete` | author 200; admin 200; non-author non-admin 403; double-delete 410 |
| `POST … /reactions — idempotent on rapid duplicates` | `Promise.all` of two identical reactions: both 200, DB row count is 0 or 1 (never 2, never errored) |

Full backend suite: **322/322 green** (up from 313). Verify gate clean: `git diff --check`, backend typecheck, frontend tests, backend tests, web build.

## Data scope on preview

**Backend-only — preview URL is not useful.** Cloudflare Pages previews host the frontend, which calls the production backend at `api.chinmayajanata.org`. The new PATCH/DELETE routes only exist on this branch and won't reach a deployed Worker until `v2 → main` cutover. For live testing now, `npm run dev` against `--local` D1. Once landed and deployed, the new routes write to prod D1 — Tier 2 disposable `board_posts` table.

## 🛢️ Migration cutover note

No migration in this PR.

## Test plan

Local smoke (preview won't exercise these routes):

```bash
git fetch origin feat/v2-boards-edit-delete && git switch feat/v2-boards-edit-delete
npm install
npm run test:backend       # 322/322 green
bash .ralph/verify.sh      # full gate (only if you have .ralph/ set up)

npm run dev                # local Worker on :8787
# then exercise PATCH / DELETE / reactions via curl per the story-overview
```

## Patterns introduced (for follow-up PRs to reuse)

- **`*IncludingDeleted` lookup variants.** `getBoardPostById` filters `deleted_at IS NULL` for the public listing path. Routes that need to distinguish "never existed" from "was deleted" should use `getBoardPostByIdIncludingDeleted` — added in this PR. Don't reuse the original for moderation/admin queries.
- **Discriminated-union return types from db helpers.** `editBoardPost` and `softDeleteBoardPost` return `{ ok: false; reason: '...' }` instead of throwing or returning `null`. The route maps each reason to the right HTTP status without inspecting raw DB state. Apply the same to future write-side board operations.
- **SQLite datetime parsing.** `datetime('now')` returns `'YYYY-MM-DD HH:MM:SS'` (space separator), which `new Date()` parses as LOCAL time in some engines. Normalize to ISO 8601 (`T` separator + trailing `Z`) before measuring time windows. Future routes comparing DB timestamps to `Date.now()` should do the same.

## What stays open on #205 (follow-up PRs)

- [ ] **Pinning** — needs migration to add `pinned_at` / `pinned_by` columns, pin/unpin routes (sevak / center admin only), sort logic in `listBoardPosts`.
- [ ] **Replies** — schema table `board_post_replies` exists; routes to create/list don't.
- [ ] **Aggregated feed** — single query for all posts across boards the user has access to, reverse-chronological with pinned-on-top.
- [ ] **Admin view of soft-deleted** — list endpoint for moderation queue (mostly lives in #209 M1).

Closes none on its own; partial progress on #205.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779906594451769