### PR TITLE
feat(seo): Google Analytics 4 gtag — env-gated (#213 follow-up)

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -5,3 +5,10 @@ EXPO_PUBLIC_POSTHOG_KEY=
 
 # Optional; default in app is https://us.i.posthog.com
 # EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Google Analytics 4 — for SEO + Search Console + referrer tracking. PostHog
+# stays the source of truth for product events; GA is search/discovery only.
+# Get this from analytics.google.com → Property → Data Stream → "Measurement ID".
+# When unset, the gtag tags are NOT emitted, so dev + PR-preview traffic stays
+# out of the production GA property. See `packages/frontend/app/+html.tsx`.
+# EXPO_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/packages/frontend/app/+html.tsx
+++ b/packages/frontend/app/+html.tsx
@@ -5,6 +5,12 @@ import { ScrollViewStyleReset } from 'expo-router/html'
 // The contents of this function only run in Node.js environments and
 // do not have access to the DOM or browser APIs.
 export default function Root({ children }: { children: React.ReactNode }) {
+  // Google Analytics 4 (#213 follow-up). Set EXPO_PUBLIC_GA_MEASUREMENT_ID
+  // in the build environment (CF Pages → production env vars, same pattern
+  // as EXPO_PUBLIC_POSTHOG_KEY) to enable. When unset (dev, PR previews,
+  // any build without the secret) the tags are not emitted — the page stays
+  // GA-free and dev/preview traffic doesn't pollute the production property.
+  const gaId = process.env.EXPO_PUBLIC_GA_MEASUREMENT_ID
   return (
     <html lang="en">
       <head>
@@ -68,6 +74,23 @@ export default function Root({ children }: { children: React.ReactNode }) {
           href="https://fonts.googleapis.com/css2?family=Inclusive+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap"
           rel="stylesheet"
         />
+
+        {/* Google Analytics 4 — only emitted when EXPO_PUBLIC_GA_MEASUREMENT_ID is set.
+            anonymize_ip: 'IP anonymization' keeps the last octet zeroed for EU/GDPR.
+            No PII is sent — just standard pageview + click events. PostHog
+            remains the source of truth for product analytics; GA is purely
+            for SEO / Search Console / referrer tracking. */}
+        {gaId ? (
+          <>
+            <link rel="preconnect" href="https://www.googletagmanager.com" />
+            <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} />
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaId}',{anonymize_ip:true});`,
+              }}
+            />
+          </>
+        ) : null}
       </head>
       <body>
         {children}

--- a/packages/frontend/components/landing/CookiePolicy.tsx
+++ b/packages/frontend/components/landing/CookiePolicy.tsx
@@ -86,7 +86,7 @@ export function CookiePolicy() {
           6. Third-Party Cookies
         </Text>
         <Text style={{ fontSize: 15, color: '#44403C', lineHeight: 24 }}>
-          We do not use third-party advertising cookies. Our analytics are provided through Cloudflare, which collects limited anonymous data for security and performance purposes.
+          We do not use third-party advertising cookies. We use analytics cookies to understand how the Service is used: Cloudflare for security and performance, PostHog for product analytics, and Google Analytics for search and referrer tracking. Google Analytics is configured with IP anonymization. None of these analytics partners receive your phone number, address, or other directly identifying personal data.
         </Text>
 
         <Text style={{ fontSize: 18, fontWeight: '600', marginTop: 24, marginBottom: 12, color: '#1C1917' }}>


### PR DESCRIPTION
Follow-up to [#213 (PR #253)](https://github.com/Project-Janata/Janata/pull/253). No issue.

## What

Adds Google Analytics 4 (gtag) to the public web pages, gated on `EXPO_PUBLIC_GA_MEASUREMENT_ID`.

- **Set the env var** → GA loads with `anonymize_ip=true`.
- **Don't set it** (dev, every PR preview, any build without the secret) → no tags emitted, no traffic to GA.

Cookie policy updated in the same PR to mention GA + PostHog explicitly (the old "Cloudflare only" sentence was about to become inaccurate the moment GA went live).

## Files

| File | What |
|---|---|
| `packages/frontend/app/+html.tsx` | Conditional `<script>` injection. Reads `process.env.EXPO_PUBLIC_GA_MEASUREMENT_ID`; emits the standard gtag snippet only when set. |
| `packages/frontend/.env.example` | Documents the new env var + the dev/preview/prod gating story. |
| `packages/frontend/components/landing/CookiePolicy.tsx` | Updates §6 to mention Cloudflare + PostHog + GA, calls out IP anonymization, asserts no directly-identifying PII is sent. |

## Three things you need to do to finish enabling

1. **Create the GA4 property** at [analytics.google.com](https://analytics.google.com) (free). Grab the `G-XXXXXXXXXX` Measurement ID.
2. **Set the env var on production** — CF Pages → `chinmaya-janata` project → Settings → Environment Variables → Production → `EXPO_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX`. Same pattern as `EXPO_PUBLIC_POSTHOG_KEY`.
3. **Sign off (or revise) the cookie policy language** — easy to soften or expand.

Until step 2 lands, GA is **inert** — the conditional in `+html.tsx` keeps the tags out of the rendered HTML. Zero behavior change for users from merging.

## Privacy

- `anonymize_ip: true` (GDPR — last octet zeroed)
- No PII sent. Standard pageview + click events only.
- PostHog remains the source of truth for product analytics. GA is purely for SEO / Search Console / referrer tracking.
- Cookie policy updated to reflect the new processor list.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9 (no change, no new tests — gtag is HTML-only)
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

```bash
# Preview should NOT include GA tags (env unset)
curl -s "$PREVIEW/" | grep -i "googletagmanager\|gtag"
# → empty

# Production once env is set
curl -s "https://chinmayajanata.org/" | grep -i "googletagmanager"
# → <script async src="https://www.googletagmanager.com/gtag/js?id=G-…"></script>
```

## Note on diff size

`+html.tsx` had mixed CRLF+LF line endings on v2. The Edit tool normalized to LF on touched hunks — inflates the apparent line count to ~180, but the actual semantic delta is **15 added lines** (the gtag block) plus comments and the line-ending sweep. Net cleanup.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779921425454579