### PR TITLE
feat(a11y): VoiceOver labels on high-traffic icon-only buttons (#108)

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -101,6 +101,8 @@ function HeaderBar({
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
         <Pressable
           onPress={onBack}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
           style={{
             flexDirection: 'row',
             alignItems: 'center',
@@ -123,6 +125,8 @@ function HeaderBar({
 
         <Pressable
           onPress={onShare}
+          accessibilityRole="button"
+          accessibilityLabel="Share this center"
           style={{
             padding: 8,
             minHeight: 44,

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -150,11 +150,21 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
       {/* Header */}
       <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8, gap: 10 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Pressable onPress={() => router.back()} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+          >
             <ChevronLeft size={20} color={colors.textSecondary} />
             <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Back</Text>
           </Pressable>
-          <Pressable onPress={handleShare} style={{ padding: 8 }}>
+          <Pressable
+            onPress={handleShare}
+            accessibilityRole="button"
+            accessibilityLabel="Share this center"
+            style={{ padding: 8 }}
+          >
             <Share2 size={18} color={colors.textSecondary} />
           </Pressable>
         </View>

--- a/packages/frontend/app/chat/[id].tsx
+++ b/packages/frontend/app/chat/[id].tsx
@@ -131,7 +131,12 @@ export default function ChatConversationDetail() {
           borderBottomColor: colors.border,
         }}
       >
-        <Pressable onPress={() => router.back()} hitSlop={10}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={10}
+        >
           <ArrowLeft size={22} color={colors.orange} />
         </Pressable>
         {conversation.type === 'dm' ? (

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -180,6 +180,8 @@ function HeaderBar({
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
         <Pressable
           onPress={onBack}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
           style={{
             flexDirection: 'row',
             alignItems: 'center',
@@ -244,6 +246,8 @@ function HeaderBar({
                   url,
                 }).catch(() => {})
               }}
+              accessibilityRole="button"
+              accessibilityLabel="Share this event"
               style={{
                 padding: 8,
                 minHeight: 44,

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -131,7 +131,12 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
       />
       {/* Header */}
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 }}>
-        <Pressable onPress={() => router.back()} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+        >
           <ChevronLeft size={20} color={colors.textSecondary} />
           <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Back</Text>
         </Pressable>
@@ -163,6 +168,8 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
                 navigator.clipboard.writeText(window.location.href)
               }
             }}
+            accessibilityRole="button"
+            accessibilityLabel="Share this event"
             style={{ padding: 8 }}
           >
             <Share2 size={18} color={colors.textSecondary} />

--- a/packages/frontend/app/feed/[id].tsx
+++ b/packages/frontend/app/feed/[id].tsx
@@ -164,7 +164,12 @@ export default function FeedPostDetail() {
           borderBottomColor: colors.border,
         }}
       >
-        <Pressable onPress={() => router.back()} hitSlop={10}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={10}
+        >
           <ArrowLeft size={22} color={colors.orange} />
         </Pressable>
         <View style={{ flex: 1 }}>

--- a/packages/frontend/components/map/Map.native.tsx
+++ b/packages/frontend/components/map/Map.native.tsx
@@ -80,7 +80,9 @@ function MapControls({
           onPressIn={() => setPressedId('in')}
           onPressOut={() => setPressedId(null)}
           style={[styles.zoomButton, { backgroundColor: makeBg('in') }]}
+          accessibilityRole="button"
           accessibilityLabel="Zoom in"
+          accessibilityHint="Zooms the map in one step"
         >
           <Plus size={18} color={iconColor} strokeWidth={2} />
         </Pressable>
@@ -90,7 +92,9 @@ function MapControls({
           onPressIn={() => setPressedId('out')}
           onPressOut={() => setPressedId(null)}
           style={[styles.zoomButton, { backgroundColor: makeBg('out') }]}
+          accessibilityRole="button"
           accessibilityLabel="Zoom out"
+          accessibilityHint="Zooms the map out one step"
         >
           <Minus size={18} color={iconColor} strokeWidth={2} />
         </Pressable>
@@ -100,7 +104,9 @@ function MapControls({
         onPressIn={() => setPressedId('loc')}
         onPressOut={() => setPressedId(null)}
         style={[styles.locateButton, { backgroundColor: makeBg('loc'), borderColor: isDark ? '#404040' : '#D6D3D1' }]}
+        accessibilityRole="button"
         accessibilityLabel="Show my location"
+        accessibilityHint="Centers the map on your current location"
       >
         <Navigation size={18} color={iconColor} strokeWidth={2} />
       </Pressable>

--- a/packages/frontend/components/ui/StackHeader.tsx
+++ b/packages/frontend/components/ui/StackHeader.tsx
@@ -34,6 +34,9 @@ export default function StackHeader({ title, onBack, right }: StackHeaderProps) 
       >
         <Pressable
           onPress={onBack ?? (() => router.back())}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          accessibilityHint="Returns to the previous screen"
           style={{ padding: 8, marginLeft: -8 }}
           hitSlop={8}
         >


### PR DESCRIPTION
Closes #108

## What

Adds `accessibilityRole="button"` + `accessibilityLabel` (+ `accessibilityHint` where useful) to the icon-only Pressables on the **navigation surface** — the screens Apple's App Store review will hit first and where VoiceOver users get the most lift.

| File | What got labeled |
|---|---|
| `components/ui/StackHeader.tsx` | Back button (used on every stack screen) |
| `components/map/Map.native.tsx` | Zoom in, Zoom out, Locate — labels were already there, added `role` + hints |
| `app/center/[id].tsx` | Back + Share |
| `app/center/[id].web.tsx` | Back + Share |
| `app/events/[id].tsx` | Back + Share (Edit / Delete already had labels) |
| `app/events/[id].web.tsx` | Back + Share |
| `app/feed/[id].tsx` | Back |
| `app/chat/[id].tsx` | Back |

Verified already-good (no change needed): `TabHeader.tsx` had dynamic role+label per action type; `WebBottomNav.tsx` had labels on every tab pill.

## What's NOT in this PR (intentional follow-up)

- **Comprehensive sweep of every Pressable.** The repo has ~225 Pressables. Labeling them all is a separate effort; this PR targets the 10-12 a reviewer hits on first navigation.
- **`accessibilityLiveRegion`** for loading states, toasts, in-app banners. Worth doing — separate scope.
- **TalkBack-specific Android QA.** React Native's accessibility API maps to both VoiceOver and TalkBack from the same prop set, so Android wins by default — but explicit Android testing is a follow-up.
- **Event RSVP / board reactions / post composer send buttons.** Next a11y PR.

## Verify

```bash
bash .ralph/verify.sh
```

- `git diff --check` ✅
- `npm run typecheck` ✅
- `npm run test:frontend` ✅ — 162 / 9
- `npm run test:backend` ✅ — 313 / 9
- `npm run build` ✅

## Manual smoke (worth doing post-merge)

1. iOS sim: Settings → Accessibility → VoiceOver → On.
2. Open the app, swipe right to step through controls.
3. Confirm each icon-only button announces a label (e.g. "Back", "Share this center", "Zoom in").

## Note on diff size

Two files (`center/[id].web.tsx`, `events/[id].web.tsx`) had mixed CRLF+LF line endings on v2 disk. The Edit tool normalized touched hunks to LF, which inflates the line counts to ~600 lines each. Actual semantic diff is **~30 added lines** of accessibility props.

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779924414991579