### PR TITLE
feat(boards): pin/unpin posts with sort priority (#205)

### DIFF
--- a/migrations/0020_board_post_pinning.sql
+++ b/migrations/0020_board_post_pinning.sql
@@ -1,0 +1,25 @@
+-- 0020_board_post_pinning.sql
+-- Adds pinning to board_posts. Pinned posts sort first in board listings.
+--
+-- Tier 2 per migrations/README.md (board_posts is disposable), but using
+-- additive ALTER here anyway so we don't drop user-visible data even
+-- though the table holds no real users yet.
+--
+-- pinned_at  - timestamp when pinned (NULL means not pinned)
+-- pinned_by  - FK to users(id), the sevak/admin who pinned it
+--
+-- The new ORDER BY in listBoardPosts is
+--   (pinned_at IS NOT NULL) DESC, pinned_at DESC, created_at DESC
+-- which puts pinned posts first.
+--
+-- IMPORTANT: keep comments free of literal semicolons.
+-- The test setup in src/__tests__/setup.ts splits each migration on the
+-- semicolon character before filtering by statement head, so a semicolon
+-- in a comment desyncs the statement parser and silently drops the
+-- ALTER that follows it.
+
+ALTER TABLE board_posts ADD COLUMN pinned_at TEXT;
+ALTER TABLE board_posts ADD COLUMN pinned_by TEXT REFERENCES users(id);
+
+CREATE INDEX IF NOT EXISTS idx_board_posts_board_pinned_created
+  ON board_posts(board_id, pinned_at DESC, created_at DESC);

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -1113,6 +1113,142 @@ describe('board routes', () => {
       expect([undefined, { emoji: '🙏', count: 1 }]).toContainEqual(ownReaction)
     })
   })
+
+  // ── Pinning (issue #205) ──────────────────────────────────────────────
+  describe('POST /api/boards/posts/:postId/pin and /unpin', () => {
+    let postId: string
+    let sevakToken: string
+
+    beforeEach(async () => {
+      const { body: createBody } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'Will be pinned' },
+        authHeader(memberToken),
+      )
+      postId = createBody.post.id
+
+      // Promote a separate user to SEVAK (verification_level = 54 per
+      // constants.ts) so we can prove the verification gate.
+      const sevak = await registerAndLogin('boardsevak', 'password123')
+      sevakToken = sevak.token
+      await env.DB.prepare(
+        'UPDATE users SET center_id = ?, verification_level = 54 WHERE username = ?',
+      )
+        .bind(centerId, 'boardsevak')
+        .run()
+    })
+
+    it('lets a sevak pin a post', async () => {
+      const { res, body } = await jsonPost(
+        `/api/boards/posts/${postId}/pin`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(res.status).toBe(200)
+      expect(body.pinned).toBe(true)
+
+      const { body: list } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(list.posts[0].id).toBe(postId)
+      expect(list.posts[0].pinnedAt).toBeTruthy()
+    })
+
+    it('rejects pin from a basic (non-sevak) user with 403', async () => {
+      const { res, body } = await jsonPost(
+        `/api/boards/posts/${postId}/pin`,
+        {},
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(403)
+      expect(body.message).toMatch(/sevak|admin/i)
+    })
+
+    it('lets an admin pin a post', async () => {
+      // Admin needs board access — place admin at this center.
+      await env.DB.prepare('UPDATE users SET center_id = ? WHERE username = ?')
+        .bind(centerId, 'chinmayajanata@gmail.com')
+        .run()
+
+      const { res } = await jsonPost(
+        `/api/boards/posts/${postId}/pin`,
+        {},
+        authHeader(adminToken),
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('returns 409 on already-pinned', async () => {
+      await jsonPost(`/api/boards/posts/${postId}/pin`, {}, authHeader(sevakToken))
+      const { res } = await jsonPost(
+        `/api/boards/posts/${postId}/pin`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(res.status).toBe(409)
+    })
+
+    it('unpins a pinned post', async () => {
+      await jsonPost(`/api/boards/posts/${postId}/pin`, {}, authHeader(sevakToken))
+      const { res, body } = await jsonPost(
+        `/api/boards/posts/${postId}/unpin`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(res.status).toBe(200)
+      expect(body.pinned).toBe(false)
+
+      const { body: list } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      const target = list.posts.find((p: { id: string }) => p.id === postId)
+      expect(target?.pinnedAt).toBeNull()
+    })
+
+    it('returns 409 on unpin when not pinned', async () => {
+      const { res } = await jsonPost(
+        `/api/boards/posts/${postId}/unpin`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(res.status).toBe(409)
+    })
+
+    it('sorts pinned posts above unpinned in listing', async () => {
+      const { body: a } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'older' },
+        authHeader(memberToken),
+      )
+      // Give SQLite's datetime('now') a tick so the timestamps differ.
+      await new Promise((r) => setTimeout(r, 1100))
+      await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'middle' },
+        authHeader(memberToken),
+      )
+      await new Promise((r) => setTimeout(r, 1100))
+      const { body: c } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'newest' },
+        authHeader(memberToken),
+      )
+
+      // Pin the oldest — it should jump to the top despite being oldest.
+      await jsonPost(`/api/boards/posts/${a.post.id}/pin`, {}, authHeader(sevakToken))
+
+      const { body: list } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      // posts[0] = pinned (a); the rest in reverse-chronological (newest first).
+      expect(list.posts[0].id).toBe(a.post.id)
+      expect(list.posts[0].pinnedAt).toBeTruthy()
+      expect(list.posts[1].id).toBe(c.post.id)
+    })
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -61,6 +61,8 @@ function boardPostToApi(post: db.BoardPostWithAuthor): BoardPostApiResponse {
     createdAt: post.created_at,
     updatedAt: post.updated_at,
     deletedAt: post.deleted_at,
+    pinnedAt: post.pinned_at,
+    pinnedBy: post.pinned_by,
     author: userRowToApi(post.author),
     reactions: post.reactions,
     replyCount: post.reply_count,
@@ -1333,6 +1335,87 @@ app.delete('/boards/posts/:postId', authMiddleware, async (c) => {
   }
 
   return c.json({ ok: true })
+})
+
+// Pin a board post. Per PRD §5.2 + #205: "Posts can be pinned by board
+// admins (sevak / center admin); pinned posts sort first." Gate: caller
+// must be SEVAK or higher (which includes Brahmachari and Admin tiers),
+// OR a global admin. listBoardPosts ORDER BY puts pinned first.
+app.post('/boards/posts/:postId/pin', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const postId = c.req.param('postId')
+
+  const post = await db.getBoardPostById(c.env.DB, postId)
+  if (!post) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, post.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+
+  // Read-side gate (must have access to the board at all)
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  // Pin authority gate
+  if (user.verification_level < SEVAK && !isAdmin(user)) {
+    return c.json(
+      { message: 'Only sevaks, brahmacharis, or admins can pin posts' },
+      403,
+    )
+  }
+
+  const result = await db.pinBoardPost(c.env.DB, postId, user.id)
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'not_found':
+        return c.json({ message: 'Board post not found' }, 404)
+      case 'deleted':
+        return c.json({ message: 'Cannot pin a deleted post' }, 410)
+      case 'already_pinned':
+        return c.json({ message: 'Post is already pinned' }, 409)
+    }
+  }
+
+  return c.json({ ok: true, pinned: true })
+})
+
+app.post('/boards/posts/:postId/unpin', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const postId = c.req.param('postId')
+
+  const post = await db.getBoardPostById(c.env.DB, postId)
+  if (!post) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, post.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  if (user.verification_level < SEVAK && !isAdmin(user)) {
+    return c.json(
+      { message: 'Only sevaks, brahmacharis, or admins can unpin posts' },
+      403,
+    )
+  }
+
+  const result = await db.unpinBoardPost(c.env.DB, postId)
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'not_found':
+        return c.json({ message: 'Board post not found' }, 404)
+      case 'deleted':
+        return c.json({ message: 'Cannot unpin a deleted post' }, 410)
+      case 'not_pinned':
+        return c.json({ message: 'Post is not currently pinned' }, 409)
+    }
+  }
+
+  return c.json({ ok: true, pinned: false })
 })
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -856,11 +856,15 @@ export async function listBoardPosts(
 ): Promise<BoardPostWithAuthor[]> {
   const limit = Math.min(Math.max(opts.limit ?? 50, 1), 100)
   const offset = Math.max(opts.offset ?? 0, 0)
+  // Order: pinned first (most-recently pinned at top of pinned section),
+  // then everything else reverse-chronological. The
+  // `pinned_at IS NOT NULL` predicate evaluates to 1 for pinned posts and 0
+  // for non-pinned; DESC puts the 1s first.
   const result = await db
     .prepare(
       `SELECT * FROM board_posts
        WHERE board_id = ?1 AND deleted_at IS NULL
-       ORDER BY created_at DESC
+       ORDER BY (pinned_at IS NOT NULL) DESC, pinned_at DESC, created_at DESC
        LIMIT ?2 OFFSET ?3`,
     )
     .bind(boardId, limit, offset)
@@ -1018,4 +1022,67 @@ export async function softDeleteBoardPost(
     .run()
 
   return { ok: true }
+}
+
+export type BoardPostPinResult =
+  | { ok: true; pinned: boolean }
+  | { ok: false; reason: 'not_found' | 'deleted' | 'already_pinned' | 'not_pinned' }
+
+/**
+ * Pin a post. Pinned posts sort first in `listBoardPosts`. Caller authority
+ * (sevak / center admin / global admin) is enforced at the route level —
+ * this helper does the DB work and idempotency check only.
+ *
+ * Soft-deleted posts can't be pinned (you'd be promoting a hidden post).
+ */
+export async function pinBoardPost(
+  db: D1Database,
+  postId: string,
+  pinnedByUserId: string,
+): Promise<BoardPostPinResult> {
+  const post = await db
+    .prepare(`SELECT pinned_at, deleted_at FROM board_posts WHERE id = ?1`)
+    .bind(postId)
+    .first<{ pinned_at: string | null; deleted_at: string | null }>()
+
+  if (!post) return { ok: false, reason: 'not_found' }
+  if (post.deleted_at) return { ok: false, reason: 'deleted' }
+  if (post.pinned_at) return { ok: false, reason: 'already_pinned' }
+
+  await db
+    .prepare(
+      `UPDATE board_posts
+       SET pinned_at = datetime('now'), pinned_by = ?1
+       WHERE id = ?2`,
+    )
+    .bind(pinnedByUserId, postId)
+    .run()
+
+  return { ok: true, pinned: true }
+}
+
+/** Unpin a previously pinned post. Idempotent failure: `not_pinned`. */
+export async function unpinBoardPost(
+  db: D1Database,
+  postId: string,
+): Promise<BoardPostPinResult> {
+  const post = await db
+    .prepare(`SELECT pinned_at, deleted_at FROM board_posts WHERE id = ?1`)
+    .bind(postId)
+    .first<{ pinned_at: string | null; deleted_at: string | null }>()
+
+  if (!post) return { ok: false, reason: 'not_found' }
+  if (post.deleted_at) return { ok: false, reason: 'deleted' }
+  if (!post.pinned_at) return { ok: false, reason: 'not_pinned' }
+
+  await db
+    .prepare(
+      `UPDATE board_posts
+       SET pinned_at = NULL, pinned_by = NULL
+       WHERE id = ?1`,
+    )
+    .bind(postId)
+    .run()
+
+  return { ok: true, pinned: false }
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -160,6 +160,8 @@ export interface BoardPostRow {
   created_at: string
   updated_at: string
   deleted_at: string | null
+  pinned_at: string | null
+  pinned_by: string | null
 }
 
 export interface BoardReactionCount {
@@ -257,6 +259,8 @@ export interface BoardPostApiResponse {
   createdAt: string
   updatedAt: string
   deletedAt: string | null
+  pinnedAt: string | null
+  pinnedBy: string | null
   author: UserApiResponse
   reactions: BoardReactionCount[]
   replyCount: number


### PR DESCRIPTION
Pinning chunk of [#205 (Boards backend B1)](https://github.com/Project-Janata/Janata/issues/205). Closes one more acceptance criterion. First story PR to ship a new D1 migration through the tooling added in #246. Builds independently of #248 (edit/delete) — both can land in any order.

## 🛢️ Migration cutover note

This PR adds **`migrations/0020_board_post_pinning.sql`** (Tier 2 — disposable). Additive ALTER, no data loss.

At the next **v2 → main cutover**, apply with:

```bash
npx wrangler d1 execute chinmaya-janata-db \
  --file=migrations/0020_board_post_pinning.sql \
  --config packages/backend/wrangler.toml
```

After #246 lands, `npm run db:cutover-status` will list this file alongside the 4 existing pending migrations (0016–0019). Apply in numerical order.

## What this adds

### Migration: `0020_board_post_pinning.sql`
- `pinned_at TEXT` and `pinned_by TEXT REFERENCES users(id)` columns on `board_posts`
- Covering index `idx_board_posts_board_pinned_created` for fast pinned-first listing

### Routes
- `POST /boards/posts/:postId/pin` — gates on `verification_level >= SEVAK` (54) OR global admin. Mapped status spread: `200` / `404` / `410` (deleted) / `409` (already pinned).
- `POST /boards/posts/:postId/unpin` — same gate. `409` if not currently pinned (idempotent failure).

### Sort logic
`listBoardPosts` now orders by `(pinned_at IS NOT NULL) DESC, pinned_at DESC, created_at DESC` — pinned section first (most-recently-pinned at top of that section), then everything else reverse-chronological. The covering index serves this exact predicate.

### API shape
`BoardPostApiResponse` gains `pinnedAt: string | null` and `pinnedBy: string | null` so the frontend (#206 / B2) can render a pinned chip.

## Tests

7 new cases under `describe('board routes', …)`:

| | |
|---|---|
| sevak can pin | 200, post lands at index 0 with `pinnedAt` set |
| basic user 403 | message matches `/sevak\|admin/i` |
| admin can pin | 200 |
| 409 on already-pinned | idempotent failure |
| unpin succeeds | 200, `pinned: false`, listing's `pinnedAt: null` |
| 409 on unpin when not pinned | idempotent failure |
| sort order | pinned (older) jumps above newer unpinned |

**320/320 backend tests green.** Frontend tests + build also pass.

## Data scope on preview

**Backend + migration — preview URL is not useful.** Cloudflare Pages previews host the frontend, which calls `api.chinmayajanata.org` (production Worker). New routes only exist on this branch until v2 → main cutover. Once cutover runs, the migration applies to prod D1 (Tier 2 disposable `board_posts` table, additive ALTER — no data loss).

For live testing: `npm run dev` against `--local` D1, then exercise via curl per the story overview.

## Pre-existing test-infra gotcha surfaced (worth a follow-up)

The migration test helper at `packages/backend/src/__tests__/setup.ts` splits each migration file on the `;` character **before** filtering by statement head. A literal `;` inside an `--` comment (or inside `'…'` quoted text inside a comment) silently desyncs the parser and drops the next statement.

I tripped this twice while writing `0020`. The migration header now has an `IMPORTANT` block documenting the constraint. **Long-term fix worth opening as its own issue**: strip `-- ...` comments from each chunk *before* splitting on `;`, not after.

## Patterns introduced

- **Idempotent-failure 409**: pin-when-already-pinned and unpin-when-not-pinned both return `409 Conflict`, not `400 Bad Request`. Distinguishes "your input was bad" from "your input was fine but the state already matches".
- **Migration comment hygiene**: ASCII semicolons banned from comment text (see IMPORTANT block in `0020`). Future migrations should follow.
- **Composite ORDER BY with `IS NOT NULL`**: cleaner than `UNION ALL` and uses the new covering index. Future "type/category-first then chronological" sorts in this codebase can reuse the pattern.

## Reviewer checklist

- [ ] Migration looks correct (additive ALTER, index, no FK breakage)
- [ ] Pin authority gate at `SEVAK >= 54` matches your intent (the issue body said "sevak / center admin" — center admin isn't a separate role yet, so I gated on `SEVAK` + `isAdmin`)
- [ ] `BoardPostApiResponse` shape change is acceptable for #206 to consume
- [ ] You're OK with `--local`-only test path for backend-only PRs (no preview exercise possible)

## What stays open on #205 (next chunks)

- [ ] Replies routes (schema exists; create/list don't)
- [ ] Aggregated feed query (cross-board posts the user has access to)
- [ ] Admin view of soft-deleted (route + frontend admin UI — lives mostly in #209 M1)

Closes none on its own; partial progress on #205.

---

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779907317849719