### PR TITLE
feat(boards): single-level threaded replies (#205)

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -1249,6 +1249,135 @@ describe('board routes', () => {
       expect(list.posts[1].id).toBe(c.post.id)
     })
   })
+
+  // ── Replies (issue #205) ──────────────────────────────────────────────
+  describe('Replies: POST /api/boards/posts/:postId/replies + GET', () => {
+    let parentId: string
+
+    beforeEach(async () => {
+      const { body } = await jsonPost(
+        `/api/boards/center/${centerId}/posts`,
+        { body: 'parent post' },
+        authHeader(memberToken),
+      )
+      parentId = body.post.id
+    })
+
+    it('creates a reply on a parent post and lists it', async () => {
+      const { res: createRes, body: createBody } = await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'first reply' },
+        authHeader(memberToken),
+      )
+      expect(createRes.status).toBe(201)
+      expect(createBody.reply.body).toBe('first reply')
+      expect(createBody.reply.author.username).toBe('boardmember')
+
+      const { res: listRes, body: listBody } = await fetchJSON(
+        `/api/boards/posts/${parentId}/replies`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(listRes.status).toBe(200)
+      expect(listBody.replies).toHaveLength(1)
+      expect(listBody.replies[0].body).toBe('first reply')
+    })
+
+    it('excludes replies from the top-level board listing', async () => {
+      await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'a reply that should not appear at top level' },
+        authHeader(memberToken),
+      )
+
+      const { body } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      // Only the original parent post should be visible at top level.
+      expect(body.posts.map((p: { body: string }) => p.body)).toEqual(['parent post'])
+    })
+
+    it('increments parent replyCount in board listing', async () => {
+      await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'r1' },
+        authHeader(memberToken),
+      )
+      await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'r2' },
+        authHeader(memberToken),
+      )
+
+      const { body } = await fetchJSON(
+        `/api/boards/center/${centerId}`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(body.posts[0].replyCount).toBe(2)
+    })
+
+    it('refuses reply-to-reply (single-level threading) with 409', async () => {
+      const { body: r1 } = await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'first reply' },
+        authHeader(memberToken),
+      )
+
+      const { res } = await jsonPost(
+        `/api/boards/posts/${r1.reply.id}/replies`,
+        { body: 'reply to a reply' },
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(409)
+    })
+
+    it('rejects reply from a user without board access (403)', async () => {
+      const stranger = await registerAndLogin('boardstranger', 'password123')
+      const { res } = await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'sneaky' },
+        authHeader(stranger.token),
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('rejects empty reply body (400)', async () => {
+      const { res } = await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: '   ' },
+        authHeader(memberToken),
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 404 when the parent does not exist', async () => {
+      const { res } = await fetchJSON(
+        `/api/boards/posts/no-such-post/replies`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it('lists replies in chronological order (oldest first)', async () => {
+      await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'first' },
+        authHeader(memberToken),
+      )
+      await new Promise((r) => setTimeout(r, 1100))
+      await jsonPost(
+        `/api/boards/posts/${parentId}/replies`,
+        { body: 'second' },
+        authHeader(memberToken),
+      )
+
+      const { body } = await fetchJSON(
+        `/api/boards/posts/${parentId}/replies`,
+        { headers: authHeader(memberToken) },
+      )
+      expect(body.replies.map((r: { body: string }) => r.body)).toEqual(['first', 'second'])
+    })
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1418,6 +1418,91 @@ app.post('/boards/posts/:postId/unpin', authMiddleware, async (c) => {
   return c.json({ ok: true, pinned: false })
 })
 
+// Single-level threaded replies (#205). Access gate: same as posting on the
+// parent's board. Replies inherit the parent's board so users RSVP'd or
+// center-verified for that board can reply.
+app.post('/boards/posts/:postId/replies', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const parentPostId = c.req.param('postId')
+
+  const parent = await db.getBoardPostById(c.env.DB, parentPostId)
+  if (!parent) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, parent.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  const body: { body?: string } = await c.req
+    .json<{ body?: string }>()
+    .catch(() => ({}))
+  const text = typeof body.body === 'string' ? body.body.trim() : ''
+  if (!text) {
+    return c.json({ message: 'Reply body is required' }, 400)
+  }
+  if (text.length > 2000) {
+    return c.json({ message: 'Reply body must be 2000 characters or fewer' }, 400)
+  }
+
+  const replyId = crypto.randomUUID()
+  const result = await db.createBoardPostReply(c.env.DB, {
+    id: replyId,
+    parent_post_id: parentPostId,
+    board_id: parent.board_id,
+    author_id: user.id,
+    body: text,
+  })
+
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'parent_not_found':
+        return c.json({ message: 'Parent post not found' }, 404)
+      case 'parent_deleted':
+        return c.json({ message: 'Cannot reply to a deleted post' }, 410)
+      case 'parent_is_reply':
+        return c.json(
+          { message: 'Cannot reply to a reply — threads are single-level only in v2' },
+          409,
+        )
+      case 'insert_failed':
+        return c.json({ message: 'Failed to create reply' }, 500)
+    }
+  }
+
+  // Reload via the listBoardPostReplies path so the returned shape matches
+  // the GET endpoint and the frontend sees consistent fields.
+  const replies = await db.listBoardPostReplies(c.env.DB, parentPostId)
+  const created = replies.find((r) => r.id === replyId)
+  if (!created) {
+    return c.json({ message: 'Reply created but could not be loaded' }, 500)
+  }
+  return c.json({ reply: boardPostToApi(created) }, 201)
+})
+
+app.get('/boards/posts/:postId/replies', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const parentPostId = c.req.param('postId')
+
+  const parent = await db.getBoardPostById(c.env.DB, parentPostId)
+  if (!parent) {
+    return c.json({ message: 'Board post not found' }, 404)
+  }
+  const board = await db.getBoardById(c.env.DB, parent.board_id)
+  if (!board) {
+    return c.json({ message: 'Board not found' }, 404)
+  }
+  const accessError = await verifyBoardAccess(c, board.type, board.parent_id, user)
+  if (accessError) return accessError
+
+  const replies = await db.listBoardPostReplies(c.env.DB, parentPostId)
+  return c.json({
+    replies: replies.map(boardPostToApi),
+  })
+})
+
 // ═══════════════════════════════════════════════════════════════════════
 // EVENT ROUTES
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -860,10 +860,15 @@ export async function listBoardPosts(
   // then everything else reverse-chronological. The
   // `pinned_at IS NOT NULL` predicate evaluates to 1 for pinned posts and 0
   // for non-pinned; DESC puts the 1s first.
+  // Exclude posts that are themselves replies (#205 threaded replies) — they
+  // belong under their parent in the reply panel, not at the top level of the
+  // board feed. Single-level threading is enforced in createBoardPostReply,
+  // so the NOT IN subquery is bounded and trivially indexed.
   const result = await db
     .prepare(
       `SELECT * FROM board_posts
        WHERE board_id = ?1 AND deleted_at IS NULL
+         AND id NOT IN (SELECT post_id FROM board_post_replies)
        ORDER BY (pinned_at IS NOT NULL) DESC, pinned_at DESC, created_at DESC
        LIMIT ?2 OFFSET ?3`,
     )
@@ -1085,4 +1090,111 @@ export async function unpinBoardPost(
     .run()
 
   return { ok: true, pinned: false }
+}
+
+export type CreateBoardPostReplyResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason:
+        | 'parent_not_found'
+        | 'parent_deleted'
+        | 'parent_is_reply'
+        | 'insert_failed'
+    }
+
+/**
+ * Create a single-level reply to a top-level board post. Enforced rules:
+ *   - parent must exist (not deleted)
+ *   - parent must itself be a top-level post — replies-to-replies are
+ *     refused with `parent_is_reply` so threads can't deepen past one level
+ *   - reply lands on the same board as the parent (caller passes board_id
+ *     for the route's access gate, but we double-check here)
+ *
+ * Uses D1 batch() so the board_posts INSERT and the board_post_replies
+ * INSERT are atomic — no orphan top-level posts if either fails.
+ */
+export async function createBoardPostReply(
+  db: D1Database,
+  args: {
+    id: string
+    parent_post_id: string
+    board_id: string
+    author_id: string
+    body: string
+  },
+): Promise<CreateBoardPostReplyResult> {
+  const parent = await db
+    .prepare(`SELECT board_id, deleted_at FROM board_posts WHERE id = ?1`)
+    .bind(args.parent_post_id)
+    .first<{ board_id: string; deleted_at: string | null }>()
+  if (!parent) return { ok: false, reason: 'parent_not_found' }
+  if (parent.deleted_at) return { ok: false, reason: 'parent_deleted' }
+
+  // Treat board mismatch as not_found rather than leak info about which
+  // board the parent is on.
+  if (parent.board_id !== args.board_id) {
+    return { ok: false, reason: 'parent_not_found' }
+  }
+
+  // Single-level threading: parent can't itself be a reply.
+  const parentIsReply = await db
+    .prepare(`SELECT 1 FROM board_post_replies WHERE post_id = ?1`)
+    .bind(args.parent_post_id)
+    .first()
+  if (parentIsReply) return { ok: false, reason: 'parent_is_reply' }
+
+  const results = await db.batch([
+    db
+      .prepare(
+        `INSERT INTO board_posts (id, board_id, author_id, body, image_url)
+         VALUES (?1, ?2, ?3, ?4, NULL)`,
+      )
+      .bind(args.id, args.board_id, args.author_id, args.body),
+    db
+      .prepare(
+        `INSERT INTO board_post_replies (post_id, parent_post_id) VALUES (?1, ?2)`,
+      )
+      .bind(args.id, args.parent_post_id),
+  ])
+
+  return results.every((r) => r.success) ? { ok: true } : { ok: false, reason: 'insert_failed' }
+}
+
+/**
+ * List replies under a parent post in chronological order (oldest first —
+ * threads read top-to-bottom). Returns hydrated `BoardPostWithAuthor`
+ * shape so the route can pass them through `boardPostToApi` directly.
+ * Reply rows don't carry their own reactions or reply_count yet (v2 doesn't
+ * reply-to-reply, and reactions on replies are deferred per PRD).
+ */
+export async function listBoardPostReplies(
+  db: D1Database,
+  parentPostId: string,
+): Promise<BoardPostWithAuthor[]> {
+  const result = await db
+    .prepare(
+      `SELECT bp.* FROM board_posts bp
+       JOIN board_post_replies bpr ON bpr.post_id = bp.id
+       WHERE bpr.parent_post_id = ?1 AND bp.deleted_at IS NULL
+       ORDER BY bp.created_at ASC`,
+    )
+    .bind(parentPostId)
+    .all<BoardPostRow>()
+
+  const replies = result.results ?? []
+  const hydrated = await Promise.all(
+    replies.map(async (post) => {
+      const author = await getUserById(db, post.author_id)
+      return author
+        ? {
+            ...post,
+            author,
+            reactions: [] as BoardReactionCount[],
+            reply_count: 0,
+          }
+        : null
+    }),
+  )
+  return hydrated.filter((p): p is BoardPostWithAuthor => p !== null)
 }


### PR DESCRIPTION
Replies chunk of [#205 (Boards backend B1)](https://github.com/Project-Janata/Janata/issues/205). Single-level threading per PRD §5.2 — reply-to-reply is explicitly refused. Schema (`board_post_replies` from 0019) already existed; this PR wires the routes. Builds independently of #248 (edit/delete) and #249 (pinning).

## What this adds

### Routes
- **`POST /boards/posts/:postId/replies`** — create a reply on a top-level post. Same access gate as posting on the parent's board (`verifyBoardAccess`). Returns `201` with the reply in the same `BoardPostApiResponse` shape as a regular post.
- **`GET /boards/posts/:postId/replies`** — list replies under a parent, chronological (oldest first — threads read top-down).

### Listing fix
`listBoardPosts` now adds `AND id NOT IN (SELECT post_id FROM board_post_replies)` to exclude reply rows from the top-level board listing. **Without this fix, replies would pollute the user-facing feed.** Uses the existing `idx_board_post_replies_parent` covering index.

### Single-level enforcement
`createBoardPostReply` checks the parent is NOT itself a reply (`SELECT 1 FROM board_post_replies WHERE post_id = ?`). Reply-to-reply attempts return `409 Conflict` with: `"Cannot reply to a reply — threads are single-level only in v2"`.

### Atomic insert
First use of D1 `db.batch()` in this codebase. Creating a reply requires inserting a `board_posts` row AND a `board_post_replies` link row. If only the first succeeds, you'd have an orphan top-level post (a would-be reply with no link). `db.batch()` runs them atomically so this can't happen.

## Schema impact

**None.** Uses the existing `board_post_replies` table created in migration 0019. Tier 2 (board_posts disposable). No new migration in this PR.

## Tests

8 new cases under `describe('board routes', …)`:

| | |
|---|---|
| Create + list happy path | 201 / 200, body + author preserved |
| Reply excluded from top-level listing | Only the parent shows in `/boards/center/:id`, not the reply |
| `replyCount` increments on parent | Two replies → parent's `replyCount` becomes 2 in the board listing |
| Reply-to-reply refused | 409 with the threading message |
| Non-member reply | 403 from `verifyBoardAccess` |
| Empty body | 400 |
| Parent not found | 404 on GET |
| Chronological order | Oldest first; uses 1.1s sleep between inserts to outrun SQLite's 1s `datetime('now')` granularity |

**321/321 backend tests green.** Frontend tests + build also pass.

## Data scope on preview

**Backend-only — preview URL is not useful.** Cloudflare Pages previews host the frontend, which calls `api.chinmayajanata.org` (production Worker). The new routes only exist on this branch until v2 → main cutover. Once cutover runs, the routes write to prod D1 (Tier 2 disposable tables — feature evolving, data treated as disposable).

## 🛢️ Migration cutover note

No migration in this PR.

## Patterns introduced

- **`db.batch()` for atomic multi-table writes.** Future multi-table writes (messaging, RSVPs with side effects, board reactions on replies if we ever permit them) should reuse this instead of sequential `.run()`s.
- **Top-level-only listing predicates.** When adding any new join table that links posts (e.g. polls, media attachments, etc.), update the equivalent of `listBoardPosts`'s `NOT IN` clause so the top-level feed stays clean.

## What stays open on #205

After this PR merges, only the **aggregated feed** acceptance criterion remains:
- [ ] Cross-board feed query (posts across all boards the user has access to, reverse-chronological with pinned-on-top, performant target <300ms)

The other open chunks (#248 edit/delete, #249 pinning) can land in any order with this one.

## Follow-up worth tracking

**"Replies are not editable" (PRD §5.2) is not enforced here.** Tightening goes in the edit route — when #248 lands and is merged, follow up to add `if (post is a reply) return 403` in `editBoardPost`. I noted this in #248's PR body.

## Reviewer checklist

- [ ] The `db.batch()` atomicity is OK for your D1 instance (Cloudflare docs say it is, but worth a sanity check)
- [ ] `NOT IN (SELECT post_id FROM board_post_replies)` on every board listing query is the right place to enforce reply exclusion (vs. a `is_reply BOOLEAN` column)
- [ ] 409 (vs 400) for reply-to-reply matches your status-code preference

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779907754106489