### PR TITLE
feat(ios): universal links / associated domains for deep linking (#104)

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
-    "scheme": "myapp",
+    "scheme": "janata",
     "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/images/logo_with_text.png",
@@ -23,7 +23,24 @@
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION"
       ],
-      "package": "org.chinmayamission.janata"
+      "package": "org.chinmayamission.janata",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            { "scheme": "https", "host": "chinmayajanata.org", "pathPrefix": "/center" },
+            { "scheme": "https", "host": "chinmayajanata.org", "pathPrefix": "/events" },
+            { "scheme": "https", "host": "chinmayajanata.org", "pathPrefix": "/feed" },
+            { "scheme": "https", "host": "chinmayajanata.org", "pathPrefix": "/auth" },
+            { "scheme": "https", "host": "www.chinmayajanata.org", "pathPrefix": "/center" },
+            { "scheme": "https", "host": "www.chinmayajanata.org", "pathPrefix": "/events" },
+            { "scheme": "https", "host": "www.chinmayajanata.org", "pathPrefix": "/feed" },
+            { "scheme": "https", "host": "www.chinmayajanata.org", "pathPrefix": "/auth" }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "assetBundlePatterns": [
       "**/*"
@@ -38,7 +55,11 @@
         "NSCameraUsageDescription": "Chinmaya Janata needs access to your camera to take a profile picture.",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "bundleIdentifier": "org.chinmayamission.janata"
+      "bundleIdentifier": "org.chinmayamission.janata",
+      "associatedDomains": [
+        "applinks:chinmayajanata.org",
+        "applinks:www.chinmayajanata.org"
+      ]
     },
     "web": {
       "bundler": "metro",

--- a/packages/frontend/public/.well-known/apple-app-site-association
+++ b/packages/frontend/public/.well-known/apple-app-site-association
@@ -1,0 +1,16 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID.org.chinmayamission.janata",
+        "paths": [
+          "/center/*",
+          "/events/*",
+          "/feed/*",
+          "/auth/*"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/frontend/public/.well-known/assetlinks.json
+++ b/packages/frontend/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.chinmayamission.janata",
+      "sha256_cert_fingerprints": ["REPLACE_WITH_EAS_ANDROID_SHA256_FINGERPRINT"]
+    }
+  }
+]

--- a/packages/frontend/public/_headers
+++ b/packages/frontend/public/_headers
@@ -1,0 +1,8 @@
+# Cloudflare Pages headers
+# Serve the Apple App Site Association file as JSON. Apple requires the AASA
+# file at /.well-known/apple-app-site-association to be valid JSON over HTTPS
+# with no redirect; setting an explicit JSON content-type is best practice.
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+/.well-known/assetlinks.json
+  Content-Type: application/json


### PR DESCRIPTION
Closes #104.

## What
iOS Universal Links + Android App Links so shared content and auth/email links open the native app instead of the browser.

| File | Change |
|---|---|
| `packages/frontend/public/.well-known/apple-app-site-association` | NEW — AASA (extensionless, valid JSON). Claims `/center/*`, `/events/*`, `/feed/*`, `/auth/*` |
| `packages/frontend/public/.well-known/assetlinks.json` | NEW — Android Digital Asset Links |
| `packages/frontend/public/_headers` | NEW — CF Pages serves both `.well-known` files as `application/json` |
| `packages/frontend/app.json` | `ios.associatedDomains` (apex + `www`), `android.intentFilters` (`autoVerify` App Links, same paths/hosts), scheme `myapp` → `janata` |

## Why these paths
`/center/*` & `/events/*` are already our shareable links (CopyLinkButton + detail screens). `/feed/*` = board post detail. `/auth/*` = password-reset / forgot flow (the issue's primary driver). Marketing/legal pages stay on web.

## Verification
- `bash .ralph/verify.sh` → exit 0 (typecheck + frontend tests + backend tests + web build).
- Fresh `expo export` copies all three `public/.well-known` files + `_headers` into `dist/` → CF Pages serves them after deploy.
- All JSON validated with `jq`. `/review` (code-reviewer): clean, no high-confidence issues.

## ⚠️ Handoff before native build (cannot be done in this env — no EAS/signing)
- [ ] Replace `TEAMID` in `apple-app-site-association` with the **CCMT Apple Team ID** → `<TeamID>.org.chinmayamission.janata`
- [ ] Replace the placeholder SHA-256 in `assetlinks.json` with the EAS Android signing cert fingerprint (`eas credentials`)
- [ ] Deploy v2 frontend so `https://chinmayajanata.org/.well-known/apple-app-site-association` is live (HTTPS, no redirect)
- [ ] Native build + TestFlight: tap `https://chinmayajanata.org/center/<id>` → app opens to that screen
- [ ] (cleanup, separate) repo-root `app.json` is stale with bundleId `com.theabhiramr.project-janata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Evidence: https://projectjanata.slack.com/archives/C0B60Q0QHHV/p1779970666597509