### PR TITLE
fix(seo): JSON-LD as text child (was silently stripped by react-helmet)

### DIFF
--- a/packages/frontend/components/seo/SeoHead.tsx
+++ b/packages/frontend/components/seo/SeoHead.tsx
@@ -67,11 +67,16 @@ export function SeoHead({
       <meta name="twitter:description" content={desc} />
       <meta name="twitter:image" content={img} />
 
+      {/*
+        react-helmet-async (used by expo-router/head) doesn't propagate
+        `dangerouslySetInnerHTML` on script tags — the inline JSON has to
+        be passed as a text-node child for it to render in <head>. Caught
+        this via Playwright evidence capture on 5/27 when the JSON-LD
+        wasn't showing up in the live DOM despite the rest of the Head
+        tags rendering correctly.
+      */}
       {jsonLd ? (
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: jsonLd }}
-        />
+        <script type="application/ld+json">{jsonLd}</script>
       ) : null}
     </Head>
   )


### PR DESCRIPTION
## Bug

The JSON-LD \`<script>\` tags shipped in #253 were not actually rendering in the live \`<head>\`. Caught via Playwright DOM extraction on the local dev server:

\`\`\`bash
node .ralph/lib/extract-jsonld.mjs http://localhost:8081/landing \\
  http://localhost:8081/center/<id>
\`\`\`

Before this fix: 0 JSON-LD scripts on either page.
After this fix: full Organization JSON-LD on landing + ReligiousOrganization/LocalBusiness on center detail.

## Root cause

\`react-helmet-async\` (which \`expo-router/head\` wraps) doesn't propagate \`dangerouslySetInnerHTML\` on script tags. Other meta tags worked fine because they use HTML attributes, not innerHTML.

## Fix

```diff
- <script
-   type="application/ld+json"
-   dangerouslySetInnerHTML={{ __html: jsonLd }}
- />
+ <script type="application/ld+json">{jsonLd}</script>
```

Text-node children are the supported pattern for inline script content in react-helmet.

## Why the test suite didn't catch this

The 11 unit tests on \`buildCenterJsonLd\` / \`buildEventJsonLd\` / \`buildOrganizationJsonLd\` test the builder functions in isolation — they don't render \`<SeoHead>\` and inspect the resulting DOM. The integration gap is what Playwright caught.

A follow-up could add a smoke test: launch dev server → navigate to a route → assert \`document.head\` contains the expected JSON-LD. Not in this PR scope (the fix is one line).

## Verify

\`bash .ralph/verify.sh\` ✅ — 173 frontend / 332 backend / build green.

Manual:
\`\`\`bash
# With dev server running locally + at least one center seeded:
node .ralph/lib/extract-jsonld.mjs http://localhost:8081/landing
# → should see Organization JSON-LD block

node .ralph/lib/extract-jsonld.mjs http://localhost:8081/center/<id>
# → should see ReligiousOrganization+LocalBusiness JSON-LD with geo
\`\`\`

Evidence saved to \`.context/evidence/v2-merge-batch/seo-jsonld-extract.txt\` (53 lines, both pages).