### PR TITLE
feat(analytics): PostHog public-surface events + taxonomy doc

### DIFF
--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,110 @@
+# PostHog event taxonomy
+
+Naming + property conventions for `posthog?.capture` calls across the app.
+Single source of truth — add new events here when you ship them, and grep
+this file before inventing a new name.
+
+## Naming rules
+
+- **`snake_case`** for both event names and property keys.
+- **`<surface>_<noun>_<verb>`** — `landing_cta_pressed`, `center_viewed`,
+  `event_registration_failed`. Past-tense verbs (`pressed`, `viewed`,
+  `created`, `failed`).
+- **One event per user action.** Don't fire `home_visited` AND
+  `home_session_started` for the same render.
+- **Source as a property, not a name suffix.** Prefer
+  `landing_cta_pressed { variant: 'hero' }` over `landing_hero_pressed`.
+  Keeps the dashboard slice-able.
+
+## Standard properties
+
+| Key | When to include |
+|---|---|
+| `source` | when the same event can fire from multiple places (`home`, `discover`, `web_detail`) |
+| `variant` | when the same CTA has multiple visual flavors (`hero`, `final`, `final_compact`) |
+| `centerId` / `eventId` | always for entity-scoped events |
+| `referrer` | when the user landed from outside the app (URL referrer if available) |
+| `error` | short string on `*_failed` events |
+
+## Pre-auth / public surface
+
+The marketing-funnel events. PostHog dashboards built on these answer
+"who clicks what on the landing page and converts?"
+
+| Event | Properties | Where it fires |
+|---|---|---|
+| `landing_cta_pressed` | `variant`, `label` | `Hero.tsx` Start Exploring, `FinalCTA.tsx` Browse events nearby |
+| `landing_signin_pressed` | `source` | `NavBar.tsx` user icon |
+| `landing_ask_pressed` | `audience: 'coordinator'\|'contributor'\|'acharya'` | `FinalCTA.tsx` AskCard CTAs |
+| `center_viewed` | `centerId`, `name`, `source` | `app/center/[id].tsx` + `.web.tsx` |
+| `center_shared` | `centerId`, `source` | center detail share button |
+| `center_address_pressed` | `centerId`, `source` | tap address row |
+| `center_website_pressed` | `centerId`, `source` | tap website row |
+| `center_phone_pressed` | `centerId`, `source` | tap phone row |
+| `center_event_pressed` | `centerId`, `eventId`, `source` | tap event row in center detail |
+
+## In-app (post-auth)
+
+The product-funnel events. Already wired pre-session; documented here for
+the source-of-truth pass.
+
+| Event | Properties | Where |
+|---|---|---|
+| `discover_filter_changed` | `filter` | Explore tab tab switch |
+| `discover_search` | `query` | Explore tab search submit |
+| `discover_date_selected` | `date` | Explore tab calendar pick |
+| `map_point_pressed` | `type`, `id` | map pin tap |
+| `event_list_item_pressed` | `eventId`, `source` | Explore tab list tap |
+| `center_list_item_pressed` | `centerId`, `source` | Explore tab list tap |
+| `event_viewed` | `eventId`, `title`, `isPast` | event detail mount |
+| `event_tab_changed` | `tab`, `eventId` | event detail tab switch |
+| `event_registered` / `event_unregistered` | `eventId` | RSVP toggle |
+| `event_registration_failed` | `eventId`, `error` | RSVP error |
+| `event_edit_opened` | `eventId` | event detail pencil |
+| `event_deleted` | `eventId` | event detail trash |
+| `event_created` | `title`, `centerID` | events/form submit (create) |
+| `event_updated` | `eventId`, `title` | events/form submit (edit) |
+| `event_create_failed` | `error`, `isEdit` | events/form submit error |
+| `home_featured_event_pressed` | `eventId` | Home featured card tap |
+| `home_event_pressed` | `eventId`, `source: 'this_week'` | Home this-week row tap |
+| `nav_logout` | — | tab header menu |
+| `nav_create_event` | — | tab header + button |
+| `nav_menu_opened` | — | tab header menu |
+| `connect_conversation_selected` | `conversationId` | (deferred surface — Chat tab is hidden post-5/26) |
+| `connect_signin_pressed` | — | signed-out chat tab |
+
+## Dashboards to build in PostHog
+
+These are the obvious cuts to build once events land:
+
+1. **Landing → Signup funnel**
+   - `landing_cta_pressed` (any variant) → `signup_completed` (placeholder — not yet wired)
+   - Conversion rate, time to convert, drop-off step
+2. **SEO entry → engagement**
+   - `center_viewed { source: web_detail }` → any `event_*` event in same session
+   - Tells us if Google-search arrivals are sticking
+3. **CTA variant test (free A/B)**
+   - `landing_cta_pressed` grouped by `variant` (hero vs final)
+   - Whichever wins, we can prune the loser
+4. **Center engagement heat**
+   - `center_viewed` count + breakdown by `centerId`
+   - Which centers attract attention via SEO vs in-app
+
+## Privacy
+
+- No PII in any property. **No** emails, phone numbers, addresses,
+  full names.
+- `centerId` / `eventId` are opaque UUIDs — safe.
+- Don't add a `userId` prop on capture; PostHog identifies via
+  `posthog.identify(userId)` once on login (already wired in `_layout.tsx`).
+- For pre-auth events, PostHog stores anonymous device IDs only — no PII.
+
+## Adding a new event
+
+1. Add a row to the table above with the event name, properties, and
+   where it fires.
+2. Use `usePostHog()` + `posthog?.capture('event_name', { ...props })`.
+   The `?.` is intentional — PostHog is null in tests and on devices
+   that didn't get the env var set.
+3. If the event is for a CTA, add a `variant` prop instead of inventing
+   a new event name per CTA placement.

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -10,6 +10,7 @@ import { ThreadPanel, boardPostToMessage } from '../../components/boards'
 import { useUser } from '../../components/contexts'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildCenterJsonLd } from '../../components/seo/jsonLd'
+import { usePostHog } from 'posthog-react-native'
 
 export default function CenterDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
@@ -50,9 +51,22 @@ function formatDateCallout(dateStr: string): { month: string; day: string } {
 function MobileCenterDetail({ centerId }: { centerId: string }) {
   const router = useRouter()
   const { user } = useUser()
+  const posthog = usePostHog()
   const { center, events, loading } = useCenterDetail(centerId)
   const colors = useDetailColors()
   const [activeTab, setActiveTab] = useState('About')
+
+  // Fire center_viewed once per center load. Mirrors the native page's
+  // event so web traffic isn't missing from PostHog. (#analytics)
+  useEffect(() => {
+    if (!loading && center?.id) {
+      posthog?.capture('center_viewed', {
+        centerId: center.id,
+        name: center.name,
+        source: 'web_detail',
+      })
+    }
+  }, [loading, center?.id, center?.name, posthog])
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
@@ -65,6 +79,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }
 
   const handleShare = () => {
+    posthog?.capture('center_shared', { centerId: center?.id, source: 'web_detail' })
     if (typeof navigator !== 'undefined' && navigator.share) {
       navigator.share({ title: center?.name || 'Center', text: `Check out ${center?.name} on Chinmaya Janata!` }).catch(() => {})
     } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -74,21 +89,25 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
 
   const handleAddressPress = () => {
     if (!center?.address) return
+    posthog?.capture('center_address_pressed', { centerId: center.id, source: 'web_detail' })
     Linking.openURL(`https://maps.google.com/?q=${encodeURIComponent(center.address)}`)
   }
 
   const handleWebsitePress = () => {
     if (!center?.website) return
+    posthog?.capture('center_website_pressed', { centerId: center.id, source: 'web_detail' })
     const url = center.website.startsWith('http') ? center.website : `https://${center.website}`
     Linking.openURL(url)
   }
 
   const handlePhonePress = () => {
     if (!center?.phone) return
+    posthog?.capture('center_phone_pressed', { centerId: center.id, source: 'web_detail' })
     Linking.openURL(`tel:${center.phone}`)
   }
 
   const handleEventPress = (event: EventDisplay) => {
+    posthog?.capture('center_event_pressed', { centerId: center?.id, eventId: event.id, source: 'web_detail' })
     router.push(`/events/${event.id}`)
   }
 

--- a/packages/frontend/components/landing/FinalCTA.tsx
+++ b/packages/frontend/components/landing/FinalCTA.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text, Pressable, useWindowDimensions, Linking } from 'react-native'
 import { useRouter } from 'expo-router'
+import { usePostHog } from 'posthog-react-native'
 
 const CONTACT_EMAIL = 'projectjanatha@gmail.com'
 
@@ -107,6 +108,7 @@ function AskCard({
 
 export function FinalCTA() {
   const router = useRouter()
+  const posthog = usePostHog()
   const { width } = useWindowDimensions()
   const isMobile = width < 768
   const isTablet = width >= 768 && width < 1024
@@ -206,7 +208,10 @@ export function FinalCTA() {
             headline="Post your next event on Janata."
             description="It takes a minute per event, and CHYKs who aren't in your WhatsApp group can finally find you. We'll personally help you migrate your RSVP flow."
             ctaLabel="Get set up"
-            onPress={() => openMail('Coordinator — getting set up on Janata')}
+            onPress={() => {
+              posthog?.capture('landing_ask_pressed', { audience: 'coordinator' })
+              openMail('Coordinator — getting set up on Janata')
+            }}
             isMobile={isMobile}
           />
           <AskCard
@@ -214,7 +219,10 @@ export function FinalCTA() {
             headline="Join the team."
             description="Volunteer-led across dev, design, product, and outreach. Async over Slack, as much or as little time as you can give. A great opportunity for seva."
             ctaLabel="Get in touch"
-            onPress={() => openMail('Joining the Janata team')}
+            onPress={() => {
+              posthog?.capture('landing_ask_pressed', { audience: 'contributor' })
+              openMail('Joining the Janata team')
+            }}
             isMobile={isMobile}
           />
           <AskCard
@@ -222,7 +230,10 @@ export function FinalCTA() {
             headline="Bless this & introduce us."
             description="Designed to be run entirely by CHYKs — nothing added to your plate. Connect us with the coordinators at your center and spread the word to your CHYKs."
             ctaLabel="Connect with us"
-            onPress={() => openMail('Acharya introduction — Janata')}
+            onPress={() => {
+              posthog?.capture('landing_ask_pressed', { audience: 'acharya' })
+              openMail('Acharya introduction — Janata')
+            }}
             isMobile={isMobile}
           />
         </View>
@@ -247,7 +258,10 @@ export function FinalCTA() {
             Just here to look around?
           </Text>
           <Pressable
-            onPress={() => router.push('/(tabs)')}
+            onPress={() => {
+              posthog?.capture('landing_cta_pressed', { variant: 'final', label: 'browse_events' })
+              router.push('/(tabs)')
+            }}
             className="bg-primary active:bg-primary-press rounded-full"
             style={{
               paddingHorizontal: 28,

--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { View, Text, Pressable, Platform, useWindowDimensions, ScrollView, Image } from 'react-native'
 import { useRouter } from 'expo-router'
+import { usePostHog } from 'posthog-react-native'
 import { useEventList, useCenterList } from '../../hooks/useApiData'
 import type { EventDisplay, DiscoverCenter } from '../../utils/api'
 
@@ -498,6 +499,7 @@ function HorizontalScrollRow({ cards }: { cards: CardData[] }) {
 
 export function Hero() {
   const router = useRouter()
+  const posthog = usePostHog()
   const { width } = useWindowDimensions()
   const isMobile = width < 768
   const isTablet = width >= 768 && width < 1024
@@ -670,7 +672,10 @@ export function Hero() {
           }}
         >
           <Pressable
-            onPress={() => router.push('/(tabs)')}
+            onPress={() => {
+              posthog?.capture('landing_cta_pressed', { variant: 'hero', label: 'start_exploring' })
+              router.push('/(tabs)')
+            }}
             className="bg-primary active:bg-primary-press rounded-full"
             style={{
               paddingHorizontal: 28,

--- a/packages/frontend/components/landing/NavBar.tsx
+++ b/packages/frontend/components/landing/NavBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { View, Text, Pressable, useWindowDimensions, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
+import { usePostHog } from 'posthog-react-native'
 import { User } from 'lucide-react-native'
 import Logo from '../ui/Logo'
 
@@ -24,6 +25,7 @@ const NAV_LINKS: string[] = []
 
 export function NavBar() {
   const router = useRouter()
+  const posthog = usePostHog()
   const { width } = useWindowDimensions()
   const isMobile = width < 768
   const isTablet = width >= 768 && width < 1024
@@ -76,7 +78,10 @@ export function NavBar() {
 
           <Pressable
             accessibilityLabel="Sign in or sign up"
-            onPress={() => router.push('/auth')}
+            onPress={() => {
+              posthog?.capture('landing_signin_pressed', { source: 'navbar' })
+              router.push('/auth')
+            }}
             style={{
               width: 36,
               height: 36,


### PR DESCRIPTION
Follow-up to the closed [#258](https://github.com/Project-Janata/Janata/pull/258) (GA4) — wires PostHog instead, per the **Option C** decision in `local-notes/analytics-plan.md`.

## What

Fills the analytics gap on the **public/marketing surface** of the app. Pre-this-PR PostHog had ~25 events firing in-app (Explore, event detail, Home, nav) but **zero** on the landing page or web-only center detail. So we had no view into "how do anonymous visitors convert?"

| New event | Properties | Where |
|---|---|---|
| `landing_cta_pressed` | `variant`, `label` | `Hero.tsx` (Start Exploring), `FinalCTA.tsx` (Browse events nearby) |
| `landing_signin_pressed` | `source` | `NavBar.tsx` user icon |
| `landing_ask_pressed` | `audience` ∈ {coordinator, contributor, acharya} | `FinalCTA.tsx` AskCard CTAs |
| `center_viewed` | `centerId`, `name`, `source` | `center/[id].web.tsx` (parity with native — was already firing there) |
| `center_shared` | `centerId`, `source` | web center detail share |
| `center_address_pressed` | `centerId`, `source` | tap address row |
| `center_website_pressed` | `centerId`, `source` | tap website row |
| `center_phone_pressed` | `centerId`, `source` | tap phone row |
| `center_event_pressed` | `centerId`, `eventId`, `source` | tap event row from center detail |

Plus [`docs/analytics-events.md`](docs/analytics-events.md) — single source of truth for the **whole** event taxonomy across the app (~35 events documented, not just the new ones). Conventions, properties, and the four dashboards to build in PostHog on top.

## Why this instead of GA4

See `local-notes/analytics-plan.md`. Short version: Search Console (free) covers SEO. Cloudflare Web Analytics (free, no consent banner) covers pageviews + referrers. PostHog already covers product. GA4 would only have added demographic/audience reports that no one's asked for.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

Manual smoke once preview is up:

1. Open the landing page in a browser with PostHog devtools / network tab.
2. Click the user-icon in the nav → see `landing_signin_pressed` event in the request.
3. Click "Start Exploring" → see `landing_cta_pressed { variant: 'hero', label: 'start_exploring' }`.
4. Navigate to `/center/<id>` → see `center_viewed { source: 'web_detail' }`.
5. Tap the address row → see `center_address_pressed { source: 'web_detail' }`.

## What you (Kish) still need to do for the full Option C stack

Per `local-notes/kish-todos.md`:

- [ ] **Enable Cloudflare Web Analytics** — CF dashboard → `chinmaya-janata` Pages → Web Analytics → Enable. Auto-injects, no code change.
- [ ] **Verify the domain in Google Search Console** + submit `https://chinmayajanata.org/sitemap.xml` (already shipped via #253).

## Note on diff size

Landing files (`Hero.tsx`, `FinalCTA.tsx`) had CRLF line endings on v2 disk; Edit tool normalizes to LF on touched hunks, which inflates the line count. Real semantic diff is **~30 added lines** of `posthog?.capture` calls + the 110-line taxonomy doc.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779922903474299