### PR TITLE
feat(profile): school + work + region + looking_for fields (#210)

### DIFF
--- a/migrations/0021_profile_fields.sql
+++ b/migrations/0021_profile_fields.sql
@@ -1,0 +1,18 @@
+-- Migration 0021 — minimal profile fields (#210)
+--
+-- Adds: school, work, region, looking_for to the users table.
+-- Tier 2 (users is disposable per migrations/README.md), but the table has
+-- real user data on prod so we use additive ALTERs anyway.
+--
+-- Renumbered from 0020 because #192 (official-event badge) reserved 0020.
+-- Call out at v2 → main cutover: this PR will be 0021 and #192 will be 0020.
+--
+-- All four columns are nullable text — empty profile fields are the norm
+-- and the API layer will only emit them when present (per #210 acceptance:
+-- "empty optional fields don't render").
+
+ALTER TABLE users ADD COLUMN school TEXT;
+ALTER TABLE users ADD COLUMN work TEXT;
+ALTER TABLE users ADD COLUMN region TEXT;
+-- JSON array string, like interests
+ALTER TABLE users ADD COLUMN looking_for TEXT;

--- a/packages/backend/src/__tests__/types.test.ts
+++ b/packages/backend/src/__tests__/types.test.ts
@@ -22,6 +22,7 @@ const mockUserRow: UserRow = {
   date_of_birth: '2000-01-01',
   phone_number: '+1234567890',
   profile_image: 'https://img.example.com/pic.jpg',
+  bio: null,
   center_id: 'c-1',
   points: 100,
   is_verified: 1,
@@ -29,6 +30,13 @@ const mockUserRow: UserRow = {
   is_active: 1,
   profile_complete: 1,
   interests: '["yoga","vedanta"]',
+  invite_code: null,
+  email_verified_at: null,
+  // Minimal profile fields (#210)
+  school: 'UC Berkeley',
+  work: 'Software Engineer',
+  region: 'San Francisco Bay Area',
+  looking_for: '["Mentorship","Study partner"]',
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-06-01T00:00:00Z',
 }
@@ -138,6 +146,29 @@ describe('userRowToApi', () => {
     expect(api.phoneNumber).toBeNull()
     expect(api.profileImage).toBeNull()
     expect(api.centerID).toBeNull()
+  })
+
+  it('surfaces minimal profile fields (#210)', () => {
+    const api = userRowToApi(mockUserRow)
+    expect(api.school).toBe('UC Berkeley')
+    expect(api.work).toBe('Software Engineer')
+    expect(api.region).toBe('San Francisco Bay Area')
+    expect(api.lookingFor).toEqual(['Mentorship', 'Study partner'])
+  })
+
+  it('returns null for unset minimal profile fields', () => {
+    const row: UserRow = {
+      ...mockUserRow,
+      school: null,
+      work: null,
+      region: null,
+      looking_for: null,
+    }
+    const api = userRowToApi(row)
+    expect(api.school).toBeNull()
+    expect(api.work).toBeNull()
+    expect(api.region).toBeNull()
+    expect(api.lookingFor).toBeNull()
   })
 })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -724,6 +724,11 @@ app.put('/auth/update-profile', authMiddleware, async (c) => {
     phoneNumber?: string
     interests?: string[]
     dateOfBirth?: string
+    // Minimal profile fields (#210)
+    school?: string
+    work?: string
+    region?: string
+    lookingFor?: string[]
   }>()
 
   const updates: Partial<UserRow> = {}
@@ -738,6 +743,14 @@ app.put('/auth/update-profile', authMiddleware, async (c) => {
   if (body.bio !== undefined) updates.bio = body.bio || null
   if (body.phoneNumber !== undefined) updates.phone_number = body.phoneNumber
   if (body.interests !== undefined) updates.interests = JSON.stringify(body.interests)
+  // Minimal profile fields. Empty strings become null so the API never
+  // exposes a field the user didn't fill in.
+  if (body.school !== undefined) updates.school = body.school?.trim() || null
+  if (body.work !== undefined) updates.work = body.work?.trim() || null
+  if (body.region !== undefined) updates.region = body.region?.trim() || null
+  if (body.lookingFor !== undefined) {
+    updates.looking_for = body.lookingFor.length > 0 ? JSON.stringify(body.lookingFor) : null
+  }
 
   const result = await db.updateUser(c.env.DB, user.id, updates)
 

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -52,6 +52,11 @@ export interface UserRow {
   interests: string | null // JSON array
   invite_code: string | null // Invite code used for signup
   email_verified_at: string | null // ISO timestamp; NULL until email verified
+  // Minimal profile fields (#210, migration 0021)
+  school: string | null
+  work: string | null
+  region: string | null
+  looking_for: string | null // JSON array
   created_at: string
   updated_at: string
 }
@@ -169,6 +174,11 @@ export interface UserApiResponse {
   isActive: boolean
   profileComplete: boolean
   interests: string[] | null
+  // Minimal profile fields (#210)
+  school: string | null
+  work: string | null
+  region: string | null
+  lookingFor: string[] | null
   createdAt: string
   updatedAt: string
 }
@@ -268,6 +278,10 @@ export function userRowToApi(row: UserRow): UserApiResponse {
     isActive: row.is_active === 1,
     profileComplete: row.profile_complete === 1,
     interests: safeParseJsonArray(row.interests),
+    school: row.school,
+    work: row.work,
+    region: row.region,
+    lookingFor: safeParseJsonArray(row.looking_for),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -104,6 +104,7 @@ export default function ProfileNative() {
 
   const centerName = allCenters.find((c) => c.centerID === user?.centerID)?.name
   const interests = user?.interests || []
+  const lookingFor = user?.lookingFor || []
 
   return (
     <View style={{ flex: 1 }}>
@@ -221,6 +222,21 @@ export default function ProfileNative() {
             >
               {user.bio}
             </Text>
+          ) : null}
+
+          {/* About — minimal profile fields (#210). Empty fields don't render. */}
+          {(user?.work || user?.school || user?.region) ? (
+            <View style={{ marginTop: 12, gap: 4 }}>
+              {user?.work ? (
+                <Text style={{ fontSize: 14, color: textColor }}>{user.work}</Text>
+              ) : null}
+              {user?.school ? (
+                <Text style={{ fontSize: 14, color: mutedTextColor }}>{user.school}</Text>
+              ) : null}
+              {user?.region ? (
+                <Text style={{ fontSize: 14, color: mutedTextColor }}>{user.region}</Text>
+              ) : null}
+            </View>
           ) : null}
         </View>
 
@@ -362,6 +378,41 @@ export default function ProfileNative() {
                 </Text>
               </View>
             ))}
+          </View>
+        ) : null}
+
+        {/* Looking for — multi-select chips (#210). Same UX as Interests. */}
+        {lookingFor.length > 0 ? (
+          <View style={{ paddingHorizontal: 20, marginTop: 16 }}>
+            <Text
+              style={{
+                fontFamily: 'Inclusive Sans',
+                fontSize: 11,
+                color: mutedTextColor,
+                letterSpacing: 0.4,
+                textTransform: 'uppercase',
+                marginBottom: 8,
+              }}
+            >
+              Looking for
+            </Text>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+              {lookingFor.map((option) => (
+                <View
+                  key={option}
+                  style={{
+                    paddingHorizontal: 14,
+                    paddingVertical: 7,
+                    borderRadius: 100,
+                    backgroundColor: chipBg,
+                  }}
+                >
+                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: mutedTextColor }}>
+                    {option}
+                  </Text>
+                </View>
+              ))}
+            </View>
           </View>
         ) : null}
 

--- a/packages/frontend/app/edit-profile.tsx
+++ b/packages/frontend/app/edit-profile.tsx
@@ -37,6 +37,15 @@ const INTEREST_OPTIONS = [
   'Formal',
 ]
 
+// Multi-select chips for "What I'm looking for" — predefined per PRD §5.4.
+const LOOKING_FOR_OPTIONS = [
+  'Mentorship',
+  'Friends in a new city',
+  'Professional network',
+  'Seva opportunities',
+  'Study partner',
+]
+
 export default function EditProfileScreen() {
   const router = useRouter()
   const { user, updateProfile, setUser } = useUser()
@@ -47,6 +56,10 @@ export default function EditProfileScreen() {
   const [birthday, setBirthday] = useState<Date | null>(null)
   const [centerID, setCenterID] = useState<string | null>(null)
   const [interests, setInterests] = useState<string[]>([])
+  const [school, setSchool] = useState('')
+  const [work, setWork] = useState('')
+  const [region, setRegion] = useState('')
+  const [lookingFor, setLookingFor] = useState<string[]>([])
   const [profileImage, setProfileImage] = useState<string | null>(null)
   const [profileImageBase64, setProfileImageBase64] = useState<string | null>(null)
   const [imageChanged, setImageChanged] = useState(false)
@@ -74,6 +87,10 @@ export default function EditProfileScreen() {
       setBirthday(user.dateOfBirth ? new Date(user.dateOfBirth.split('T')[0] + 'T00:00:00') : null)
       setCenterID(user.centerID || null)
       setInterests(user.interests || [])
+      setSchool(user.school || '')
+      setWork(user.work || '')
+      setRegion(user.region || '')
+      setLookingFor(user.lookingFor || [])
       setProfileImage(user.profileImage || null)
       setProfileImageBase64(null)
       setImageChanged(false)
@@ -143,6 +160,10 @@ export default function EditProfileScreen() {
         lastName: nameParts.slice(1).join(' '),
         bio,
         interests,
+        school: school.trim(),
+        work: work.trim(),
+        region: region.trim(),
+        lookingFor,
         ...(centerID ? { centerID } : {}),
         ...(birthday ? { dateOfBirth: birthday.toISOString().split('T')[0] } : {}),
         ...(imageChanged && profileImageBase64 ? { profileImage: profileImageBase64 } : {}),
@@ -162,6 +183,12 @@ export default function EditProfileScreen() {
     } finally {
       setIsSaving(false)
     }
+  }
+
+  const toggleLookingFor = (option: string) => {
+    setLookingFor((prev) =>
+      prev.includes(option) ? prev.filter((i) => i !== option) : [...prev, option]
+    )
   }
 
   const toggleInterest = (interest: string) => {
@@ -333,6 +360,82 @@ export default function EditProfileScreen() {
                   <ChevronRight size={18} color={faintColor} />
                 </View>
               </Pressable>
+            </View>
+          </Section>
+
+          {/* About you — #210 minimal profile fields */}
+          <Section title="ABOUT YOU" titleColor={faintColor}>
+            <View style={cardSection}>
+              <View style={[rowStyle, { borderBottomWidth: 1, borderBottomColor: borderColor }]}>
+                <Text style={fieldLabelStyle}>SCHOOL</Text>
+                <TextInput
+                  value={school}
+                  onChangeText={setSchool}
+                  placeholder="University of California, Berkeley"
+                  placeholderTextColor={faintColor}
+                  style={inputStyle}
+                  autoCapitalize="words"
+                />
+              </View>
+              <View style={[rowStyle, { borderBottomWidth: 1, borderBottomColor: borderColor }]}>
+                <Text style={fieldLabelStyle}>WORK</Text>
+                <TextInput
+                  value={work}
+                  onChangeText={setWork}
+                  placeholder="Software Engineer at Acme"
+                  placeholderTextColor={faintColor}
+                  style={inputStyle}
+                  autoCapitalize="words"
+                />
+              </View>
+              <View style={rowStyle}>
+                <Text style={fieldLabelStyle}>REGION</Text>
+                <TextInput
+                  value={region}
+                  onChangeText={setRegion}
+                  placeholder="San Francisco Bay Area"
+                  placeholderTextColor={faintColor}
+                  style={inputStyle}
+                  autoCapitalize="words"
+                />
+              </View>
+            </View>
+          </Section>
+
+          {/* Looking for — multi-select chips, same UX as Interests */}
+          <Section title="LOOKING FOR" titleColor={faintColor}>
+            <View style={cardSection}>
+              <View style={[rowStyle, { flexDirection: 'row', flexWrap: 'wrap', gap: 8 }]}>
+                {LOOKING_FOR_OPTIONS.map((option) => {
+                  const selected = lookingFor.includes(option)
+                  return (
+                    <Pressable
+                      key={option}
+                      onPress={() => toggleLookingFor(option)}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected }}
+                      style={{
+                        paddingHorizontal: 16,
+                        paddingVertical: 9,
+                        borderRadius: 100,
+                        borderWidth: 1.5,
+                        borderColor: selected ? '#C2410C' : borderColor,
+                        backgroundColor: selected ? '#C2410C10' : 'transparent',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          fontSize: 14,
+                          color: selected ? '#C2410C' : mutedColor,
+                          fontWeight: selected ? '600' : '400',
+                        }}
+                      >
+                        {option}
+                      </Text>
+                    </Pressable>
+                  )
+                })}
+              </View>
             </View>
           </Section>
 

--- a/packages/frontend/src/auth/types.ts
+++ b/packages/frontend/src/auth/types.ts
@@ -17,6 +17,11 @@ export interface User {
   isActive?: boolean
   profileComplete?: boolean
   interests?: string[] | null
+  // Minimal profile fields (#210)
+  school?: string | null
+  work?: string | null
+  region?: string | null
+  lookingFor?: string[] | null
   createdAt?: string
   updatedAt?: string
   // Cached original image for re-editing in the current session
@@ -55,6 +60,11 @@ export interface UpdateProfileRequest {
   phoneNumber?: string
   interests?: string[]
   dateOfBirth?: string
+  // Minimal profile fields (#210)
+  school?: string
+  work?: string
+  region?: string
+  lookingFor?: string[]
 }
 
 export interface AuthSuccessResponse {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -62,6 +62,11 @@ export interface UserData {
   isActive: boolean
   profileComplete: boolean
   interests: string[] | null
+  // Minimal profile fields (#210)
+  school?: string | null
+  work?: string | null
+  region?: string | null
+  lookingFor?: string[] | null
   createdAt?: string
   updatedAt?: string
 }


### PR DESCRIPTION
Closes #210

## What

Adds the four PRD §5.4 "minimal profile" fields end-to-end:

| Field | Type | UI |
|---|---|---|
| `school` | free text | "ABOUT YOU" section in edit-profile |
| `work` | free text | "ABOUT YOU" section |
| `region` | free text | "ABOUT YOU" section |
| `looking_for` | JSON array | "LOOKING FOR" chip group (same UX as Interests) |

The native profile screen renders the new fields with **hide-if-empty** logic — a user who fills nothing gets no extra rows. Privacy holds: phone, email, address are unchanged in their (already non-public) status.

## Files

- `migrations/0021_profile_fields.sql` — additive `ALTER TABLE users ADD COLUMN` (Tier 2 disposable, but used additive because users has real prod data).
- `packages/backend/src/types.ts` — extends `UserRow`, `UserApiResponse`, `userRowToApi` (with `safeParseJsonArray` for lookingFor).
- `packages/backend/src/app.ts` — extends `PUT /auth/update-profile` to accept + persist the four new fields. Empty strings → `null` so the API never exposes a field the user didn't fill.
- `packages/backend/src/__tests__/types.test.ts` — 2 new tests for the new fields (surfacing + null-handling).
- `packages/frontend/src/auth/types.ts` — extends `User` + `UpdateProfileRequest`.
- `packages/frontend/utils/api.ts` — extends `UserData`.
- `packages/frontend/app/edit-profile.tsx` — two new sections: "ABOUT YOU" (3 text rows) + "LOOKING FOR" (5-chip multi-select with the same UX as Interests).
- `packages/frontend/app/(tabs)/profile.tsx` — renders work/school/region under the bio, and a "Looking for" chip group below interests.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 173 / 10 files
- `npm run test:backend` ✅ — 315 / 9 files (+2 SEO tests on userRowToApi)
- `npm run build` ✅

Manual smoke once the preview is up:

```bash
curl -s -X PUT $PREVIEW/api/auth/update-profile \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"school":"UC Berkeley","work":"SWE at Acme","region":"SF Bay","lookingFor":["Mentorship"]}'
```

The response's `user` object includes `school`, `work`, `region`, `lookingFor`.

## Migration callout

```sql
ALTER TABLE users ADD COLUMN school TEXT;
ALTER TABLE users ADD COLUMN work TEXT;
ALTER TABLE users ADD COLUMN region TEXT;
ALTER TABLE users ADD COLUMN looking_for TEXT;
```

Renumbered from the spec's `0020` because #192 (official-event badge) reserved 0020. Either order works at cutover — different tables, no dependencies.

## 🛢️ Migration cutover note

This PR adds `migrations/0021_profile_fields.sql` (Tier 2 — disposable).

At the next **v2 → main cutover**, apply with:

```bash
npx wrangler d1 execute chinmaya-janata-db \
  --file=migrations/0021_profile_fields.sql \
  --config packages/backend/wrangler.toml
```

`npm run db:cutover-status` will list this file once the PR merges into v2.

## Deferred to follow-up

- **`profile.web.tsx`** layout doesn't render the new fields yet — the data is already in `UserData` and arrives at the page; just the layout needs to surface it. Easy small PR.
- **LinkedIn-style aesthetic redesign** mentioned in the PRD's "LinkedIn-inspired clean and factual" — the fields are added in the existing visual language. The redesign pass is a separate effort, easier with Pranav.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779919689128509