### PR TITLE
docs(deploy): point everything at project-janatha Pages (#165)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,11 @@ jobs:
           EXPO_PUBLIC_POSTHOG_HOST: ${{ secrets.EXPO_PUBLIC_POSTHOG_HOST }}
 
       - name: Deploy production frontend
-        run: npx wrangler pages deploy dist --project-name chinmaya-janata --branch __release
+        # CF Pages project name is `project-janatha`; custom domain
+        # chinmayajanata.org CNAMEs to project-janatha.pages.dev.
+        # The old `chinmaya-janata` Pages project is frozen; deploys here
+        # would silently no-op due to API token scoping. See #165.
+        run: npx wrangler pages deploy dist --project-name project-janatha --branch __release
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,11 +11,11 @@ The app runs as **two independent Cloudflare services**:
 
 ```
 Browser
-  ├── https://chinmaya-janata.pages.dev
-  │     └── Cloudflare Pages (static assets only)
+  ├── https://chinmayajanata.org  (CNAME → https://project-janatha.pages.dev)
+  │     └── Cloudflare Pages "project-janatha" (static assets only)
   │
-  └── https://chinmaya-janata-api.chinmayajanata.workers.dev/api/*
-        └── Cloudflare Worker (Hono API)
+  └── https://api.chinmayajanata.org/api/*
+        └── Cloudflare Worker "chinmaya-janata-api" (Hono)
               └── D1 database (SQLite)
 ```
 
@@ -117,7 +117,7 @@ npm run dev:frontend   # just the Expo dev server
 
 Configured in `packages/backend/wrangler.toml` (D1) and via `npx wrangler secret put` (secrets).
 
-### Frontend Pages (`chinmaya-janata`)
+### Frontend Pages (`project-janatha` — served behind `chinmayajanata.org`)
 
 | Variable                    | Type      | Description                             |
 |-----------------------------|-----------|-----------------------------------------|
@@ -139,5 +139,5 @@ GitHub Actions (`.github/workflows/deploy.yml`) runs two parallel jobs on push t
 ## Monitoring
 
 - **Backend** — Cloudflare Dashboard → Workers & Pages → chinmaya-janata-api → logs and analytics
-- **Frontend** — Cloudflare Dashboard → Workers & Pages → chinmaya-janata → deployments
+- **Frontend** — Cloudflare Dashboard → Workers & Pages → project-janatha → deployments (custom domain: chinmayajanata.org)
 - **D1** — Cloudflare Dashboard → Workers & Pages → D1 → chinmaya-janata-db → query browser

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -133,19 +133,24 @@ app.use(
   cors({
     origin: (origin) => {
       if (!origin) return '*'
+      // Canonical frontend = chinmayajanata.org (CNAME → project-janatha.pages.dev).
+      // The chinmaya-janata.pages.dev entries are the OLD Pages project — frozen,
+      // doesn't receive deploys, but kept in the allowlist as a safety net in case
+      // a stale link out there still routes there. See #165.
       const allowed = [
-        'https://chinmaya-janata.pages.dev',
         'https://chinmayajanata.org',
         'https://www.chinmayajanata.org',
+        'https://project-janatha.pages.dev',
         'https://main.project-janatha.pages.dev',
+        'https://chinmaya-janata.pages.dev', // legacy frozen project
         'http://localhost:8081',
         'http://localhost:8787',
         'http://localhost:19006',
       ]
       if (allowed.includes(origin)) return origin
       if (origin.startsWith('http://localhost:')) return origin
-      if (origin.endsWith('.chinmaya-janata.pages.dev')) return origin
       if (origin.endsWith('.project-janatha.pages.dev')) return origin
+      if (origin.endsWith('.chinmaya-janata.pages.dev')) return origin // legacy
       return ''
     },
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
Closes #165

## What

The active CF Pages project is **`project-janatha`** (custom domain `chinmayajanata.org` → CNAME). The old `chinmaya-janata.pages.dev` project is frozen and no longer receives deploys. The stale docs + workflow caused ~30 min of confusion during #164.

| File | Change |
|---|---|
| `docs/DEPLOYMENT.md` | Architecture diagram + Frontend Pages section + Monitoring section now name `project-janatha`. Custom domain `chinmayajanata.org` called out as the user-facing URL. |
| `.github/workflows/deploy.yml` | Production frontend step now `--project-name project-janatha`. The old name silently no-op'd because the API token is scoped to project-janatha. |
| `packages/backend/src/app.ts` | CORS allowlist reordered so `project-janatha.pages.dev` is canonical; `chinmaya-janata.pages.dev` flagged as legacy/safety-net. Both still match. |

## What's NOT changing

Backend `wrangler*.toml` files keep `chinmaya-janata-*` names — that's the worker, D1, R2 bucket. Per the issue: those are still correct, only the frontend Pages project moved.

## Verify

```bash
bash .ralph/verify.sh
```

All green. Real verification = next prod deploy lands on chinmayajanata.org correctly (which it already does — this PR just makes the workflow tell the truth about which project name it's targeting).

## Optional follow-up (Kish-only)

In CF dashboard: delete or archive the dormant `chinmaya-janata` Pages project so it can't accidentally serve stale content if someone manually re-uploads. Not blocking — the project is frozen and not in any rotation.

Evidence: pending — Slack permalink will be added by ralph-post-slack