### PR TITLE
feat(invites): multi-use invite links with cap + expiry (#272)

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -2523,13 +2523,55 @@ async function registerAsDeveloper(): Promise<{ token: string; user: any }> {
 }
 
 describe('POST /api/auth/invite-codes (mint)', () => {
-  it('verified user mints a single-use 30-day code', async () => {
+  it('verified user mints a multi-use code (default 25 uses / 7-day expiry)', async () => {
     const { token } = await registerAsDeveloper()
     const { res, body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
     expect(res.status).toBe(200)
     expect(body.code).toMatch(/^[0-9A-F]{12}$/)
     expect(body.shareUrl).toContain(body.code)
-    expect(new Date(body.expiresAt).getTime()).toBeGreaterThan(Date.now())
+    expect(body.maxUses).toBe(25)
+    const ttlDays = (new Date(body.expiresAt).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+    expect(ttlDays).toBeGreaterThan(6.9)
+    expect(ttlDays).toBeLessThan(7.1)
+  })
+
+  it('honors maxUses + expiresInDays overrides', async () => {
+    const { token } = await registerAsDeveloper()
+    const { res, body } = await jsonPost(
+      '/api/auth/invite-codes',
+      { maxUses: 3, expiresInDays: 2 },
+      authHeader(token),
+    )
+    expect(res.status).toBe(200)
+    expect(body.maxUses).toBe(3)
+    const ttlDays = (new Date(body.expiresAt).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+    expect(ttlDays).toBeGreaterThan(1.9)
+    expect(ttlDays).toBeLessThan(2.1)
+  })
+
+  it('clamps out-of-range overrides (maxUses to 100, expiry to 30 days)', async () => {
+    const { token } = await registerAsDeveloper()
+    const { body } = await jsonPost(
+      '/api/auth/invite-codes',
+      { maxUses: 9999, expiresInDays: 9999 },
+      authHeader(token),
+    )
+    expect(body.maxUses).toBe(100)
+    const ttlDays = (new Date(body.expiresAt).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+    expect(ttlDays).toBeLessThan(30.1)
+    expect(ttlDays).toBeGreaterThan(29.9)
+  })
+
+  it('rejects non-integer overrides with 400', async () => {
+    const { token } = await registerAsDeveloper()
+    const bad = await jsonPost('/api/auth/invite-codes', { maxUses: 2.5 }, authHeader(token))
+    expect(bad.res.status).toBe(400)
+    const bad2 = await jsonPost(
+      '/api/auth/invite-codes',
+      { expiresInDays: 'soon' as any },
+      authHeader(token),
+    )
+    expect(bad2.res.status).toBe(400)
   })
 
   it('rejects unverified user with 403', async () => {
@@ -2664,9 +2706,13 @@ describe('POST /api/auth/redeem-invite', () => {
     expect(body.message).toContain('Invalid')
   })
 
-  it('rejects already-consumed single-use codes with 401 (validate fails)', async () => {
+  it('rejects redemption of an exhausted (single-use) code with 409 exhausted', async () => {
     const { token: devToken } = await registerAsDeveloper()
-    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+    const { body: minted } = await jsonPost(
+      '/api/auth/invite-codes',
+      { maxUses: 1 },
+      authHeader(devToken),
+    )
 
     // First redemption: user A
     await jsonPost('/api/auth/register', { username: 'first@test.com', password: 'password123' })
@@ -2681,7 +2727,7 @@ describe('POST /api/auth/redeem-invite', () => {
     )
     expect(first.res.status).toBe(200)
 
-    // Second redemption attempt by user B should fail
+    // Second redemption attempt by user B should fail as exhausted
     await jsonPost('/api/auth/register', { username: 'second@test.com', password: 'password123' })
     const { body: authB } = await jsonPost('/api/auth/authenticate', {
       username: 'second@test.com',
@@ -2692,14 +2738,106 @@ describe('POST /api/auth/redeem-invite', () => {
       { code: minted.code },
       authHeader(authB.token),
     )
-    expect(second.res.status).toBe(401)
+    expect(second.res.status).toBe(409)
+    expect(second.body.reason).toBe('exhausted')
+  })
+
+  it('a multi-use code can be redeemed up to its cap, then is exhausted', async () => {
+    const { token: devToken } = await registerAsDeveloper()
+    const { body: minted } = await jsonPost(
+      '/api/auth/invite-codes',
+      { maxUses: 3 },
+      authHeader(devToken),
+    )
+
+    // Three distinct unverified users redeem successfully.
+    for (let i = 0; i < 3; i++) {
+      await jsonPost('/api/auth/register', {
+        username: `cap${i}@test.com`,
+        password: 'password123',
+      })
+      const { body: auth } = await jsonPost('/api/auth/authenticate', {
+        username: `cap${i}@test.com`,
+        password: 'password123',
+      })
+      const r = await jsonPost(
+        '/api/auth/redeem-invite',
+        { code: minted.code },
+        authHeader(auth.token),
+      )
+      expect(r.res.status).toBe(200)
+    }
+
+    // Fourth redemption is refused as exhausted.
+    await jsonPost('/api/auth/register', { username: 'cap3@test.com', password: 'password123' })
+    const { body: auth4 } = await jsonPost('/api/auth/authenticate', {
+      username: 'cap3@test.com',
+      password: 'password123',
+    })
+    const fourth = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: minted.code },
+      authHeader(auth4.token),
+    )
+    expect(fourth.res.status).toBe(409)
+    expect(fourth.body.reason).toBe('exhausted')
+  })
+
+  it('redeeming an expired code returns 410 expired, and records inviter attribution on success', async () => {
+    const { token: devToken, user: dev } = await registerAsDeveloper()
+    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+
+    // Force the code into the past.
+    await env.DB.prepare('UPDATE invite_codes SET expires_at = ? WHERE code = ?')
+      .bind('2000-01-01T00:00:00.000Z', minted.code)
+      .run()
+
+    await jsonPost('/api/auth/register', { username: 'expired@test.com', password: 'password123' })
+    const { body: auth } = await jsonPost('/api/auth/authenticate', {
+      username: 'expired@test.com',
+      password: 'password123',
+    })
+    const expired = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: minted.code },
+      authHeader(auth.token),
+    )
+    expect(expired.res.status).toBe(410)
+    expect(expired.body.reason).toBe('expired')
+
+    // A fresh code from the same minter records inviter attribution on the
+    // redeemer (users.invite_code → invite_codes.created_by_user_id = minter).
+    const { body: fresh } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+    await jsonPost('/api/auth/register', { username: 'attrib@test.com', password: 'password123' })
+    const { body: authAttrib } = await jsonPost('/api/auth/authenticate', {
+      username: 'attrib@test.com',
+      password: 'password123',
+    })
+    const ok = await jsonPost(
+      '/api/auth/redeem-invite',
+      { code: fresh.code },
+      authHeader(authAttrib.token),
+    )
+    expect(ok.res.status).toBe(200)
+    const row = await env.DB.prepare(
+      `SELECT ic.created_by_user_id AS inviter
+         FROM users u JOIN invite_codes ic ON ic.code = u.invite_code
+        WHERE u.username = ?`,
+    )
+      .bind('attrib@test.com')
+      .first<{ inviter: string }>()
+    expect(row?.inviter).toBe(dev.id)
   })
 })
 
 describe('POST /api/auth/register — invite code consume', () => {
   it('single-use code can only be redeemed once at signup', async () => {
     const { token: devToken } = await registerAsDeveloper()
-    const { body: minted } = await jsonPost('/api/auth/invite-codes', {}, authHeader(devToken))
+    const { body: minted } = await jsonPost(
+      '/api/auth/invite-codes',
+      { maxUses: 1 },
+      authHeader(devToken),
+    )
 
     const a = await jsonPost('/api/auth/register', {
       username: 'racea@test.com',

--- a/packages/backend/src/__tests__/inviteCodes.test.ts
+++ b/packages/backend/src/__tests__/inviteCodes.test.ts
@@ -331,4 +331,65 @@ describe('Invite Codes Module', () => {
       expect(api.isActive).toBe(false)
     })
   })
+
+  describe('clampMaxUses / clampTtlDays (#272)', () => {
+    it('clamps maxUses into [1, 100]', () => {
+      expect(inviteCodes.clampMaxUses(0)).toBe(1)
+      expect(inviteCodes.clampMaxUses(-5)).toBe(1)
+      expect(inviteCodes.clampMaxUses(25)).toBe(25)
+      expect(inviteCodes.clampMaxUses(100)).toBe(100)
+      expect(inviteCodes.clampMaxUses(9999)).toBe(100)
+      expect(inviteCodes.clampMaxUses(2.9)).toBe(2) // floored
+    })
+
+    it('clamps ttl days into [1, 30]', () => {
+      expect(inviteCodes.clampTtlDays(0)).toBe(1)
+      expect(inviteCodes.clampTtlDays(7)).toBe(7)
+      expect(inviteCodes.clampTtlDays(30)).toBe(30)
+      expect(inviteCodes.clampTtlDays(9999)).toBe(30)
+    })
+  })
+
+  describe('classifyInviteCode (#272)', () => {
+    const baseRow = (over: Record<string, any>) => ({
+      code: 'MULTI001',
+      label: 'multi',
+      verification_level: 45,
+      is_active: 1,
+      created_at: '2026-04-07T00:00:00Z',
+      created_by_user_id: 'u1',
+      expires_at: null,
+      max_uses: 25,
+      uses_count: 0,
+      ...over,
+    })
+    const now = new Date('2026-05-28T00:00:00Z')
+
+    it('returns not_found for a missing code', async () => {
+      expect(await inviteCodes.classifyInviteCode(env, 'NOPE', now)).toBe('not_found')
+    })
+
+    it('returns inactive for a deactivated code', async () => {
+      ;(env.DB as any).setData('MULTI001', baseRow({ is_active: 0 }))
+      expect(await inviteCodes.classifyInviteCode(env, 'multi001', now)).toBe('inactive')
+    })
+
+    it('returns expired when past expires_at', async () => {
+      ;(env.DB as any).setData('MULTI001', baseRow({ expires_at: '2026-05-01T00:00:00Z' }))
+      expect(await inviteCodes.classifyInviteCode(env, 'MULTI001', now)).toBe('expired')
+    })
+
+    it('returns exhausted when uses_count >= max_uses', async () => {
+      ;(env.DB as any).setData('MULTI001', baseRow({ max_uses: 3, uses_count: 3 }))
+      expect(await inviteCodes.classifyInviteCode(env, 'MULTI001', now)).toBe('exhausted')
+    })
+
+    it('returns ok for an active, in-window, non-exhausted code', async () => {
+      ;(env.DB as any).setData(
+        'MULTI001',
+        baseRow({ expires_at: '2026-06-30T00:00:00Z', max_uses: 25, uses_count: 4 }),
+      )
+      expect(await inviteCodes.classifyInviteCode(env, 'MULTI001', now)).toBe('ok')
+    })
+  })
 })

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -247,13 +247,18 @@ app.post('/auth/validate-invite-code', rateLimit(10, 60_000), async (c) => {
     return c.json({ valid: false, error: 'Invite code is required' }, 400)
   }
 
-  const code = await inviteCodes.validateInviteCode(c.env, body.code)
-
-  if (code) {
+  const status = await inviteCodes.classifyInviteCode(c.env, body.code)
+  if (status === 'ok') {
     return c.json({ valid: true })
   }
 
-  return c.json({ valid: false, error: 'Invalid or inactive invite code' })
+  const messages: Record<Exclude<inviteCodes.InviteCodeStatus, 'ok'>, string> = {
+    not_found: 'Invalid or inactive invite code',
+    inactive: 'This invite link has been deactivated',
+    expired: 'This invite link has expired',
+    exhausted: 'This invite link has reached its maximum number of uses',
+  }
+  return c.json({ valid: false, error: messages[status], reason: status })
 })
 
 app.post('/auth/register', rateLimit(5, 60_000), async (c) => {
@@ -609,7 +614,23 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
     return c.json({ message: 'Only verified users can issue invite codes' }, 403)
   }
 
-  const result = await inviteCodes.mintUserInviteCode(c.env, user.id)
+  const body = await c.req
+    .json<{ maxUses?: number; expiresInDays?: number }>()
+    .catch(() => ({}) as { maxUses?: number; expiresInDays?: number })
+
+  // Optional overrides; out-of-range values are clamped in the lib, but reject
+  // non-integers so a typo doesn't silently fall back to the default.
+  if (body.maxUses !== undefined && !Number.isInteger(body.maxUses)) {
+    return c.json({ message: 'maxUses must be an integer' }, 400)
+  }
+  if (body.expiresInDays !== undefined && !Number.isInteger(body.expiresInDays)) {
+    return c.json({ message: 'expiresInDays must be an integer' }, 400)
+  }
+
+  const result = await inviteCodes.mintUserInviteCode(c.env, user.id, {
+    maxUses: body.maxUses,
+    expiresInDays: body.expiresInDays,
+  })
   if (!result.success) {
     console.error('mintUserInviteCode error:', result.error)
     return c.json({ message: 'Failed to mint invite code' }, 500)
@@ -618,6 +639,7 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
   return c.json({
     code: result.code,
     expiresAt: result.expiresAt,
+    maxUses: result.maxUses,
     shareUrl: `${INVITE_SHARE_URL_BASE}?code=${result.code}`,
   })
 })
@@ -648,23 +670,40 @@ app.post('/auth/redeem-invite', rateLimit(5, 60_000), authMiddleware, async (c) 
     return c.json({ message: 'Invite code is required' }, 400)
   }
 
-  const validated = await inviteCodes.validateInviteCode(c.env, body.code)
-  if (!validated) {
-    return c.json({ message: 'Invalid, expired, or fully redeemed invite code' }, 401)
+  // Fetch once and both classify (for a specific error: expired vs exhausted
+  // vs deactivated) and consume off the same row. The atomic guard in
+  // consumeInviteCode is what actually prevents over-redemption under load.
+  const codeRow = await inviteCodes.getInviteCode(c.env, body.code)
+  const status = inviteCodes.classifyInviteCodeRow(codeRow)
+  if (status !== 'ok' || !codeRow) {
+    const reasons: Record<
+      Exclude<inviteCodes.InviteCodeStatus, 'ok'>,
+      { message: string; code: 401 | 403 | 409 | 410 }
+    > = {
+      not_found: { message: 'Invalid invite code', code: 401 },
+      inactive: { message: 'This invite link has been deactivated', code: 403 },
+      expired: { message: 'This invite link has expired', code: 410 },
+      exhausted: { message: 'This invite link has reached its maximum number of uses', code: 409 },
+    }
+    const r = reasons[status === 'ok' ? 'not_found' : status]
+    return c.json({ message: r.message, reason: status === 'ok' ? 'not_found' : status }, r.code)
   }
 
-  const consumed = await inviteCodes.consumeInviteCode(c.env, validated.code)
+  const consumed = await inviteCodes.consumeInviteCode(c.env, codeRow.code)
   if (!consumed) {
-    // Race: someone else consumed it between validate and consume.
-    return c.json({ message: 'Invite code already redeemed or expired' }, 409)
+    // Race: the last remaining use was taken between classify and consume.
+    return c.json(
+      { message: 'This invite link has reached its maximum number of uses', reason: 'exhausted' },
+      409,
+    )
   }
 
   // Record the code on the user. If email is already verified, apply the
   // promotion now. Otherwise the bump happens at email-verify.
-  const updates: Partial<UserRow> = { invite_code: validated.code }
+  const updates: Partial<UserRow> = { invite_code: codeRow.code }
   let promoted = false
-  if (user.email_verified_at && user.verification_level < validated.verification_level) {
-    updates.verification_level = validated.verification_level
+  if (user.email_verified_at && user.verification_level < codeRow.verification_level) {
+    updates.verification_level = codeRow.verification_level
     promoted = true
   }
   await db.updateUser(c.env.DB, user.id, updates)

--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -6,8 +6,9 @@
  * Invite code management. Supports two flavors against the same table:
  *   - Admin cohort codes (created via createInviteCode): multi-use,
  *     no expiry. Used for batch beta seeding.
- *   - User-issued single-use links (created via mintUserInviteCode,
- *     v2): one consumption, 30-day expiry, tied to a creator.
+ *   - User-issued multi-use links (created via mintUserInviteCode,
+ *     v2): default 25 uses / 7-day expiry (adjustable + clamped),
+ *     tied to a creator. maxUses=1 gives the legacy single-use link.
  *
  * See docs/plans/2026-05-05-v2-roles-invites-messaging.md §5.A.
  */
@@ -15,8 +16,27 @@
 import type { Env, InviteCodeRow } from './types'
 import { ADMIN_CUTOFF, NORMAL_USER } from './constants'
 
-const USER_INVITE_TTL_MS = 30 * 24 * 60 * 60 * 1000
 const USER_INVITE_CODE_BYTES = 6 // 12 hex chars
+
+// v2 multi-use defaults (#272): an acharya hands one link to a group.
+// Single-use (maxUses=1) stays valid — this just changes the default.
+export const USER_INVITE_DEFAULT_MAX_USES = 25
+export const USER_INVITE_DEFAULT_TTL_DAYS = 7
+// Acharya-adjustable, but clamped so a single link can't seed unbounded signups.
+export const USER_INVITE_MAX_USES_LIMIT = 100
+export const USER_INVITE_MAX_TTL_DAYS = 30
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Clamp a requested max-use cap into [1, USER_INVITE_MAX_USES_LIMIT]. */
+export function clampMaxUses(value: number): number {
+  return Math.max(1, Math.min(USER_INVITE_MAX_USES_LIMIT, Math.floor(value)))
+}
+
+/** Clamp a requested TTL into [1, USER_INVITE_MAX_TTL_DAYS] days. */
+export function clampTtlDays(value: number): number {
+  return Math.max(1, Math.min(USER_INVITE_MAX_TTL_DAYS, Math.floor(value)))
+}
 
 const SELECT_COLUMNS = `code, label, verification_level, is_active, created_at,
   created_by_user_id, expires_at, max_uses, uses_count`
@@ -77,6 +97,42 @@ export async function getInviteCode(
 }
 
 /**
+ * Why a redemption would be refused. `ok` means the code is currently
+ * redeemable. Used to give the user a specific error (expired vs exhausted
+ * vs deactivated) instead of one lumped "invalid" message (#272).
+ */
+export type InviteCodeStatus = 'ok' | 'not_found' | 'inactive' | 'expired' | 'exhausted'
+
+/**
+ * Pure classifier over an already-fetched row. Lets a caller fetch once and
+ * both classify and consume off the same row (avoids a redundant query and
+ * a misleading status if the row changes between two reads).
+ */
+export function classifyInviteCodeRow(
+  row: InviteCodeRow | null,
+  now: Date = new Date(),
+): InviteCodeStatus {
+  if (!row) return 'not_found'
+  if (row.is_active !== 1) return 'inactive'
+  if (row.expires_at && new Date(row.expires_at) <= now) return 'expired'
+  if (row.max_uses !== null && row.uses_count >= row.max_uses) return 'exhausted'
+  return 'ok'
+}
+
+/**
+ * Classify a code's current redeemability. This is for human-facing error
+ * copy on the non-contended path; the atomic guard in consumeInviteCode is
+ * still what prevents over-redemption under concurrency.
+ */
+export async function classifyInviteCode(
+  env: Env,
+  code: string,
+  now: Date = new Date(),
+): Promise<InviteCodeStatus> {
+  return classifyInviteCodeRow(await getInviteCode(env, code), now)
+}
+
+/**
  * Create an admin cohort code (multi-use, no expiry).
  * Used for batch beta seeding via admin endpoints.
  */
@@ -114,14 +170,30 @@ export async function createInviteCode(
   }
 }
 
+export interface MintInviteOptions {
+  /** Max redemptions. Clamped to [1, 100]. Defaults to 25. */
+  maxUses?: number
+  /** Days until expiry. Clamped to [1, 30]. Defaults to 7. */
+  expiresInDays?: number
+}
+
 /**
- * Mint a single-use, 30-day-expiry invite link tied to a user.
- * Promotes the recipient to NORMAL_USER on redemption.
+ * Mint a multi-use invite link tied to a user (#272). Defaults to 25 uses /
+ * 7-day expiry; the minter may pass a smaller/larger cap and expiry (clamped).
+ * Redemption promotes the recipient to NORMAL_USER. Pass `{ maxUses: 1 }` for
+ * the legacy single-use behavior.
  */
 export async function mintUserInviteCode(
   env: Env,
   userId: string,
-): Promise<{ success: true; code: string; expiresAt: string } | { success: false; error: string }> {
+  options: MintInviteOptions = {},
+): Promise<
+  | { success: true; code: string; expiresAt: string; maxUses: number }
+  | { success: false; error: string }
+> {
+  const maxUses = clampMaxUses(options.maxUses ?? USER_INVITE_DEFAULT_MAX_USES)
+  const ttlDays = clampTtlDays(options.expiresInDays ?? USER_INVITE_DEFAULT_TTL_DAYS)
+
   // Random 12-char hex code. Collision space is 2^48 ≈ 2.8e14, plenty for
   // user-issued links. Retry up to 3 times in the (vanishingly rare) case
   // of a collision against an existing code.
@@ -133,7 +205,7 @@ export async function mintUserInviteCode(
       .join('')
       .toUpperCase()
 
-    const expiresAt = new Date(Date.now() + USER_INVITE_TTL_MS).toISOString()
+    const expiresAt = new Date(Date.now() + ttlDays * DAY_MS).toISOString()
     const now = new Date().toISOString()
 
     try {
@@ -141,11 +213,11 @@ export async function mintUserInviteCode(
         `INSERT INTO invite_codes
            (code, label, verification_level, is_active, created_at,
             created_by_user_id, expires_at, max_uses, uses_count)
-         VALUES (?, ?, ?, 1, ?, ?, ?, 1, 0)`,
+         VALUES (?, ?, ?, 1, ?, ?, ?, ?, 0)`,
       )
-        .bind(code, `User invite from ${userId}`, NORMAL_USER, now, userId, expiresAt)
+        .bind(code, `User invite from ${userId}`, NORMAL_USER, now, userId, expiresAt, maxUses)
         .run()
-      return { success: true, code, expiresAt }
+      return { success: true, code, expiresAt, maxUses }
     } catch (error: any) {
       const message = String(error?.message || '')
       if (message.includes('UNIQUE') || message.includes('PRIMARY KEY')) {

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -3,7 +3,8 @@
  *
  * Client for the v2 user-issued invite code endpoints.
  *
- *   - mintCode: verified user creates a single-use 30-day code to share
+ *   - mintCode: verified user creates a multi-use code to share (default
+ *     25 uses / 7-day expiry; adjustable, or maxUses=1 for single-use)
  *   - listMyCodes: list codes the current user has minted
  *   - redeem: an Unverified user redeems a code post-signup (the signup
  *     path itself takes the code in /auth/register)
@@ -71,7 +72,15 @@ const safeJson = async <T>(response: Response): Promise<T | null> => {
 export interface MintedInviteCode {
   code: string
   expiresAt: string
+  maxUses: number
   shareUrl: string
+}
+
+export interface MintInviteOptions {
+  /** Max redemptions. Server clamps to [1, 100]. Defaults to 25. */
+  maxUses?: number
+  /** Days until expiry. Server clamps to [1, 30]. Defaults to 7. */
+  expiresInDays?: number
 }
 
 export interface MintedCodeListEntry {
@@ -94,16 +103,22 @@ export interface RedeemResponse extends GenericSuccessResponse {
 
 export const inviteClient = {
   /**
-   * Mint a new single-use, 30-day-expiry invite code tied to the caller.
-   * Requires verification_level >= NORMAL_USER (45) server-side.
+   * Mint a new multi-use invite code tied to the caller. Defaults to 25 uses
+   * / 7-day expiry; pass `options` to adjust (server clamps maxUses to
+   * [1, 100] and expiresInDays to [1, 30]). Pass `{ maxUses: 1 }` for a
+   * single-use link. Requires verification_level >= NORMAL_USER (45) server-side.
    */
-  async mintCode(token: string): AsyncResult<MintedInviteCode> {
+  async mintCode(token: string, options: MintInviteOptions = {}): AsyncResult<MintedInviteCode> {
     try {
       const response = await withTimeout(
         buildUrl('/auth/invite-codes'),
         {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            ...(options.maxUses !== undefined ? { maxUses: options.maxUses } : {}),
+            ...(options.expiresInDays !== undefined ? { expiresInDays: options.expiresInDays } : {}),
+          }),
         },
         API_TIMEOUTS.standard,
       )
@@ -119,7 +134,12 @@ export const inviteClient = {
 
       return {
         success: true,
-        data: { code: data.code, expiresAt: data.expiresAt, shareUrl: data.shareUrl },
+        data: {
+          code: data.code,
+          expiresAt: data.expiresAt,
+          maxUses: data.maxUses,
+          shareUrl: data.shareUrl,
+        },
       }
     } catch (error: any) {
       if (error?.name === 'AbortError') {
@@ -183,12 +203,16 @@ export const inviteClient = {
         API_TIMEOUTS.standard,
       )
 
-      const data = await safeJson<RedeemResponse>(response)
+      const data = await safeJson<RedeemResponse & { reason?: string }>(response)
 
       if (!response.ok || !data?.user) {
         return {
           success: false,
-          error: toError(data?.message || 'Failed to redeem invite code', response.status),
+          error: toError(
+            data?.message || 'Failed to redeem invite code',
+            response.status,
+            data?.reason,
+          ),
         }
       }
 


### PR DESCRIPTION
Closes #272.

## What
Extends user-issued invite codes (#221) from single-use to **multi-use with a max-use cap + expiry**. Standard private-community model (Discord/Slack).

**No migration** — `max_uses`/`uses_count`/`expires_at` already exist (migration 0017) and `validateInviteCode`/`consumeInviteCode` already enforce them atomically.

## Changes
- `mintUserInviteCode(env, userId, { maxUses?, expiresInDays? })` — default **25 uses / 7-day expiry** (was single-use/30-day), clamped to `[1,100]` / `[1,30]` days. `maxUses: 1` = legacy single-use.
- `POST /auth/invite-codes` accepts optional `maxUses`/`expiresInDays` (non-integer → 400), returns `maxUses`.
- `POST /auth/redeem-invite` — distinct, machine-readable reasons: `not_found`→401, `inactive`→403, `expired`→410, `exhausted`→409. Single fetch → pure classify → atomic consume (last-use race → 409 exhausted).
- `POST /auth/validate-invite-code` returns a `reason` for clear signup-time copy.
- `inviteClient.ts` (shared client method): `mintCode(token, options?)` + returns `maxUses`; redeem threads `reason`. `MintedCodeListEntry` already exposes `maxUses`/`usesCount`/`isUsable` for the "N uses left" mockup → Lane B can build the UI.
- Inviter attribution unchanged (`users.invite_code` → `created_by_user_id`), now tested.

## ⚠️ Behavior change to eyeball (why this is BIG)
A freshly minted link is now **multi-use (25/7)** by default instead of single-use. Admin cohort codes (`max_uses=NULL`) and the `/auth/register` consume path are unaffected.

## Assumption (adjustable)
Any Verified+ minter may set a custom cap/expiry (clamped) — acharyas are the use case, not a hard permission gate. Single-use still supported via `maxUses:1`.

## Verification
- `bash .ralph/verify.sh` → exit 0: 366 backend + 173 frontend tests, typecheck, web build.
- New integration tests (real D1): default 25/7, overrides, clamping, non-integer→400, multi-use cap exhaustion, single-use, expired→410, inviter attribution. Unit tests: clamps + all 5 classify statuses.
- `/review`: backward-compat + atomicity confirmed; fixed the one flagged issue (dropped a redundant validate that could mislabel a rare race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)