### PR TITLE
feat(api): pagination for /centers + /fetchAllEvents (#107)

### DIFF
--- a/packages/backend/src/__tests__/db.test.ts
+++ b/packages/backend/src/__tests__/db.test.ts
@@ -216,6 +216,57 @@ describe('centers', () => {
     })
   })
 
+  describe('getCentersPaginated (#107)', () => {
+    beforeEach(async () => {
+      // Seed 5 centers with predictable names so pagination is deterministic.
+      for (let i = 0; i < 5; i++) {
+        await db.createCenter(env.DB, {
+          ...testCenter,
+          id: `c-${i}`,
+          name: `Center ${String.fromCharCode(65 + i)}`, // A..E
+        })
+      }
+    })
+
+    it('returns first page with total count', async () => {
+      const { data, total } = await db.getCentersPaginated(env.DB, 2, 0)
+      expect(total).toBe(5)
+      expect(data).toHaveLength(2)
+      expect(data[0].name).toBe('Center A')
+      expect(data[1].name).toBe('Center B')
+    })
+
+    it('returns second page', async () => {
+      const { data, total } = await db.getCentersPaginated(env.DB, 2, 2)
+      expect(total).toBe(5)
+      expect(data).toHaveLength(2)
+      expect(data[0].name).toBe('Center C')
+      expect(data[1].name).toBe('Center D')
+    })
+
+    it('returns partial last page', async () => {
+      const { data, total } = await db.getCentersPaginated(env.DB, 2, 4)
+      expect(total).toBe(5)
+      expect(data).toHaveLength(1)
+      expect(data[0].name).toBe('Center E')
+    })
+
+    it('clamps limit to [1, 200]', async () => {
+      const zero = await db.getCentersPaginated(env.DB, 0, 0)
+      expect(zero.data).toHaveLength(1) // clamped to limit=1
+      // Limit > total just returns whatever's there
+      const big = await db.getCentersPaginated(env.DB, 9999, 0)
+      expect(big.data).toHaveLength(5)
+      expect(big.total).toBe(5)
+    })
+
+    it('clamps negative offset to 0', async () => {
+      const { data } = await db.getCentersPaginated(env.DB, 3, -10)
+      expect(data).toHaveLength(3)
+      expect(data[0].name).toBe('Center A')
+    })
+  })
+
   describe('updateCenter', () => {
     it('updates center fields', async () => {
       await db.createCenter(env.DB, testCenter)
@@ -311,6 +362,42 @@ describe('events', () => {
       expect(events[0].date).toBe('2025-06-01T00:00:00Z')
       expect(events[1].date).toBe('2025-03-01T00:00:00Z')
       expect(events[2].date).toBe('2025-01-01T00:00:00Z')
+    })
+  })
+
+  describe('getEventsPaginated (#107)', () => {
+    beforeEach(async () => {
+      // Seed 4 events with descending dates; date DESC means e-4 first.
+      for (let i = 1; i <= 4; i++) {
+        await db.createEvent(env.DB, {
+          ...testEvent,
+          id: `e-${i}`,
+          date: `2025-0${i}-01T00:00:00Z`,
+        })
+      }
+    })
+
+    it('returns first page with total count, newest first', async () => {
+      const { data, total } = await db.getEventsPaginated(env.DB, 2, 0)
+      expect(total).toBe(4)
+      expect(data).toHaveLength(2)
+      expect(data[0].id).toBe('e-4')
+      expect(data[1].id).toBe('e-3')
+    })
+
+    it('returns subsequent page', async () => {
+      const { data, total } = await db.getEventsPaginated(env.DB, 2, 2)
+      expect(total).toBe(4)
+      expect(data).toHaveLength(2)
+      expect(data[0].id).toBe('e-2')
+      expect(data[1].id).toBe('e-1')
+    })
+
+    it('clamps limit and offset', async () => {
+      const zero = await db.getEventsPaginated(env.DB, 0, 0)
+      expect(zero.data.length).toBe(1)
+      const neg = await db.getEventsPaginated(env.DB, 4, -5)
+      expect(neg.data).toHaveLength(4)
     })
   })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -798,8 +798,29 @@ app.post('/deauthenticate', (c) => {
 // ═══════════════════════════════════════════════════════════════════════
 
 app.get('/centers', cacheControl(30), async (c) => {
-  const centers = await db.getAllCenters(c.env.DB)
-  return c.json({ centers: centers.map(centerRowToApi) })
+  // Pagination (#107). Backwards-compatible: when no `limit` is provided we
+  // return the entire centers list as before (matches the legacy clients).
+  // When `limit` is set, return `{ centers, total, limit, offset }`.
+  const limitParam = c.req.query('limit')
+  if (limitParam == null) {
+    const centers = await db.getAllCenters(c.env.DB)
+    return c.json({ centers: centers.map(centerRowToApi) })
+  }
+  const limit = Number.parseInt(limitParam, 10)
+  const offset = Number.parseInt(c.req.query('offset') ?? '0', 10)
+  if (!Number.isFinite(limit) || limit < 1) {
+    return c.json({ message: 'limit must be a positive integer' }, 400)
+  }
+  if (!Number.isFinite(offset) || offset < 0) {
+    return c.json({ message: 'offset must be >= 0' }, 400)
+  }
+  const { data, total } = await db.getCentersPaginated(c.env.DB, limit, offset)
+  return c.json({
+    centers: data.map(centerRowToApi),
+    total,
+    limit: Math.min(limit, 200),
+    offset,
+  })
 })
 
 app.post('/addCenter', authMiddleware, async (c) => {
@@ -1465,10 +1486,32 @@ app.post('/fetchEventsByCenter', async (c) => {
 })
 
 app.get('/fetchAllEvents', cacheControl(30), async (c) => {
-  const events = await db.getAllEvents(c.env.DB)
+  // Pagination (#107). Backwards-compatible: legacy callers omit `limit`
+  // and get the full list. Paginated callers pass `?limit=&offset=` and
+  // receive `{ events, total, limit, offset }` for infinite-scroll UIs.
+  const limitParam = c.req.query('limit')
+  if (limitParam == null) {
+    const events = await db.getAllEvents(c.env.DB)
+    return c.json({
+      message: 'Success',
+      events: events.map(eventRowToApi),
+    })
+  }
+  const limit = Number.parseInt(limitParam, 10)
+  const offset = Number.parseInt(c.req.query('offset') ?? '0', 10)
+  if (!Number.isFinite(limit) || limit < 1) {
+    return c.json({ message: 'limit must be a positive integer' }, 400)
+  }
+  if (!Number.isFinite(offset) || offset < 0) {
+    return c.json({ message: 'offset must be >= 0' }, 400)
+  }
+  const { data, total } = await db.getEventsPaginated(c.env.DB, limit, offset)
   return c.json({
     message: 'Success',
-    events: events.map(eventRowToApi),
+    events: data.map(eventRowToApi),
+    total,
+    limit: Math.min(limit, 200),
+    offset,
   })
 })
 

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -213,6 +213,30 @@ export async function getAllCenters(db: D1Database): Promise<CenterRow[]> {
   return result.results ?? []
 }
 
+/**
+ * Paginated centers fetch (#107). Returns the page of results plus the
+ * grand total so the caller can render "showing N of M" + know when to
+ * stop requesting more pages.
+ *
+ * `limit` is clamped to [1, 200] to bound worker CPU + response size.
+ * `offset` is clamped to non-negative integers.
+ */
+export async function getCentersPaginated(
+  db: D1Database,
+  limit: number,
+  offset: number,
+): Promise<{ data: CenterRow[]; total: number }> {
+  const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)))
+  const safeOffset = Math.max(0, Math.floor(offset))
+  const [page, countResult] = await Promise.all([
+    db.prepare('SELECT * FROM centers ORDER BY name LIMIT ?1 OFFSET ?2')
+      .bind(safeLimit, safeOffset)
+      .all<CenterRow>(),
+    db.prepare('SELECT COUNT(*) as count FROM centers').first<{ count: number }>(),
+  ])
+  return { data: page.results ?? [], total: countResult?.count ?? 0 }
+}
+
 export async function updateCenter(
   db: D1Database,
   centerId: string,
@@ -350,6 +374,26 @@ export async function getAllEvents(db: D1Database): Promise<EventRow[]> {
     .prepare('SELECT * FROM events ORDER BY date DESC')
     .all<EventRow>()
   return result.results ?? []
+}
+
+/**
+ * Paginated events fetch (#107). Mirrors getCentersPaginated. Sort order
+ * is date DESC so the newest/upcoming events naturally land on page 1.
+ */
+export async function getEventsPaginated(
+  db: D1Database,
+  limit: number,
+  offset: number,
+): Promise<{ data: EventRow[]; total: number }> {
+  const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)))
+  const safeOffset = Math.max(0, Math.floor(offset))
+  const [page, countResult] = await Promise.all([
+    db.prepare('SELECT * FROM events ORDER BY date DESC LIMIT ?1 OFFSET ?2')
+      .bind(safeLimit, safeOffset)
+      .all<EventRow>(),
+    db.prepare('SELECT COUNT(*) as count FROM events').first<{ count: number }>(),
+  ])
+  return { data: page.results ?? [], total: countResult?.count ?? 0 }
 }
 
 export async function getEventsByCenterId(

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -237,6 +237,44 @@ export function invalidateCentersCache(): void {
   _centersTimestamp = 0
 }
 
+/**
+ * Paginated centers result (#107). `total` is the count BEFORE the page slice,
+ * useful for "showing N of M" and for knowing when to stop calling for more.
+ */
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/**
+ * Paginated centers fetch (#107). Use for infinite scroll: start at offset=0
+ * and call again with `offset += limit` until `data.length === 0` OR
+ * `offset >= total`. Returns an empty page (not an error) on network failure
+ * so the UI can fall back gracefully.
+ */
+export async function fetchCentersPage(
+  limit: number,
+  offset = 0,
+): Promise<PaginatedResult<CenterData>> {
+  const url = `/centers?limit=${Math.max(1, Math.floor(limit))}&offset=${Math.max(0, Math.floor(offset))}`
+  try {
+    const response = await apiFetch(url)
+    if (!response.ok) return { data: [], total: 0, limit, offset }
+    const data = await response.json()
+    return {
+      data: data.centers || [],
+      total: typeof data.total === 'number' ? data.total : 0,
+      limit: typeof data.limit === 'number' ? data.limit : limit,
+      offset: typeof data.offset === 'number' ? data.offset : offset,
+    }
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchCentersPage]', err?.message || err)
+    return { data: [], total: 0, limit, offset }
+  }
+}
+
 // ── API methods ────────────────────────────────────────────────────────
 
 export async function fetchCenter(centerID: string): Promise<CenterData | null> {
@@ -305,6 +343,35 @@ export async function fetchAllEvents(): Promise<EventData[]> {
   } catch (err: any) {
     if (__DEV__) console.warn('[fetchAllEvents]', err?.message || err)
     return []
+  }
+}
+
+/**
+ * Paginated events fetch (#107). Sort order is date DESC (matches the
+ * unpaginated /fetchAllEvents). Image URLs are normalized to absolute,
+ * same as the unpaginated path.
+ */
+export async function fetchEventsPage(
+  limit: number,
+  offset = 0,
+): Promise<PaginatedResult<EventData>> {
+  const url = `/fetchAllEvents?limit=${Math.max(1, Math.floor(limit))}&offset=${Math.max(0, Math.floor(offset))}`
+  try {
+    const response = await apiFetch(url)
+    if (!response.ok) return { data: [], total: 0, limit, offset }
+    const data = await response.json()
+    const events = ((data.events || []) as EventData[]).map((e) =>
+      e.image && e.image.startsWith('/') ? { ...e, image: `${API_BASE_URL}${e.image}` } : e,
+    )
+    return {
+      data: events,
+      total: typeof data.total === 'number' ? data.total : 0,
+      limit: typeof data.limit === 'number' ? data.limit : limit,
+      offset: typeof data.offset === 'number' ? data.offset : offset,
+    }
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchEventsPage]', err?.message || err)
+    return { data: [], total: 0, limit, offset }
   }
 }
 


### PR DESCRIPTION
Closes #107

## What

Adds optional `?limit=&offset=` pagination to `GET /centers` and `GET /fetchAllEvents`. Responses with pagination requested include `total`, `limit`, `offset` so the frontend can drive infinite scroll without guessing when to stop.

## Behavior matrix

| Request | Response |
|---|---|
| `GET /centers` (legacy) | `{ centers: [...full list] }` — unchanged |
| `GET /centers?limit=10` | `{ centers: [...10], total: 91, limit: 10, offset: 0 }` |
| `GET /centers?limit=10&offset=20` | `{ centers: [...10 starting at 20], total: 91, limit: 10, offset: 20 }` |
| `GET /centers?limit=-1` | `400 { message: "limit must be a positive integer" }` |
| `GET /centers?limit=10&offset=-3` | `400 { message: "offset must be >= 0" }` |
| `GET /centers?limit=99999` | `200 { ..., limit: 200 }` (clamped) |
| `GET /fetchAllEvents` (legacy) | `{ message: "Success", events: [...full list] }` — unchanged |
| `GET /fetchAllEvents?limit=20` | `{ message: "Success", events: [...20], total: N, limit: 20, offset: 0 }` |

## Files

| File | What |
|---|---|
| `packages/backend/src/db.ts` | `getCentersPaginated(db, limit, offset)` + `getEventsPaginated(db, limit, offset)`. Both clamp limit to `[1, 200]` and offset to `>= 0` so bad-faith callers can't ask for huge pages. Returns `{ data, total }`. |
| `packages/backend/src/app.ts` | `/centers` and `/fetchAllEvents` accept `?limit=&offset=`. Branch: no `limit` → legacy `getAllCenters/Events` path; with `limit` → paginated path with the new response shape. |
| `packages/backend/src/__tests__/db.test.ts` | 8 new integration tests — first page, second page, partial last page, limit clamping, offset clamping, for both centers and events. |
| `packages/frontend/utils/api.ts` | Adds `PaginatedResult<T>` + `fetchCentersPage(limit, offset)` + `fetchEventsPage(limit, offset)`. Existing `fetchCenters` / `fetchAllEvents` unchanged. |

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 tests / 9 files (no change)
- `npm run test:backend` ✅ — **321 tests / 9 files (+8 pagination tests)**
- `npm run build` ✅

```bash
# Once preview is up
curl -s "$PREVIEW/api/centers?limit=5" | jq '{count: (.centers|length), total, limit, offset}'
curl -s "$PREVIEW/api/fetchAllEvents?limit=10&offset=20" | jq '{count: (.events|length), total, limit, offset}'
```

## Deferred to follow-up

**Front-of-app infinite-scroll wiring** (`useDiscoverData` + `onEndReached` + pull-to-refresh + per-page cache). That's a meaningful UX refactor of the Explore screen's `FlatList`, not a 2-line change. The new client functions (`fetchCentersPage`, `fetchEventsPage`) are exposed and ready to consume. Next PR wires them into the Explore hook + adds the scroll-driven prefetch.

**Cursor-based pagination** — spec mentioned it as an option. Skipped intentionally: at our scale (<100 centers, ~few-thousand events) offset is fine. Cursor only becomes valuable when deletes-during-scroll cause shifting-window issues, which we're nowhere near.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779920543028869