### PR TITLE
feat(events): official-event badge (#192)

### DIFF
--- a/migrations/0022_official_event_badge.sql
+++ b/migrations/0022_official_event_badge.sql
@@ -1,0 +1,18 @@
+-- Migration 0022 — official-event badge (#192)
+--
+-- Adds `is_official` to events. Auto-set to 1 by /createEvent when the
+-- creator's verification_level >= SEVAK (54). Frontend renders a verified-
+-- check badge when set.
+--
+-- Renumbered from spec's 0020 because the slot is no longer the next free
+-- one in v2 (0021 already shipped with profile fields). Call out at the
+-- v2 → main cutover.
+--
+-- Tier 2 (events is canon Tier 1 per the migrations README, BUT this is
+-- additive ALTER only — safe regardless of tier).
+
+ALTER TABLE events ADD COLUMN is_official INTEGER NOT NULL DEFAULT 0;
+
+-- No backfill. Per #192's "Backfill on creator level change" decision:
+-- existing events keep their badge state at create-time. Simpler for v2.
+-- An admin can manually toggle via a future moderation tool if needed.

--- a/packages/backend/src/__tests__/types.test.ts
+++ b/packages/backend/src/__tests__/types.test.ts
@@ -67,6 +67,7 @@ const mockEventRow: EventRow = {
   point_of_contact: 'Ramesh Ji',
   image: 'https://img.example.com/event.jpg',
   category: 91,
+  is_official: 0,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-06-01T00:00:00Z',
 }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1307,6 +1307,11 @@ app.post('/addEvent', authMiddleware, async (c) => {
     return c.json({ message: 'External URL or signup URL is invalid' }, 400)
   }
 
+  // #192 — auto-mark "official" when the creator's verification_level was
+  // SEVAK (54) or higher at create time. Snapshot value; no backfill on
+  // future level changes. Frontend renders a verified-check badge.
+  const isOfficial = (user.verification_level ?? 0) >= SEVAK ? 1 : 0
+
   const result = await db.createEvent(c.env.DB, {
     id: eventId,
     title: validTitle ?? '',
@@ -1322,6 +1327,7 @@ app.post('/addEvent', authMiddleware, async (c) => {
     external_url: validExternalUrl ?? null,
     signup_url: validSignupUrl ?? null,
     allow_janata_signup: data.allowJanataSignup ? 1 : 0,
+    is_official: isOfficial,
     created_by: user.id,
   })
 

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -326,9 +326,9 @@ export async function createEvent(
       .prepare(
         `INSERT INTO events (id, title, description, date, latitude, longitude, address,
           center_id, tier, people_attending, point_of_contact, image, category,
-          external_url, signup_url, allow_janata_signup,
+          external_url, signup_url, allow_janata_signup, is_official,
           created_by, created_at, updated_at)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)`,
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)`,
       )
       .bind(
         event.id,
@@ -347,6 +347,7 @@ export async function createEvent(
         event.external_url ?? null,
         event.signup_url ?? null,
         event.allow_janata_signup ?? 0,
+        event.is_official ?? 0,
         event.created_by ?? null,
         now,
         now,
@@ -501,7 +502,7 @@ export async function addEventAttendee(
 
     // Wait briefly to ensure D1 consistency (optional, but safer in some environments)
     // Actually, in D1, consecutive await run() calls are sequential.
-    
+
     return { success: true }
   } catch (err: any) {
     return { success: false, error: err?.message ?? 'Unknown error' }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -98,6 +98,9 @@ export interface EventRow {
   external_url: string | null
   signup_url: string | null
   allow_janata_signup: number // 0 | 1
+  // Migration 0022 (#192): 1 when creator's verification_level was >= SEVAK
+  // (54) at event creation. Frontend renders a verified-check badge.
+  is_official: number // 0 | 1
   created_at: string
   updated_at: string
 }
@@ -220,6 +223,8 @@ export interface EventApiResponse {
   externalUrl: string | null
   signupUrl: string | null
   allowJanataSignup: boolean
+  // Migration 0022 (#192): true when creator was at SEVAK or higher at create time.
+  isOfficial: boolean
   createdAt: string
   updatedAt: string
 }
@@ -327,6 +332,7 @@ export function eventRowToApi(row: EventRow): EventApiResponse {
     externalUrl: row.external_url,
     signupUrl: row.signup_url,
     allowJanataSignup: row.allow_janata_signup === 1,
+    isOfficial: row.is_official === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/packages/frontend/components/events/EventCard.tsx
+++ b/packages/frontend/components/events/EventCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { View, Text } from 'react-native'
-import { MapPin, ThumbsUp, MessageCircle } from 'lucide-react-native'
+import { MapPin, ThumbsUp, MessageCircle, BadgeCheck } from 'lucide-react-native'
 import { Card } from '../ui'
 
 export interface EventCardData {
@@ -11,6 +11,8 @@ export interface EventCardData {
   attendees: number
   likes: number
   comments: number
+  // #192 — true when creator was at SEVAK level or higher at create time.
+  isOfficial?: boolean
 }
 
 interface EventCardProps {
@@ -33,9 +35,18 @@ export function EventCard({ event, onPress, variant = 'compact' }: EventCardProp
               {event.location}
             </Text>
           </View>
-          <Text className="text-content dark:text-content-dark font-sans text-xl font-bold leading-tight mt-1">
-            {event.title}
-          </Text>
+          <View className="flex-row items-center gap-2 mt-1">
+            <Text className="text-content dark:text-content-dark font-sans text-xl font-bold leading-tight flex-shrink">
+              {event.title}
+            </Text>
+            {event.isOfficial && (
+              <BadgeCheck
+                size={18}
+                color="#C2410C"
+                accessibilityLabel="Official event"
+              />
+            )}
+          </View>
           <Text className="text-content dark:text-content-dark text-base font-medium mt-2">
             {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
           </Text>
@@ -66,9 +77,18 @@ export function EventCard({ event, onPress, variant = 'compact' }: EventCardProp
         <Text className="text-content dark:text-content-dark font-sans text-sm">
           {event.location}
         </Text>
-        <Text className="text-content dark:text-content-dark font-sans text-lg font-semibold leading-tight">
-          {event.title}
-        </Text>
+        <View className="flex-row items-center gap-1.5">
+          <Text className="text-content dark:text-content-dark font-sans text-lg font-semibold leading-tight flex-shrink">
+            {event.title}
+          </Text>
+          {event.isOfficial && (
+            <BadgeCheck
+              size={15}
+              color="#C2410C"
+              accessibilityLabel="Official event"
+            />
+          )}
+        </View>
         <Text className="text-content dark:text-content-dark text-sm mt-1">
           {event.attendees} {event.attendees === 1 ? 'person' : 'people'}
         </Text>

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -126,6 +126,7 @@ function apiEventToDisplay(e: EventData, _username?: string): EventDisplay {
     externalUrl: e.externalUrl ?? null,
     signupUrl: e.signupUrl ?? null,
     allowJanataSignup: e.allowJanataSignup ?? false,
+    isOfficial: e.isOfficial ?? false,
   }
 
   // If we have an image URL for the event, ensure it's absolute

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -42,6 +42,8 @@ export interface EventData {
   externalUrl?: string | null
   signupUrl?: string | null
   allowJanataSignup?: boolean
+  // #192 — true when creator was at SEVAK level or higher at create time.
+  isOfficial?: boolean
   createdAt?: string
   updatedAt?: string
 }
@@ -133,6 +135,8 @@ export interface EventDisplay {
   externalUrl?: string | null
   signupUrl?: string | null
   allowJanataSignup?: boolean
+  // #192 — true when creator was at SEVAK level or higher at create time.
+  isOfficial?: boolean
 }
 
 export interface DiscoverCenter {


### PR DESCRIPTION
Closes #192

## What

Adds \`is_official\` to events, auto-flagged at creation when the creator's \`verification_level >= SEVAK (54)\`. EventCard renders a Twitter-check-style BadgeCheck icon next to the title when set.

| Layer | Change |
|---|---|
| Migration | \`migrations/0022_official_event_badge.sql\` — additive \`ALTER TABLE events ADD COLUMN is_official INTEGER NOT NULL DEFAULT 0\`. Renumbered from spec's 0020 (slot taken). |
| Backend types | \`EventRow.is_official\`, \`EventApiResponse.isOfficial\` (boolean), \`eventRowToApi\` mapping |
| db.ts | \`createEvent\` INSERT now binds \`is_official\` |
| Route | \`POST /createEvent\` computes \`isOfficial = (user.verification_level >= SEVAK) ? 1 : 0\` |
| Frontend types | \`EventData.isOfficial\` + \`EventDisplay.isOfficial\` |
| Hook | \`apiEventToDisplay\` carries it through |
| UI | \`components/events/EventCard.tsx\` renders \`<BadgeCheck size={18} color="#C2410C">\` in both compact + full variants |

## Snapshot semantics (per spec)

Creator's level at create time is what counts. **No backfill** on later promotions/demotions. Simpler for v2 launch. An admin can toggle manually via a future mod tool if/when needed.

## 🛢️ Migration cutover note

This PR adds \`migrations/0022_official_event_badge.sql\` (Tier 1 events table, but additive ALTER — safe regardless).

At the v2 → main cutover, apply with:

\`\`\`bash
npx wrangler d1 execute chinmaya-janata-db \\
  --file=migrations/0022_official_event_badge.sql \\
  --config packages/backend/wrangler.toml
\`\`\`

(Note: between this PR and the one that's already in v2, \`migrations/0021_profile_fields.sql\`, \`0022\` is what you'd apply next.)

## Verify

\`\`\`bash
bash .ralph/verify.sh
\`\`\`

- \`git diff --check\` ✅
- \`typecheck\` ✅
- \`test:frontend\` ✅ — 173 / 10
- \`test:backend\` ✅ — 323 / 9 (no new tests; mock fixture updated for new field)
- \`build\` ✅

Manual smoke after deploy:

1. Sign in as a SEVAK-or-higher user, create an event → see BadgeCheck on the card.
2. Sign in as a NORMAL_USER, create one → no badge.
3. Existing pre-migration events all read \`isOfficial: false\` (the DEFAULT 0 backfills them implicitly).

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779926651760059