### PR TITLE
feat(home): boards peek empty-state section in v3 layout (#199)

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -158,6 +158,30 @@ export default function HomeScreen() {
           )}
         </SectionHeader>
 
+        {/*
+          Boards peek (#199). Static empty state for now — when the Boards
+          backend (#205) lands in v2 and the user's center has posts, wire
+          this to fetch 1-2 latest from `useBoard('center', user.centerID)`
+          and render them as small cards. Keep this section visible even
+          when empty so the user knows where to look once posts arrive.
+        */}
+        <SectionHeader
+          eyebrow="LATEST ON YOUR BOARDS"
+          trailing="Open Feed"
+          accentColor={c.accent}
+          faintColor={c.textFaint}
+          onTrailingPress={() => router.push('/feed' as never)}
+        >
+          <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 6 }}>
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>
+              No posts yet on your boards
+            </Text>
+            <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+              Conversations from your center and events you've joined will appear here. Head to the Feed to see what's new across the network.
+            </Text>
+          </View>
+        </SectionHeader>
+
         <SectionHeader
           eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
           trailing="See all"


### PR DESCRIPTION
Closes #199

## What

Adds the **"Latest on your boards"** section to the Home v3 layout. Sits between the featured event card and the "This week" / "Coming up" list. For now it's a static empty-state with an **"Open Feed"** trailing link routing to `/feed`.

## Why this is the only diff for #199

The other v3 acceptance criteria already shipped in v2:

| Criterion | State |
|---|---|
| Greeting personalized when signed in; "Namaste" when not | ✅ already in `index.tsx:130` |
| Featured event from upcoming events with designed empty state | ✅ already in `index.tsx:135-158` (`FeaturedEventCard` + fallback) |
| This-week list with ~3 events + today highlight | ✅ `liveEventToWeekItem` passes `highlight: today` → `MiniEventRow` |
| **Boards peek with path into the Feed** | **❌ → this PR** |
| No regression on web; works on iOS sim | ✅ same JSX file used by both |

The bulk of v3 landed via [#241](https://github.com/Project-Janata/Janata/pull/241) (mock-data removal) — this PR closes the last acceptance bullet.

## Why empty state and not real data

The Boards backend (#205) is in-flight via PRs #246-#251 and hasn't merged to v2 yet. Wiring this section to `useBoard('center', user.centerID)` now would render `Loading…` forever or break on the missing endpoint. The empty-state copy is honest in the meantime — and when Boards lands, the follow-up wiring is a ~10-line change inside the existing JSX block (comment in the file calls that out exactly).

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 173 tests / 10 files (no change)
- `npm run test:backend` ✅ — 313 tests / 9 files (no change)
- `npm run build` ✅

Manual:

1. `<preview>/` — confirm section order is Greeting → UP NEXT FOR YOU → **LATEST ON YOUR BOARDS** → THIS WEEK.
2. Click "Open Feed" — routes to `/feed`.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779920066416669