### PR TITLE
feat(observability): forward render errors to PostHog $exception (#105)

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -26,7 +26,7 @@ import {
   ThemeProvider as CustomThemeProvider,
   useTheme,
 } from '../components/contexts'
-import { ErrorBoundary } from '../components/ui/ErrorBoundary'
+import { ErrorBoundary, ErrorBoundaryWithAnalytics } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
 import '../globals.css'
 
@@ -85,13 +85,13 @@ export default function RootLayout() {
 
   return posthogEnabled ? (
     <PostHogProvider apiKey={posthogKey!.trim()} options={{ host: posthogHost }}>
-      <ErrorBoundary>
+      <ErrorBoundaryWithAnalytics>
         <CustomThemeProvider>
           <UserProvider>
             <RootLayoutNav onAuthReady={handleAuthReady} />
           </UserProvider>
         </CustomThemeProvider>
-      </ErrorBoundary>
+      </ErrorBoundaryWithAnalytics>
     </PostHogProvider>
   ) : (
     <ErrorBoundary>

--- a/packages/frontend/components/ui/ErrorBoundary.tsx
+++ b/packages/frontend/components/ui/ErrorBoundary.tsx
@@ -1,9 +1,29 @@
 import React, { Component, type ErrorInfo, type ReactNode } from 'react'
 import { ScrollView, View, Text, Pressable } from 'react-native'
+import { usePostHog } from 'posthog-react-native'
+
+/**
+ * Minimal shape of the PostHog client we actually use. Typed loosely so a
+ * null/missing client never trips us up — error reporting must never crash
+ * the error reporter.
+ */
+type PosthogLike =
+  | { capture: (event: string, props?: Record<string, unknown>) => void }
+  | null
+  | undefined
 
 interface Props {
   children: ReactNode
   fallback?: ReactNode
+  /**
+   * Optional PostHog client. Passed in by `ErrorBoundaryWithAnalytics`
+   * (function-component wrapper) so this class component can forward to
+   * PostHog's `$exception` capture from `componentDidCatch`.
+   *
+   * When absent (PostHog not configured), errors still log to console and
+   * `window.__lastErrorInfo` — the friendly fallback UI is identical.
+   */
+  posthog?: PosthogLike
 }
 
 interface State {
@@ -37,6 +57,22 @@ export class ErrorBoundary extends Component<Props, State> {
         stack: error?.stack,
         componentStack: info.componentStack,
       }
+    }
+    // Forward to PostHog as an Error Tracking event (#105).
+    // PostHog's $exception event maps to its Error Tracking UI when the
+    // standard property keys ($exception_message / _type / _stack_trace_raw)
+    // are present. Conservative — no PII captured, just the error itself
+    // and the React component stack so we know where it rendered.
+    try {
+      this.props.posthog?.capture('$exception', {
+        $exception_message: error?.message ?? '(no message)',
+        $exception_type: error?.name ?? 'Error',
+        $exception_stack_trace_raw: error?.stack ?? '(no stack)',
+        component_stack: info.componentStack ?? '(no component stack)',
+        url: typeof window !== 'undefined' ? window.location?.href : undefined,
+      })
+    } catch {
+      // Error reporter must never crash the app — swallow any PostHog hiccup.
     }
     this.setState({ componentStack: info.componentStack ?? null })
   }
@@ -247,4 +283,20 @@ export class ErrorBoundary extends Component<Props, State> {
 
     return this.props.children
   }
+}
+
+/**
+ * Function-component wrapper that injects PostHog into the class-based
+ * ErrorBoundary via props. Use this in app/_layout.tsx instead of bare
+ * `<ErrorBoundary>` so component-tree crashes get forwarded to PostHog's
+ * Error Tracking (#105).
+ *
+ * The hook can't live inside the class component, so the standard pattern
+ * is: hook here → prop into the class. When PostHog isn't configured
+ * (no EXPO_PUBLIC_POSTHOG_KEY), `usePostHog()` returns `undefined` and
+ * the class component handles the absence gracefully.
+ */
+export function ErrorBoundaryWithAnalytics(props: Omit<Props, 'posthog'>) {
+  const posthog = usePostHog()
+  return <ErrorBoundary {...props} posthog={posthog as PosthogLike} />
 }


### PR DESCRIPTION
Closes #105 — replacement for the closed [#260 Sentry rails PR](https://github.com/Project-Janata/Janata/pull/260).

## Decision

Kish 5/27: **no new tools. PostHog + Cloudflare are enough.** A 2-dev team triaging crashes doesn't benefit from a third dashboard. PostHog has [Error Tracking](https://posthog.com/docs/error-tracking) — same data, same workflow, no Sentry account / DSN / SDK to maintain.

See `local-notes/analytics-plan.md` for the full reasoning trail.

## What changes

- **`components/ui/ErrorBoundary.tsx`**
  - New optional `posthog` prop (typed loosely so a missing client is safe).
  - `componentDidCatch` forwards to `posthog.capture('$exception', { ... })` with PostHog's standard Error Tracking properties (`$exception_message`, `$exception_type`, `$exception_stack_trace_raw`, plus `component_stack` and `url`). Wrapped in try/catch — the error reporter must never crash the app.
  - New `ErrorBoundaryWithAnalytics` function-component wrapper at the bottom of the same file uses `usePostHog()` and passes the client in as a prop. Standard hook → class workaround.
- **`app/_layout.tsx`** — swaps `<ErrorBoundary>` to `<ErrorBoundaryWithAnalytics>` inside the PostHog-enabled branch. No-PostHog branch unchanged (bare ErrorBoundary, no capture attempt).

## State matrix

| Build | Behavior |
|---|---|
| PostHog disabled (no `EXPO_PUBLIC_POSTHOG_KEY`) | Bare ErrorBoundary, friendly fallback only. No $exception attempt. |
| PostHog enabled, no crash | Provider initialized, $exception never fires. |
| PostHog enabled, render crash | Friendly fallback + console.error + `window.__lastErrorInfo` AND `posthog.capture('$exception', {...})` to PostHog Error Tracking. |

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

To smoke after merge + deploy: hit a route known to crash (or temporarily inject a `throw new Error('test')` into a screen). Confirm:
1. The friendly fallback renders.
2. PostHog dashboard → Error Tracking → see the event with the stack.

## Coordination with the open analytics PR

The taxonomy doc `docs/analytics-events.md` is on the open [#259 (analytics public-surface)](https://github.com/Project-Janata/Janata/pull/259) branch. Whichever of #259 + this PR merges second should add a brief `$exception` entry to that doc — small append. Noted in this PR body so we don't miss it.

## What's no longer happening

- ~~Create Sentry account~~ — dropped.
- ~~`npx expo install @sentry/react-native`~~ — dropped.
- ~~`EXPO_PUBLIC_SENTRY_DSN` env~~ — dropped.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779923556417369