### PR TITLE
feat(boards): surface pinned state in message mapping (#205)

### DIFF
--- a/packages/frontend/components/boards/liveBoard.ts
+++ b/packages/frontend/components/boards/liveBoard.ts
@@ -50,5 +50,8 @@ export function boardPostToMessage(post: BoardPostData): BoardMessage {
     attachmentLabel: post.imageUrl ? 'Image attachment' : undefined,
     reactions: post.reactions,
     replyCount: post.replyCount,
+    // #249 — surface the pinned state so ThreadPanel renders its "Pinned" pill
+    // + accent treatment for posts a sevak has pinned.
+    pinned: !!post.pinnedAt,
   }
 }


### PR DESCRIPTION
Maps `pinned: !!post.pinnedAt` in `boardPostToMessage` so the "Pinned" pill + accent treatment ThreadPanel already implements render for posts pinned via the #249 backend.

Small, correct, verified (`bash .ralph/verify.sh` → 173 frontend / 354 backend / build green).

## Why this is small + what's left
The remaining interactive Boards UI is a focused rebuild, not a wiring tweak, for two concrete reasons:
1. **Feed tab groups by source** (center/event labels). `GET /feed` returns a flat post list without source names, so the swap needs `buildFeedPosts` reworked + boardId→source resolution.
2. **`feed/[id].tsx` is mock-driven** (`centerBoards[0]`, synthetic IDs). Replies + pin + edit/delete actions need it rebuilt to fetch a real post + real replies first.

The backend (pin/reply/feed/edit/delete) and the API client (#270) are fully in v2. The interactive UI is the next focused pass.