### PR TITLE
feat(seo): per-page JSON-LD + sitemap + robots.txt (#213)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:backend": "cd packages/backend && npm run dev",
     "dev:frontend": "cd packages/frontend && npm run dev",
     "build": "npm run typecheck && npm run build:frontend",
-    "build:frontend": "cd packages/frontend && npm run build && rm -rf ../../dist && cp -R dist ../../dist",
+    "build:frontend": "cd packages/frontend && npm run build && rm -rf ../../dist && cp -R dist ../../dist && node ../../scripts/generate-sitemap.cjs",
     "typecheck": "cd packages/backend && npm run typecheck",
     "deploy": "npm run deploy:backend && npm run deploy:frontend",
     "deploy:frontend": "npm run build:frontend && npx wrangler pages deploy dist",

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -8,6 +8,8 @@ import { createBoardPost, type EventDisplay } from '../../utils/api'
 import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
 import { ThreadPanel, boardPostToMessage } from '../../components/boards'
 import { useUser } from '../../components/contexts'
+import { SeoHead } from '../../components/seo/SeoHead'
+import { buildCenterJsonLd } from '../../components/seo/jsonLd'
 
 export default function CenterDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
@@ -110,8 +112,22 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }
 
   const displayWebsite = (center.website ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '')
+  const seoTitle = center.name || 'Center'
+  const seoDesc =
+    `${center.name} — a Chinmaya Mission center` +
+    (center.address ? ` at ${center.address}` : '') +
+    '. Find upcoming events, contact info, and connect with the local community on Chinmaya Janata.'
+  const centerJsonLd = buildCenterJsonLd(center)
+
   return (
     <View style={{ flex: 1, backgroundColor: colors.panelBg }}>
+      <SeoHead
+        title={seoTitle}
+        description={seoDesc}
+        path={`/center/${center.id}`}
+        ogImage={center.image || undefined}
+        jsonLd={centerJsonLd}
+      />
       {/* Header */}
       <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8, gap: 10 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -14,6 +14,8 @@ import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import AuthPromptModal from '../../components/ui/AuthPromptModal'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { ThreadPanel, boardPostToMessage } from '../../components/boards'
+import { SeoHead } from '../../components/seo/SeoHead'
+import { buildEventJsonLd } from '../../components/seo/jsonLd'
 
 function formatEventDateLabel(dateStr: string): string {
   const d = new Date(`${dateStr}T00:00:00`)
@@ -109,8 +111,24 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
     )
   }
 
+  const seoTitle = event.title || 'Event'
+  const seoDesc =
+    event.description && event.description.length > 30
+      ? event.description
+      : `${event.title} on ${event.date}` +
+        (event.address ? ` at ${event.address}` : '') +
+        '. Find details and RSVP on Chinmaya Janata.'
+  const eventJsonLd = buildEventJsonLd(event)
+
   return (
     <View style={{ flex: 1, backgroundColor: colors.panelBg }}>
+      <SeoHead
+        title={seoTitle}
+        description={seoDesc}
+        path={`/events/${event.id}`}
+        ogImage={event.image || undefined}
+        jsonLd={eventJsonLd}
+      />
       {/* Header */}
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 }}>
         <Pressable onPress={() => router.back()} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>

--- a/packages/frontend/app/landing.web.tsx
+++ b/packages/frontend/app/landing.web.tsx
@@ -13,6 +13,8 @@ import { ProblemSection } from '../components/landing/ProblemSection'
 import { CommunitySection } from '../components/landing/CommunitySection'
 import { FinalCTA } from '../components/landing/FinalCTA'
 import { Footer } from '../components/landing/Footer'
+import { SeoHead } from '../components/seo/SeoHead'
+import { buildOrganizationJsonLd } from '../components/seo/jsonLd'
 
 export default function LandingPage() {
   return (
@@ -22,6 +24,13 @@ export default function LandingPage() {
       bounces={false}
       overScrollMode="never"
     >
+      <SeoHead
+        title="Chinmaya Janata — Connect with your Chinmaya community"
+        exactTitle
+        description="Chinmaya Janata brings the worldwide Chinmaya Mission community together. Find nearby centers, discover upcoming events, and connect with fellow members."
+        path="/"
+        jsonLd={buildOrganizationJsonLd()}
+      />
       <NavBar />
       <Hero />
       <ProblemSection />

--- a/packages/frontend/components/seo/SeoHead.tsx
+++ b/packages/frontend/components/seo/SeoHead.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import Head from 'expo-router/head'
+
+import { SITE_URL } from './jsonLd'
+
+interface SeoHeadProps {
+  /** Page title (will be suffixed with " · Chinmaya Janata" unless `exactTitle` is true). */
+  title: string
+  /** ≤ 160 char meta description. */
+  description: string
+  /** Path-only canonical URL — joined with the site origin. e.g. `/center/abc`. */
+  path?: string
+  /** Absolute URL for the OG image. Defaults to the site logo. */
+  ogImage?: string
+  /** When true, render `title` exactly; otherwise append the brand. */
+  exactTitle?: boolean
+  /** JSON-LD blob (use buildCenterJsonLd / buildEventJsonLd / buildOrganizationJsonLd). */
+  jsonLd?: string | null
+  /** Hint to crawlers — `noindex` for auth-gated views. */
+  noIndex?: boolean
+}
+
+const DEFAULT_OG_IMAGE = `${SITE_URL}/logo.png`
+
+/**
+ * Per-page SEO head. Renders title + meta + canonical + OG/Twitter tags +
+ * optional JSON-LD into the document `<head>` via `expo-router/head`.
+ *
+ * Because the app is Expo Router with `web.output: "single"` (SPA), these
+ * tags are injected at runtime via react-helmet-async. Googlebot still
+ * indexes JS-rendered content, but for full SSR-quality SEO we'd want to
+ * migrate to `output: "static"` — see PR body for the follow-up plan.
+ */
+export function SeoHead({
+  title,
+  description,
+  path,
+  ogImage,
+  exactTitle,
+  jsonLd,
+  noIndex,
+}: SeoHeadProps) {
+  const fullTitle = exactTitle ? title : `${title} · Chinmaya Janata`
+  const canonical = path ? new URL(path, SITE_URL).toString() : SITE_URL
+  const img = ogImage || DEFAULT_OG_IMAGE
+  const desc = description.length > 160 ? description.slice(0, 157) + '…' : description
+
+  return (
+    <Head>
+      <title>{fullTitle}</title>
+      <meta name="description" content={desc} />
+      <link rel="canonical" href={canonical} />
+
+      {noIndex ? <meta name="robots" content="noindex, nofollow" /> : null}
+
+      {/* Open Graph */}
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Chinmaya Janata" />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:image" content={img} />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={desc} />
+      <meta name="twitter:image" content={img} />
+
+      {jsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+      ) : null}
+    </Head>
+  )
+}

--- a/packages/frontend/components/seo/jsonLd.ts
+++ b/packages/frontend/components/seo/jsonLd.ts
@@ -1,0 +1,190 @@
+/**
+ * JSON-LD builders for SEO structured data.
+ *
+ * Emit one `<script type="application/ld+json">` per detail page so Google
+ * can render rich results (centers as religious organizations, events with
+ * date/location/organizer).
+ *
+ * Pure functions — no React. Tested in src/__tests__/seo/jsonLd.test.ts.
+ */
+
+/**
+ * Structural input types — accept either the raw API shape (`centerID`, `eventID`)
+ * or the hook's display shape (`id`). Builders normalize internally.
+ */
+export interface CenterJsonLdInput {
+  id?: string
+  centerID?: string
+  name?: string
+  latitude?: number
+  longitude?: number
+  address?: string | null
+  website?: string | null
+  phone?: string | null
+  image?: string | null
+  memberCount?: number
+}
+
+export interface EventJsonLdInput {
+  id?: string
+  eventID?: string
+  title?: string
+  description?: string
+  date?: string
+  endDate?: string | null
+  latitude?: number
+  longitude?: number
+  address?: string | null
+  image?: string | null
+  signupUrl?: string | null
+}
+
+/**
+ * Canonical base URL of the deployed app. Prefer the env var so previews can
+ * point sitemap + JSON-LD at the right host; default to the prod custom domain.
+ */
+export const SITE_URL =
+  (typeof process !== 'undefined' && process.env.EXPO_PUBLIC_SITE_URL) ||
+  'https://chinmayajanata.org'
+
+const SITE_NAME = 'Chinmaya Janata'
+
+/**
+ * Build a LocalBusiness / ReligiousOrganization JSON-LD block for a center.
+ *
+ * Returns `null` when the center lacks the minimum required fields (name +
+ * latitude/longitude) — emitting a malformed block hurts SEO worse than not
+ * emitting one.
+ */
+export function buildCenterJsonLd(center: CenterJsonLdInput | null | undefined): string | null {
+  if (!center || !center.name) return null
+  if (!Number.isFinite(center.latitude) || !Number.isFinite(center.longitude)) return null
+
+  const centerId = center.centerID ?? center.id
+  if (!centerId) return null
+  const url = `${SITE_URL}/center/${encodeURIComponent(centerId)}`
+  const node: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': ['ReligiousOrganization', 'LocalBusiness'],
+    '@id': url,
+    name: center.name,
+    url,
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: center.latitude,
+      longitude: center.longitude,
+    },
+  }
+
+  if (center.address) {
+    // We don't have parsed address components — emit the freeform string only.
+    // Google accepts a `streetAddress` only LocalBusiness in practice.
+    node.address = {
+      '@type': 'PostalAddress',
+      streetAddress: center.address,
+    }
+  }
+
+  if (center.website) node.sameAs = [center.website]
+  if (center.phone) node.telephone = center.phone
+  if (center.image) node.image = center.image
+  if (typeof center.memberCount === 'number' && center.memberCount > 0) {
+    node.numberOfEmployees = center.memberCount
+  }
+
+  return JSON.stringify(node)
+}
+
+/**
+ * Build an Event JSON-LD block. Past events get `eventStatus: EventScheduled`
+ * with the original date; Google handles "past" via the date itself.
+ *
+ * Returns `null` if the event lacks a title or date.
+ */
+export function buildEventJsonLd(
+  event: EventJsonLdInput | null | undefined,
+  options: { centerName?: string | null; centerWebsite?: string | null } = {},
+): string | null {
+  if (!event || !event.title || !event.date) return null
+
+  const eventId = event.eventID ?? event.id
+  if (!eventId) return null
+  const url = `${SITE_URL}/events/${encodeURIComponent(eventId)}`
+  const isPast = !!event.date && new Date(event.date).getTime() < Date.now() - 24 * 3600_000
+
+  const node: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    '@id': url,
+    name: event.title,
+    url,
+    startDate: event.date,
+    // Schema.org expects ISO 8601; the API returns 'YYYY-MM-DD' which is valid.
+    // If we have an endDate use it; otherwise omit (Google then treats as
+    // single-day from startDate).
+    ...(event.endDate ? { endDate: event.endDate } : {}),
+    eventStatus: isPast
+      ? 'https://schema.org/EventScheduled'
+      : 'https://schema.org/EventScheduled',
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    description: event.description || `${event.title} — find more on Chinmaya Janata.`,
+  }
+
+  // Location: schema.org Place requires name + address OR geo. Use whatever
+  // we have — geo coords always, address when present.
+  const place: Record<string, unknown> = {
+    '@type': 'Place',
+    name: event.address || event.title || SITE_NAME,
+  }
+  if (event.address) {
+    place.address = {
+      '@type': 'PostalAddress',
+      streetAddress: event.address,
+    }
+  }
+  if (Number.isFinite(event.latitude) && Number.isFinite(event.longitude)) {
+    place.geo = {
+      '@type': 'GeoCoordinates',
+      latitude: event.latitude,
+      longitude: event.longitude,
+    }
+  }
+  node.location = place
+
+  // Organizer — the center hosting the event, if known.
+  if (options.centerName) {
+    const organizer: Record<string, unknown> = {
+      '@type': 'Organization',
+      name: options.centerName,
+    }
+    if (options.centerWebsite) organizer.url = options.centerWebsite
+    node.organizer = organizer
+  }
+
+  if (event.image) node.image = event.image
+  if (event.signupUrl) node.offers = {
+    '@type': 'Offer',
+    url: event.signupUrl,
+    availability: 'https://schema.org/InStock',
+  }
+
+  return JSON.stringify(node)
+}
+
+/**
+ * Build an Organization JSON-LD block for the landing page — establishes the
+ * sameAs / brand surface so Google groups all centers/events under one
+ * organization knowledge panel.
+ */
+export function buildOrganizationJsonLd(): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: SITE_NAME,
+    alternateName: 'Chinmaya Mission Janata',
+    url: SITE_URL,
+    logo: `${SITE_URL}/logo.png`,
+    description:
+      'Chinmaya Janata connects the worldwide Chinmaya Mission community: discover nearby centers, find events, and stay connected with fellow members.',
+  })
+}

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,0 +1,27 @@
+# robots.txt for Chinmaya Janata
+# Public site: https://chinmayajanata.org
+
+User-agent: *
+Allow: /
+Allow: /center/
+Allow: /events/
+Allow: /landing
+Allow: /terms
+Allow: /privacy
+Allow: /cookies
+
+# Auth-gated and admin surfaces — don't index
+Disallow: /auth
+Disallow: /auth/
+Disallow: /admin
+Disallow: /admin/
+Disallow: /onboarding
+Disallow: /edit-profile
+Disallow: /settings
+Disallow: /settings/
+Disallow: /chat/
+Disallow: /feed/
+
+# AI crawlers — same rules; no separate carve-outs.
+
+Sitemap: https://chinmayajanata.org/sitemap.xml

--- a/packages/frontend/src/__tests__/seo/jsonLd.test.ts
+++ b/packages/frontend/src/__tests__/seo/jsonLd.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  buildCenterJsonLd,
+  buildEventJsonLd,
+  buildOrganizationJsonLd,
+  SITE_URL,
+} from '../../../components/seo/jsonLd'
+
+const validCenter = {
+  centerID: 'ctr_123',
+  name: 'Chinmaya Mission Boston',
+  latitude: 42.36,
+  longitude: -71.06,
+  address: '123 Vedanta Way, Boston, MA 02101',
+  website: 'https://chinmayaboston.org',
+  phone: '+1-555-123-4567',
+  image: 'https://chinmayaboston.org/logo.png',
+  memberCount: 240,
+}
+
+const validEvent = {
+  eventID: 'evt_42',
+  title: 'Gita Jayanti Satsang',
+  description: 'An evening of chanting, discourse, and prasadam.',
+  date: '2026-07-15',
+  endDate: '2026-07-15',
+  latitude: 37.77,
+  longitude: -122.42,
+  address: '1 Krishna Lane, San Francisco, CA',
+  image: 'https://example.com/event.jpg',
+}
+
+describe('buildCenterJsonLd', () => {
+  it('builds a valid LocalBusiness JSON-LD for a full center', () => {
+    const raw = buildCenterJsonLd(validCenter)
+    expect(raw).not.toBeNull()
+    const ld = JSON.parse(raw!)
+    expect(ld['@context']).toBe('https://schema.org')
+    expect(ld['@type']).toContain('ReligiousOrganization')
+    expect(ld['@type']).toContain('LocalBusiness')
+    expect(ld.name).toBe('Chinmaya Mission Boston')
+    expect(ld['@id']).toBe(`${SITE_URL}/center/ctr_123`)
+    expect(ld.url).toBe(`${SITE_URL}/center/ctr_123`)
+    expect(ld.geo.latitude).toBe(42.36)
+    expect(ld.geo.longitude).toBe(-71.06)
+    expect(ld.address.streetAddress).toContain('Boston')
+    expect(ld.telephone).toBe('+1-555-123-4567')
+    expect(ld.numberOfEmployees).toBe(240)
+    expect(ld.sameAs).toEqual(['https://chinmayaboston.org'])
+  })
+
+  it('returns null for missing name', () => {
+    expect(buildCenterJsonLd({ ...validCenter, name: undefined } as any)).toBeNull()
+  })
+
+  it('returns null for non-numeric coordinates', () => {
+    expect(buildCenterJsonLd({ ...validCenter, latitude: NaN } as any)).toBeNull()
+    expect(buildCenterJsonLd({ ...validCenter, longitude: undefined } as any)).toBeNull()
+  })
+
+  it('returns null for missing id (no centerID, no id)', () => {
+    const { centerID, ...rest } = validCenter as any
+    expect(buildCenterJsonLd(rest)).toBeNull()
+  })
+
+  it('accepts the hook display shape (id instead of centerID)', () => {
+    const display = { ...validCenter, id: validCenter.centerID, centerID: undefined } as any
+    delete display.centerID
+    const raw = buildCenterJsonLd(display)
+    expect(raw).not.toBeNull()
+    const ld = JSON.parse(raw!)
+    expect(ld['@id']).toContain('/center/ctr_123')
+  })
+
+  it('omits optional fields gracefully when absent', () => {
+    const minimal = {
+      centerID: 'ctr_min',
+      name: 'Minimal Center',
+      latitude: 0,
+      longitude: 0,
+    }
+    const ld = JSON.parse(buildCenterJsonLd(minimal as any)!)
+    expect(ld.address).toBeUndefined()
+    expect(ld.telephone).toBeUndefined()
+    expect(ld.image).toBeUndefined()
+    expect(ld.sameAs).toBeUndefined()
+    expect(ld.numberOfEmployees).toBeUndefined()
+  })
+})
+
+describe('buildEventJsonLd', () => {
+  it('builds a valid Event JSON-LD for a full event', () => {
+    const ld = JSON.parse(buildEventJsonLd(validEvent)!)
+    expect(ld['@type']).toBe('Event')
+    expect(ld.name).toBe('Gita Jayanti Satsang')
+    expect(ld['@id']).toBe(`${SITE_URL}/events/evt_42`)
+    expect(ld.startDate).toBe('2026-07-15')
+    expect(ld.endDate).toBe('2026-07-15')
+    expect(ld.eventAttendanceMode).toContain('OfflineEvent')
+    expect(ld.location['@type']).toBe('Place')
+    expect(ld.location.geo.latitude).toBe(37.77)
+    expect(ld.location.address.streetAddress).toContain('Krishna Lane')
+    expect(ld.description).toContain('chanting')
+  })
+
+  it('returns null without title or date', () => {
+    expect(buildEventJsonLd({ ...validEvent, title: '' } as any)).toBeNull()
+    expect(buildEventJsonLd({ ...validEvent, date: undefined } as any)).toBeNull()
+  })
+
+  it('attaches organizer when centerName option is provided', () => {
+    const ld = JSON.parse(
+      buildEventJsonLd(validEvent, { centerName: 'CM Boston', centerWebsite: 'https://chinmayaboston.org' })!,
+    )
+    expect(ld.organizer.name).toBe('CM Boston')
+    expect(ld.organizer.url).toBe('https://chinmayaboston.org')
+  })
+
+  it('attaches Offer when signupUrl is set', () => {
+    const ld = JSON.parse(buildEventJsonLd({ ...validEvent, signupUrl: 'https://signup.com/abc' })!)
+    expect(ld.offers.url).toBe('https://signup.com/abc')
+    expect(ld.offers.availability).toContain('InStock')
+  })
+})
+
+describe('buildOrganizationJsonLd', () => {
+  it('emits an Organization block with the canonical site URL', () => {
+    const ld = JSON.parse(buildOrganizationJsonLd())
+    expect(ld['@type']).toBe('Organization')
+    expect(ld.url).toBe(SITE_URL)
+    expect(ld.logo).toContain('logo.png')
+    expect(ld.alternateName).toBe('Chinmaya Mission Janata')
+  })
+})

--- a/scripts/generate-sitemap.cjs
+++ b/scripts/generate-sitemap.cjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * generate-sitemap.cjs
+ *
+ * Build-time helper that writes `dist/sitemap.xml` for SEO crawling.
+ * Always includes static pages; tries to enrich with all centers + events
+ * from the prod API. Network failure during build is non-fatal — we ship a
+ * sitemap with just the static pages and log a warning.
+ *
+ * Env vars:
+ *   SITE_URL                — canonical site origin (default: https://chinmayajanata.org)
+ *   SITEMAP_API_BASE_URL    — backend API origin used for the centers/events fetch
+ *                              (default: https://api.chinmayajanata.org)
+ *   SITEMAP_SKIP_NETWORK    — set to '1' to skip the dynamic fetch entirely
+ *
+ * Usage: invoked from package.json as a postbuild step.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SITE_URL = (process.env.SITE_URL || 'https://chinmayajanata.org').replace(/\/$/, '');
+const API_BASE = (process.env.SITEMAP_API_BASE_URL || 'https://api.chinmayajanata.org').replace(/\/$/, '');
+const SKIP_NETWORK = process.env.SITEMAP_SKIP_NETWORK === '1';
+const TIMEOUT_MS = 15_000;
+
+const DIST_DIR = path.resolve(__dirname, '..', 'dist');
+
+const STATIC_ROUTES = [
+  { path: '/', changefreq: 'daily', priority: 1.0 },
+  { path: '/landing', changefreq: 'weekly', priority: 0.9 },
+  { path: '/terms', changefreq: 'yearly', priority: 0.3 },
+  { path: '/privacy', changefreq: 'yearly', priority: 0.3 },
+  { path: '/cookies', changefreq: 'yearly', priority: 0.3 },
+];
+
+function xmlEscape(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+async function fetchJson(url) {
+  const ctl = new AbortController();
+  const to = setTimeout(() => ctl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(url, { signal: ctl.signal, headers: { Accept: 'application/json' } });
+    if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
+    return await r.json();
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+async function fetchCenters() {
+  if (SKIP_NETWORK) return [];
+  try {
+    const data = await fetchJson(`${API_BASE}/api/centers`);
+    const list = Array.isArray(data) ? data : data.centers || data.data || [];
+    return list.filter((c) => c && (c.centerID || c.id));
+  } catch (e) {
+    console.warn(`[sitemap] centers fetch failed: ${e.message} — skipping centers`);
+    return [];
+  }
+}
+
+async function fetchEvents() {
+  if (SKIP_NETWORK) return [];
+  try {
+    const data = await fetchJson(`${API_BASE}/api/fetchAllEvents`);
+    const list = Array.isArray(data) ? data : data.events || data.data || [];
+    return list.filter((e) => e && (e.eventID || e.id));
+  } catch (e) {
+    console.warn(`[sitemap] events fetch failed: ${e.message} — skipping events`);
+    return [];
+  }
+}
+
+function urlEntry({ loc, lastmod, changefreq, priority }) {
+  const parts = [`    <loc>${xmlEscape(loc)}</loc>`];
+  if (lastmod) parts.push(`    <lastmod>${xmlEscape(lastmod)}</lastmod>`);
+  if (changefreq) parts.push(`    <changefreq>${changefreq}</changefreq>`);
+  if (priority !== undefined) parts.push(`    <priority>${priority.toFixed(1)}</priority>`);
+  return `  <url>\n${parts.join('\n')}\n  </url>`;
+}
+
+(async () => {
+  if (!fs.existsSync(DIST_DIR)) {
+    console.warn(`[sitemap] dist/ not found at ${DIST_DIR}; nothing to write`);
+    return;
+  }
+
+  const [centers, events] = await Promise.all([fetchCenters(), fetchEvents()]);
+
+  const entries = [];
+
+  for (const route of STATIC_ROUTES) {
+    entries.push(urlEntry({ loc: `${SITE_URL}${route.path}`, changefreq: route.changefreq, priority: route.priority }));
+  }
+
+  for (const c of centers) {
+    const id = c.centerID || c.id;
+    entries.push(urlEntry({
+      loc: `${SITE_URL}/center/${encodeURIComponent(id)}`,
+      lastmod: c.updatedAt || c.createdAt || undefined,
+      changefreq: 'weekly',
+      priority: 0.8,
+    }));
+  }
+
+  for (const e of events) {
+    const id = e.eventID || e.id;
+    // Skip past events (>30 days old) — Google deprioritizes ancient event pages
+    const dateStr = e.date || e.endDate;
+    if (dateStr) {
+      const eventTime = new Date(dateStr).getTime();
+      const cutoff = Date.now() - 30 * 24 * 3600_000;
+      if (eventTime < cutoff) continue;
+    }
+    entries.push(urlEntry({
+      loc: `${SITE_URL}/events/${encodeURIComponent(id)}`,
+      lastmod: e.updatedAt || e.createdAt || undefined,
+      changefreq: 'weekly',
+      priority: 0.7,
+    }));
+  }
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    entries.join('\n') +
+    `\n</urlset>\n`;
+
+  const outPath = path.join(DIST_DIR, 'sitemap.xml');
+  fs.writeFileSync(outPath, xml);
+  console.log(`[sitemap] wrote ${outPath} with ${entries.length} URL(s) (${STATIC_ROUTES.length} static, ${centers.length} centers, ${entries.length - STATIC_ROUTES.length - centers.length} upcoming events)`);
+})().catch((e) => {
+  console.error('[sitemap] fatal:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #213

## What

Public web pages now ship per-route structured data, a build-time `sitemap.xml`, and a sane `robots.txt`. This is the foundation for Google rich results on `/center/<id>` and `/events/<id>` and for indexing all public surfaces.

## Files

| File | What |
|---|---|
| `packages/frontend/components/seo/jsonLd.ts` | Pure builders for `LocalBusiness`/`ReligiousOrganization`, `Event`, and `Organization` JSON-LD. Accepts both raw API shape (`centerID`/`eventID`) and the hook display shape (`id`). Returns `null` on missing required fields so we never emit malformed structured data. |
| `packages/frontend/components/seo/SeoHead.tsx` | `<Head>` wrapper around `expo-router/head` rendering title + description + canonical + OG + Twitter Card + optional JSON-LD. Used by landing, center detail, event detail. |
| `packages/frontend/app/landing.web.tsx` | Wires `SeoHead` with `buildOrganizationJsonLd()` for the root page. |
| `packages/frontend/app/center/[id].web.tsx` | Wires `SeoHead` with `buildCenterJsonLd(center)` per loaded center. |
| `packages/frontend/app/events/[id].web.tsx` | Wires `SeoHead` with `buildEventJsonLd(event)` per loaded event. |
| `packages/frontend/public/robots.txt` | Allow public pages (`/`, `/center/*`, `/events/*`, terms/privacy/cookies), disallow auth-gated (`/auth`, `/admin`, `/settings`, `/chat`, `/feed`). Points at `/sitemap.xml`. |
| `scripts/generate-sitemap.cjs` | Build-time script — hits the prod API for centers + upcoming events (past events >30 days old dropped) and writes `dist/sitemap.xml`. Network failure is non-fatal and ships static-only sitemap with a warning. |
| `packages/frontend/src/__tests__/seo/jsonLd.test.ts` | 11 unit tests for the JSON-LD builders. |
| `package.json` | `build:frontend` now runs `generate-sitemap.cjs` after the Expo export. |

## Behavior

| Surface | What ships |
|---|---|
| `GET /` | Title + description + Organization JSON-LD |
| `GET /center/<id>` | Per-center title, description (auto from name + address), OG image (center image fallback to logo), `LocalBusiness` + `ReligiousOrganization` JSON-LD with geo + address + phone |
| `GET /events/<id>` | Per-event title + description, `Event` JSON-LD with `startDate`, `endDate`, `location` (geo + address), `Offer` when `signupUrl` is set |
| `GET /sitemap.xml` | 5 static URLs + every center + upcoming events (past >30 days dropped) |
| `GET /robots.txt` | Allow public, disallow auth-gated, point at sitemap |

## Verify

```bash
SITEMAP_SKIP_NETWORK=1 bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 173 tests / 10 files (+11 SEO tests on the new builders)
- `npm run test:backend` ✅ — 313 tests / 9 files
- `npm run build` ✅ — Expo web export + `[sitemap] wrote dist/sitemap.xml` post-step

Live verification once the preview is up (will be added to PR body once CF Pages builds):

1. View source on `<preview>/center/<id>` and confirm the `<script type="application/ld+json">` block validates in [Rich Results Test](https://search.google.com/test/rich-results).
2. Same for `<preview>/events/<id>` — should classify as `Event`.
3. `curl <preview>/sitemap.xml` — XML, includes static + dynamic URLs.
4. `curl <preview>/robots.txt` — allow/disallow as expected.
5. Paste a center URL into Slack — OG preview shows title + description from the center.

## Deferred to follow-up PRs

1. **City landing pages (`/chyk/<slug>`)** — needs design + content decisions on what each city page lists, copy tone, internal-link strategy.
2. **`web.output: "static"` migration** — current SPA mode means `<Head>` tags are client-rendered. Googlebot picks them up, but for Lighthouse SEO ≥95 + zero-JS OG previews we want SSR. Each route would need to declare its data dependencies for prerender — meaningful work, separate PR.

## Note on line endings

`app/center/[id].web.tsx` and `app/events/[id].web.tsx` had mixed CRLF + LF on disk in `v2`. The Edit tool normalized to LF on touched hunks, which inflates the line-change counts but is a net cleanup. No behavior change.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779918955556349