### PR TITLE
feat(observability): Sentry rails — env-gated, dep-optional (#105)

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -5,3 +5,14 @@ EXPO_PUBLIC_POSTHOG_KEY=
 
 # Optional; default in app is https://us.i.posthog.com
 # EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Sentry crash reporting — for production-only error tracking. When unset,
+# Sentry stays inert (no init, no requests). To enable:
+#   1. Create a project at sentry.io → grab the DSN.
+#   2. Run `npx expo install @sentry/react-native` (dep is intentionally not
+#      pre-installed so the env var alone gates activation).
+#   3. Set this var in CF Pages production env + EAS secrets.
+# See `packages/frontend/src/lib/sentry.ts` and GitHub issue #105.
+# EXPO_PUBLIC_SENTRY_DSN=https://your-key@oXXX.ingest.sentry.io/YYY
+# Optional — tags errors per environment in the Sentry dashboard.
+# EXPO_PUBLIC_SENTRY_ENV=production

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -28,7 +28,14 @@ import {
 } from '../components/contexts'
 import { ErrorBoundary } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
+import { initSentry } from '../src/lib/sentry'
 import '../globals.css'
+
+// Initialize Sentry at module load — before any render. No-op when
+// EXPO_PUBLIC_SENTRY_DSN is unset (current state for dev + previews) so
+// this is a free addition until Kish creates the project + sets the env.
+// See src/lib/sentry.ts + #105 for the activation steps.
+initSentry()
 
 export const unstable_settings = {
   initialRouteName: '(tabs)',

--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import React, { Component, type ErrorInfo, type ReactNode } from 'react'
 import { ScrollView, View, Text, Pressable } from 'react-native'
 
+import { captureError } from '../../src/lib/sentry'
+
 interface Props {
   children: ReactNode
   fallback?: ReactNode
@@ -38,6 +40,10 @@ export class ErrorBoundary extends Component<Props, State> {
         componentStack: info.componentStack,
       }
     }
+    // Forward to Sentry. No-op until EXPO_PUBLIC_SENTRY_DSN is set + the
+    // @sentry/react-native package is installed — see src/lib/sentry.ts
+    // and #105 for activation steps.
+    captureError(error, { componentStack: info.componentStack ?? '(none)' })
     this.setState({ componentStack: info.componentStack ?? null })
   }
 

--- a/packages/frontend/src/lib/sentry.ts
+++ b/packages/frontend/src/lib/sentry.ts
@@ -1,0 +1,126 @@
+/**
+ * sentry.ts — opt-in error reporting via Sentry.
+ *
+ * RAILS-ONLY for #105. The actual @sentry/react-native dep is NOT yet a
+ * dependency of this repo — Kish runs `npx expo install @sentry/react-native`
+ * once a Sentry project exists and a DSN is in hand.
+ *
+ * This file is wired NOW so that:
+ *   1. The integration points (init at root, capture in ErrorBoundary) are
+ *      in place and won't need a follow-up PR to add.
+ *   2. With EXPO_PUBLIC_SENTRY_DSN unset (current state), every call here
+ *      is a cheap no-op. Nothing ships to Sentry, nothing crashes.
+ *   3. The moment Kish sets EXPO_PUBLIC_SENTRY_DSN + installs the dep,
+ *      Sentry just works.
+ *
+ * The dynamic `require` pattern mirrors how `edit-profile.tsx` handles
+ * `expo-image-picker` — keeps the dep optional at the type-system level.
+ */
+
+let sentry: any = null
+let initialized = false
+
+function loadSentry(): any | null {
+  if (sentry !== null) return sentry
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    sentry = require('@sentry/react-native')
+    return sentry
+  } catch {
+    // Dep not installed yet. Stay silent — return null and let callers no-op.
+    sentry = false // memoize the negative so we don't keep trying
+    return null
+  }
+}
+
+/**
+ * Initialize Sentry. Idempotent — safe to call multiple times.
+ *
+ * - No DSN env var set → no-op (intended for dev + previews).
+ * - DSN set but @sentry/react-native missing → no-op + a one-time warning.
+ * - DSN set + dep present → Sentry initialized with the standard options.
+ */
+export function initSentry(): void {
+  if (initialized) return
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN?.trim()
+  if (!dsn) return
+
+  const s = loadSentry()
+  if (!s) {
+    if (typeof console !== 'undefined' && (globalThis as any).__DEV__) {
+      console.warn(
+        '[sentry] EXPO_PUBLIC_SENTRY_DSN is set but @sentry/react-native is not installed. ' +
+          'Run `npx expo install @sentry/react-native` to enable error reporting.',
+      )
+    }
+    return
+  }
+
+  try {
+    s.init({
+      dsn,
+      // Conservative defaults — we can tune once we see real traffic.
+      tracesSampleRate: 0.1,        // 10% of transactions get performance traces
+      profilesSampleRate: 0.1,
+      // Per-environment tagging so prod / preview crashes don't blur together
+      // in the Sentry dashboard.
+      environment: process.env.EXPO_PUBLIC_SENTRY_ENV ?? 'production',
+      // Don't ship breadcrumbs that include PII. Captured fields go through
+      // beforeSend to scrub anything risky.
+      beforeSend(event: any) {
+        if (event?.request?.headers) delete event.request.headers
+        if (event?.user) {
+          // Keep an opaque id only; never email/name.
+          delete event.user.email
+          delete event.user.username
+        }
+        return event
+      },
+    })
+    initialized = true
+  } catch (e) {
+    if (typeof console !== 'undefined') {
+      console.warn('[sentry] init failed:', (e as Error).message)
+    }
+  }
+}
+
+/**
+ * Forward an uncaught error to Sentry. Safe to call before init() — just no-ops.
+ *
+ * Use from ErrorBoundary.componentDidCatch (already wired) and from any
+ * other catch site that wants to surface non-fatal errors.
+ */
+export function captureError(error: unknown, context?: Record<string, unknown>): void {
+  const s = loadSentry()
+  if (!s || !initialized) return
+  try {
+    if (context) {
+      s.withScope((scope: any) => {
+        scope.setExtras(context)
+        s.captureException(error)
+      })
+    } else {
+      s.captureException(error)
+    }
+  } catch {
+    // Don't let Sentry errors take down the app.
+  }
+}
+
+/**
+ * Identify the current user to Sentry. Pair with the PostHog identify call
+ * in _layout.tsx so a single user shows up correctly in both dashboards.
+ *
+ * Pass a stable opaque id — NEVER pass email, username, or other PII.
+ */
+export function identifyUser(userId: string | null): void {
+  const s = loadSentry()
+  if (!s || !initialized) return
+  try {
+    if (userId) s.setUser({ id: userId })
+    else s.setUser(null)
+  } catch {
+    /* swallow */
+  }
+}


### PR DESCRIPTION
Closes #105

## What

Wires the integration points for Sentry crash reporting without installing `@sentry/react-native` or requiring a DSN yet. **Rails-only by design** — same pattern as the now-closed GA4 PR.

Files:
| File | What |
|---|---|
| `packages/frontend/src/lib/sentry.ts` | `initSentry()`, `captureError()`, `identifyUser()`. Dynamic `require('@sentry/react-native')` so the dep stays optional. Conservative defaults when active: 10% traces sample, environment tagging, `beforeSend` strips PII (`request.headers`, `user.email`, `user.username`). |
| `packages/frontend/app/_layout.tsx` | `initSentry()` at module load, before any render. |
| `packages/frontend/components/ui/ErrorBoundary.tsx` | `componentDidCatch` now also forwards to `captureError(error, { componentStack })`. Existing `console.error` + `window.__lastErrorInfo` behavior unchanged. |
| `packages/frontend/.env.example` | Documents `EXPO_PUBLIC_SENTRY_DSN` + the activation steps. |

## State matrix

| Build | Behavior |
|---|---|
| `EXPO_PUBLIC_SENTRY_DSN` unset (dev, every PR preview, prod today) | **No-op everywhere.** No init, no requests, no warnings. |
| DSN set, `@sentry/react-native` missing | One-time `__DEV__` warning telling you to run `npx expo install`. No exception thrown, app continues. |
| DSN set + dep installed | Sentry init with the defaults above. Crashes from `ErrorBoundary` ship to your project. |

## Activation (when Kish is ready)

```bash
# 1. Create the Sentry project at sentry.io (free tier, 10K events/mo)

# 2. Install the dep (Expo-aware install so the iOS/Android native bits land)
cd packages/frontend
npx expo install @sentry/react-native

# 3. Set the env in CF Pages + EAS
#    CF Pages → chinmaya-janata → Settings → Environment Variables → Production →
#      EXPO_PUBLIC_SENTRY_DSN=https://your-key@oXXX.ingest.sentry.io/YYY
#    EAS → eas.json env → same key

# 4. (Optional) tag the environment so prod/preview/dev split in the dashboard
#    EXPO_PUBLIC_SENTRY_ENV=production
```

Zero code follow-up needed — once the env + dep are in place, the existing wiring activates.

## Why no @sentry/react-native pre-install

Two reasons:
1. **Cleaner activation gate.** With the dep installed, `require()` doesn't throw — meaning the "is Sentry actually wired?" check would be "is the env var set?" only, hiding misconfiguration. Keeping the dep optional means the system catches *both* failure modes: missing env OR missing dep.
2. **No `package-lock.json` churn** for a dep that's not yet used. Adding @sentry/react-native + its peer deps adds ~80 lines to lock; cleaner to land that with the activation PR.

If you'd rather just install it now, say the word — one-line follow-up commit.

## What's deferred

**Backend Sentry** (`@sentry/cloudflare-workers`) intentionally separate scope. Frontend covers the React error path; backend would catch Hono route exceptions + D1 errors. Follow-up PR once frontend is live.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

The build succeeds without `@sentry/react-native` installed — proves the dynamic-require fallback works.

Evidence: pending — Slack permalink will be added by ralph-post-slack