### PR TITLE
chore(error-boundary): gate debug panel behind EXPO_PUBLIC_SHOW_DEBUG_DETAILS (#166)

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -5,3 +5,10 @@ EXPO_PUBLIC_POSTHOG_KEY=
 
 # Optional; default in app is https://us.i.posthog.com
 # EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Show the ErrorBoundary debug panel (full error message, stack trace, Copy
+# details button) when a crash occurs. Useful for dev/beta triage. Leave UNSET
+# (or set to anything other than 'true') in production builds — exposing stack
+# traces to public users leaks internals and looks unpolished. See
+# `components/ui/ErrorBoundary.tsx` and GitHub issue #166.
+# EXPO_PUBLIC_SHOW_DEBUG_DETAILS=true

--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -180,9 +180,14 @@ export class ErrorBoundary extends Component<Props, State> {
             </Pressable>
           )}
 
-          {/* Beta-phase debug panel: shown to every user so a screenshot is
-              enough to triage. Remove or gate behind a flag at public launch. */}
-          {this.state.error && (
+          {/* Beta-phase debug panel: full error message + stack trace + Copy
+              details button. Useful for triaging phone-only crashes during
+              beta/dev. Hidden in production builds (env unset on prod →
+              undefined !== 'true').
+
+              Devs can opt in by setting EXPO_PUBLIC_SHOW_DEBUG_DETAILS=true
+              in `packages/frontend/.env` — see `.env.example`. */}
+          {process.env.EXPO_PUBLIC_SHOW_DEBUG_DETAILS === 'true' && this.state.error && (
             <View
               style={{
                 marginTop: 32,


### PR DESCRIPTION
Closes #166

## What

Wraps the beta-phase debug panel in `packages/frontend/components/ui/ErrorBoundary.tsx` (lines ~183–243) behind `process.env.EXPO_PUBLIC_SHOW_DEBUG_DETAILS === 'true'`. The friendly fallback (the "Something went wrong" view + Try Again pill + Reset session link) is unchanged.

Documents the new env var in `packages/frontend/.env.example` so devs can opt back in by adding it to their local `.env`.

## Why

PR #164 added the panel so phone-only crashes were triagable from a screenshot during beta. The in-file comment already flagged that this should be gated at public launch (full stack traces in front of every public user leak internals + look unpolished). MSC launch (Aug 1) is when to gate, and per the snapshot it's S2 priority.

## How it behaves

| Build path | Env var | Behavior |
|---|---|---|
| Production CF Pages (`v2 → main` cutover) | unset | Debug panel **hidden**. Friendly fallback only. |
| Preview CF Pages (PR previews) | unset | Debug panel **hidden**. Friendly fallback only. |
| Local `npm run dev` with `EXPO_PUBLIC_SHOW_DEBUG_DETAILS=true` in `.env` | `'true'` | Debug panel **shown**, same as before. |
| Local `npm run dev` without that line | undefined | Debug panel **hidden**, friendly fallback only. |

Note on the `console.error('ErrorBoundary caught:', ...)` call and the `window.__lastErrorInfo` write inside `componentDidCatch`: per the issue, these are debug-channel only (not user-visible), so they remain unconditional. Sentry / log scrapers continue to receive crash info.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` (backend) ✅
- `npm run test:frontend` ✅ — 162 tests / 9 files
- `npm run test:backend` ✅ — 313 tests / 9 files
- `npm run build` ✅

## Note on staging frontend build (spec gap)

The issue's acceptance criteria say: _"Set that env var to `'true'` in `.github/workflows/deploy.yml` for staging builds; leave it unset (or `'false'`) for production builds."_

Today's `deploy.yml` has a `deploy-staging` job, but it only deploys the **backend** worker — there is no staging frontend build job. So there is nowhere to set `EXPO_PUBLIC_SHOW_DEBUG_DETAILS=true` for staging without first adding a new job.

Took the minimum correct interpretation: gate defaults to OFF for everyone (prod + previews + dev that doesn't opt in), with explicit local opt-in via `.env`. If we want a hosted staging surface with the debug panel always on, that's a follow-up PR adding a staging frontend build job (would belong with #103 / EAS pipeline work).

## Files

- `packages/frontend/components/ui/ErrorBoundary.tsx` — 1 JSX condition added (`process.env.EXPO_PUBLIC_SHOW_DEBUG_DETAILS === 'true' && ...`), comment updated.
- `packages/frontend/.env.example` — documents the new variable.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779917511066129