### PR TITLE
chore(ios): EAS Build config + GH Actions workflow + runbook (#103)

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,101 @@
+name: EAS Build
+
+# Triggers a production build via EAS — NEVER auto-submits to App Store /
+# TestFlight / Play Store. The human runs `eas submit` after reviewing the
+# build artifact. See docs/eas-build-runbook.md.
+#
+# Setup (one-time, see runbook):
+#   1. expo.dev → Account → Access Tokens → Create token
+#   2. GitHub → Settings → Secrets → Actions → Add EXPO_TOKEN
+
+on:
+  # Tag pushes are the canonical trigger. Use `ios-v0.2.0` or
+  # `android-v0.2.0` patterns. Each tag scopes the build to one platform
+  # so we don't waste credits when only one is needed.
+  push:
+    tags:
+      - 'ios-v*'
+      - 'android-v*'
+
+  # Manual trigger for ad-hoc internal builds, dry-runs, or rebuilding
+  # an existing version after fixing a build-time issue.
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build'
+        required: true
+        type: choice
+        options:
+          - ios
+          - android
+          - all
+        default: 'ios'
+      profile:
+        description: 'EAS build profile (matches a key under build.* in eas.json)'
+        required: true
+        type: choice
+        options:
+          - development
+          - preview
+          - production
+        default: 'preview'
+
+jobs:
+  build:
+    name: Build via EAS
+    runs-on: ubuntu-latest
+
+    # The build itself runs on Expo's macOS hosts; this runner only kicks
+    # off the EAS job. Keeping it ubuntu means we don't burn macOS minutes.
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve platform + profile
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "platform=${{ github.event.inputs.platform }}" >> "$GITHUB_OUTPUT"
+            echo "profile=${{ github.event.inputs.profile }}" >> "$GITHUB_OUTPUT"
+          else
+            # Tag-triggered. Pattern: ios-v0.2.0 / android-v0.2.0
+            tag="${{ github.ref_name }}"
+            case "$tag" in
+              ios-v*)     echo "platform=ios" >> "$GITHUB_OUTPUT" ;;
+              android-v*) echo "platform=android" >> "$GITHUB_OUTPUT" ;;
+              *) echo "::error::Unrecognized tag pattern: $tag"; exit 1 ;;
+            esac
+            echo "profile=production" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies (root + workspace)
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build
+        working-directory: packages/frontend
+        env:
+          EXPO_NO_TELEMETRY: '1'
+        run: |
+          echo "::notice::Building platform=${{ steps.resolve.outputs.platform }} profile=${{ steps.resolve.outputs.profile }}"
+          eas build \
+            --platform "${{ steps.resolve.outputs.platform }}" \
+            --profile "${{ steps.resolve.outputs.profile }}" \
+            --non-interactive \
+            --no-wait
+
+      - name: Note about submit
+        run: |
+          echo "::notice::This workflow builds only. Human runs 'eas submit' after reviewing the artifact in the EAS dashboard. See docs/eas-build-runbook.md."

--- a/docs/eas-build-runbook.md
+++ b/docs/eas-build-runbook.md
@@ -1,0 +1,175 @@
+# EAS Build runbook
+
+How to get a build out the door. Covers the **automated** pieces (CI, eas.json) and the **human-only** pieces (`eas login`, `eas submit`).
+
+> **Why this exists:** the agent that built this can write configs and workflows all day, but it can never log into your Expo account, never sign a build, never submit to TestFlight. That's you. This doc draws the line cleanly.
+
+---
+
+## One-time setup (human, ~10 min)
+
+### 1. `eas login`
+
+On the Mac mini (or wherever the dev environment lives):
+
+```bash
+cd ~/Code/Project-Janatha/packages/frontend
+npx eas login
+# Browser opens → log in to expo.dev → confirm
+```
+
+Confirms with `npx eas whoami` → should print your Expo username.
+
+### 2. Create an EAS access token for CI
+
+For the GitHub Actions workflow to drive builds:
+
+1. Open https://expo.dev/accounts/[your-account]/settings/access-tokens
+2. **Create token** → give it a name like `github-actions-janata`
+3. Copy the token (one-time view).
+4. GitHub: repo → Settings → Secrets and variables → Actions → **New repository secret**:
+   - Name: `EXPO_TOKEN`
+   - Value: paste the token
+
+### 3. App Store Connect API key (only needed when you `eas submit`)
+
+For `eas submit` to upload to TestFlight non-interactively:
+
+1. App Store Connect → Users and Access → Keys → **+** to create a new API key with **App Manager** role.
+2. Download the `.p8` file (one-time download, **never re-downloadable**).
+3. Note the **Issuer ID** (header of the Keys page) and **Key ID** (next to the key name).
+4. Either:
+   - **(Recommended)** Run `eas credentials` and paste them in when prompted — EAS stores them remotely.
+   - **(CI path)** Add them as GitHub secrets: `ASC_API_KEY_P8`, `ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`. The submit step in the runbook below references these.
+
+You only need this once. Re-build, re-submit, re-build again all use the same key.
+
+### 4. iOS distribution certificate + provisioning profile
+
+Two options:
+
+- **(Recommended)** Let EAS manage them. First `eas build` will prompt: "EAS doesn't have credentials for this project — would you like EAS to generate them?" → Yes. EAS creates the cert and profile in your Apple Developer account on your behalf. Stored remotely; no `.p12` to lose.
+- **(Manual)** Use existing cert via `eas credentials`. Only if you need to keep your existing CCMT cert.
+
+Per Notion 5/26 — we're shipping under CCMT's existing org account. So when EAS asks "Apple Developer Team," pick CCMT's team, not your personal one.
+
+---
+
+## Daily flow
+
+### Trigger a build via GitHub Actions (recommended)
+
+Tag the commit you want to ship:
+
+```bash
+git checkout main          # or v2 if pre-launch
+git pull
+git tag ios-v0.2.0         # the tag scopes the platform
+git push origin ios-v0.2.0
+```
+
+The `.github/workflows/eas-build.yml` workflow:
+- Resolves platform from the tag prefix (`ios-v*` → iOS; `android-v*` → Android)
+- Runs `eas build --platform ios --profile production --non-interactive --no-wait`
+- Reports back with a link to the build in the EAS dashboard
+
+Or manually via GitHub UI:
+
+1. Actions tab → **EAS Build** → Run workflow
+2. Pick platform + profile
+3. Run
+
+Track the actual build on https://expo.dev — the GitHub job exits as soon as the EAS job kicks off (`--no-wait`).
+
+### Local build (debugging)
+
+```bash
+cd packages/frontend
+eas build --profile preview --platform ios       # for a real-device test build
+eas build --profile production --platform ios    # for a TestFlight-ready build
+```
+
+`preview` profile = internal distribution. `production` = needs `eas submit` to ship to TestFlight.
+
+### Submit to TestFlight (human-only step)
+
+After the build finishes (you'll get an email from EAS):
+
+```bash
+cd packages/frontend
+eas submit --profile production --platform ios --latest
+```
+
+`--latest` grabs the most recent production iOS build. EAS uses the ASC API key you set up in step 3 above.
+
+Then in App Store Connect:
+1. Wait ~15-30 min for Apple to process the build.
+2. TestFlight tab → Internal Testing → Add the build to your test group.
+3. Internal testers get a push notification within minutes.
+
+---
+
+## What the agent can and cannot do for you
+
+| Task | Agent? |
+|---|---|
+| Write/maintain `eas.json` | ✅ |
+| Add/modify the GitHub Actions workflow | ✅ |
+| Bump version numbers in `app.json` | ✅ |
+| Write release notes | ✅ |
+| `eas login` | ❌ — needs your browser auth |
+| `eas submit` to TestFlight | ❌ — per Kish 5/27, human-only |
+| Apple Developer portal config (certs, AASA, push keys) | ❌ — needs Apple account credentials |
+| Diagnose a failed EAS build by reading logs | ✅ |
+
+---
+
+## Common gotchas
+
+### "Project not configured for EAS" on first build
+
+You haven't run `eas login` (step 1) — or your token expired. Re-run `eas login`.
+
+### "Could not find a project linked to this EAS account"
+
+Run `eas init --id` from `packages/frontend/` to bind this repo to an EAS project. EAS picks the project from your account. If you have multiple Expo accounts → log out and back in as the right one.
+
+### CI build fails with "Authentication required"
+
+`EXPO_TOKEN` secret missing or expired in GitHub Actions. Re-generate at expo.dev and re-add to the repo secrets.
+
+### Build succeeds but bundle is wrong
+
+Most likely `EXPO_PUBLIC_*` env vars are missing from the EAS build environment. EAS doesn't read your local `.env` — set them via:
+
+```bash
+eas secret:create --scope project --name EXPO_PUBLIC_POSTHOG_KEY --value "phc_..."
+```
+
+These get injected into every `eas build` automatically.
+
+The vars to set right now (per `packages/frontend/.env.example`):
+- `EXPO_PUBLIC_POSTHOG_KEY` — required
+- `EXPO_PUBLIC_API_BASE_URL` — defaults to local, override to `https://api.chinmayajanata.org/api` for prod builds
+- `EXPO_PUBLIC_SHOW_DEBUG_DETAILS` — explicitly `false` for prod builds (or unset, same effect)
+
+### "App Store Connect API request failed: Authentication failed"
+
+ASC API key wrong / expired / wrong role. Re-do step 3 above.
+
+---
+
+## What's NOT in this runbook (yet)
+
+- **OTA updates via EAS Update** — separate from EAS Build. Lets you push JS-only changes without a new TestFlight build. Worth setting up post-launch for fast iteration.
+- **Android Play Store path** — same workflow shape, different submit endpoint. Add when we cross the bridge.
+- **Build version bumping** — `app.json` has `ios.buildNumber` which `eas build --profile production` auto-increments via `autoIncrement: true` in eas.json. No manual step.
+
+---
+
+## Related
+
+- `packages/frontend/eas.json` — build profile config
+- `.github/workflows/eas-build.yml` — CI workflow
+- `packages/frontend/app.json` — iOS bundle identifier, version, permissions
+- `local-notes/kish-todos.md` — pre-launch human-only steps

--- a/packages/frontend/eas.json
+++ b/packages/frontend/eas.json
@@ -7,18 +7,32 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "resourceClass": "m-medium"
+      },
+      "env": {
+        "EXPO_NO_TELEMETRY": "1"
       }
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "ios": {
-        "simulator": false
+        "simulator": false,
+        "resourceClass": "m-medium"
+      },
+      "env": {
+        "EXPO_NO_TELEMETRY": "1"
       }
     },
     "production": {
       "autoIncrement": true,
+      "channel": "production",
+      "ios": {
+        "resourceClass": "m-medium"
+      },
       "env": {
         "EXPO_NO_TELEMETRY": "1"
       }


### PR DESCRIPTION
Closes #103

## What's wired (no Kish credentials needed)

| File | What |
|---|---|
| [`packages/frontend/eas.json`](packages/frontend/eas.json) | Adds explicit `channel:` per profile (dev/preview/production), `resourceClass: m-medium` on iOS (cheapest tier; sufficient for our JS bundle), `EXPO_NO_TELEMETRY` env across all profiles. Existing `submit.production.ios` block unchanged (kishparikh18@gmail.com + ascAppId 6761746513 per Notion's 5/26 Apple-account decision). |
| [`.github/workflows/eas-build.yml`](.github/workflows/eas-build.yml) | New workflow. Triggers on tag push (`ios-v*` / `android-v*`) — platform inferred from prefix — AND supports `workflow_dispatch` for ad-hoc builds with platform + profile inputs. Uses `--no-wait` so the GH runner exits as soon as EAS accepts the build (track on expo.dev). **NEVER calls `eas submit`.** |
| [`docs/eas-build-runbook.md`](docs/eas-build-runbook.md) | Full operator runbook — one-time setup (eas login, EXPO_TOKEN secret, ASC API key, certs), daily flow (tag → CI → review → manual submit), troubleshooting, table of what the agent can vs cannot do. |

## What's NOT wired (intentionally)

Per Kish 5/27: *"dont do testflight deployment yourself, we will do that later. do everything up to that point."*

| Step | Why it stays human-only |
|---|---|
| `eas login` | Needs your browser auth on the Mac mini. |
| `eas submit` | Per your direction — no auto-submit. |
| ASC API key / cert / provisioning profile | Apple Developer credentials you own. |
| `EXPO_TOKEN` GitHub secret | Created in your Expo account, added to repo settings. |

All four are documented step-by-step in [`docs/eas-build-runbook.md`](docs/eas-build-runbook.md).

## Daily flow once you've done the one-time steps

```bash
# Tag the commit you want to ship
git checkout v2 && git pull
git tag ios-v0.2.0
git push origin ios-v0.2.0
```

The workflow runs `eas build --platform ios --profile production --non-interactive --no-wait`. You get an email from EAS when it's done. Review on expo.dev, then on your machine:

```bash
cd packages/frontend
eas submit --profile production --platform ios --latest
```

That's the manual TestFlight step. Internal testers see it ~15-30 min later.

## Verify

```bash
bash .ralph/verify.sh
```

No code paths touched — verify.sh stays green:

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

## What's NOT in this PR

- **EAS Update (OTA)** — separate feature from EAS Build. Lets you push JS-only changes without re-submitting to TestFlight. Worth setting up after the first TestFlight build is in testers' hands.
- **Android Play Store** — same workflow shape, deferred until iOS is shipped.
- **Build-time `EXPO_PUBLIC_*` env injection** — set via `eas secret:create` after `eas login`. Runbook documents the commands.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779923903808749