### PR TITLE
fix(backend/test): strip SQL comments before splitting migrations on ';'

### DIFF
--- a/packages/backend/src/__tests__/setup.test.ts
+++ b/packages/backend/src/__tests__/setup.test.ts
@@ -1,0 +1,65 @@
+/**
+ * setup.test.ts — Unit tests for the migration-parsing helpers in setup.ts.
+ *
+ * Regression guard: a `;` inside a `--` comment must not break statement
+ * boundaries. Stripping comments before splitting on `;` is what prevents
+ * the following CREATE TABLE from losing its head and being dropped.
+ */
+import { describe, it, expect } from 'vitest'
+import { extractSchemaStatements, stripSqlComments } from './setup'
+
+describe('stripSqlComments', () => {
+  it('removes -- line comments, including any semicolons inside them', () => {
+    const sql = `CREATE TABLE a (id TEXT); -- drop this; and this
+CREATE TABLE b (id TEXT);`
+    const out = stripSqlComments(sql)
+    expect(out).not.toContain('drop this')
+    expect(out).toContain('CREATE TABLE a')
+    expect(out).toContain('CREATE TABLE b')
+  })
+
+  it('removes /* */ block comments spanning lines', () => {
+    const sql = `/* header;
+ with a semicolon */
+CREATE TABLE a (id TEXT);`
+    const out = stripSqlComments(sql)
+    expect(out).not.toContain('header')
+    expect(out).toContain('CREATE TABLE a')
+  })
+})
+
+describe('extractSchemaStatements', () => {
+  it('still yields correct CREATE TABLE statements when a -- comment contains a semicolon', () => {
+    const sql = `
+-- migration 0024: add boards; backfill later
+CREATE TABLE IF NOT EXISTS boards (
+  id    TEXT PRIMARY KEY,
+  title TEXT NOT NULL
+);
+
+-- note: this index matters; keep it
+CREATE INDEX IF NOT EXISTS idx_boards_title ON boards(title);
+`
+    const statements = extractSchemaStatements(sql)
+    expect(statements).toHaveLength(2)
+    expect(statements[0]).toMatch(/^CREATE TABLE IF NOT EXISTS boards/)
+    expect(statements[0]).toContain('title TEXT NOT NULL')
+    expect(statements[1]).toMatch(/^CREATE INDEX IF NOT EXISTS idx_boards_title/)
+  })
+
+  it('drops INSERT/UPDATE seed statements and strips FK clauses', () => {
+    const sql = `
+CREATE TABLE users (
+  id          TEXT PRIMARY KEY,
+  invite_code TEXT REFERENCES invite_codes(code) ON DELETE SET NULL
+);
+INSERT INTO users (id) VALUES ('u-1');
+UPDATE users SET id = 'u-2';
+`
+    const statements = extractSchemaStatements(sql)
+    expect(statements).toHaveLength(1)
+    expect(statements[0]).toContain('CREATE TABLE users')
+    expect(statements[0]).not.toContain('REFERENCES')
+    expect(statements[0]).not.toContain('ON DELETE')
+  })
+})

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -34,23 +34,25 @@ function stripForeignKeys(stmt: string): string {
 }
 
 /**
+ * Strip block comments and line comments from SQL. Must run BEFORE splitting
+ * on `;` — a `;` inside a comment would otherwise land mid-comment and chop
+ * the following statement's head, dropping it.
+ */
+export function stripSqlComments(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n]*/g, '')
+}
+
+/**
  * Split a migration file into individual statements, keeping only schema
  * ones (CREATE/ALTER/DROP TABLE/INDEX). Comments and blank lines are
  * dropped. INSERT/UPDATE statements (seed data) are skipped.
  */
-function extractSchemaStatements(sql: string): string[] {
-  return sql
+export function extractSchemaStatements(sql: string): string[] {
+  return stripSqlComments(sql)
     .split(';')
     .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    // Strip leading -- comments inside each statement so we can match the head
-    .map((s) =>
-      s
-        .split('\n')
-        .filter((line) => !line.trim().startsWith('--'))
-        .join('\n')
-        .trim(),
-    )
     .filter((s) => s.length > 0)
     .filter((s) => {
       const head = s.slice(0, 60).toUpperCase()


### PR DESCRIPTION
## Summary

`setup.ts` applies the real D1 migrations to the cloudflare:test DB by doing `sql.split(';')` and *then* stripping `--` comment lines per chunk. If any migration has a `;` inside a `--` (or block) comment, the split lands mid-comment: the following `CREATE TABLE` loses its leading lines, fails the schema-head filter, and is silently dropped. The result is that **every** backend test fails with a confusing `no such table` error in `applyMigration`.

This bug cost a full debug loop on 2026-05-28 while building #209's migration 0024.

## Fix

- Add `stripSqlComments()` that removes `/* */` block comments and `--` line comments from the **full** SQL, and run it *before* `split(';')` in `extractSchemaStatements()`. A `;` inside a comment can no longer break statement boundaries.
- Existing FK-stripping and INSERT/UPDATE-dropping behavior is unchanged.
- Export `extractSchemaStatements` / `stripSqlComments` so they can be unit-tested.

## Regression test

New `setup.test.ts` covers:
- A `;` inside a `--` comment still yields the correct `CREATE TABLE` / `CREATE INDEX` statements.
- Block comments spanning lines are stripped.
- INSERT/UPDATE seed statements are dropped and FK clauses stripped.

## Test plan

- [x] `npm run test:backend` — 10 files, 370 tests pass
- [x] `npm run typecheck` (backend) clean

Backend-test-infra only (Lane A); small and isolated.

---
_Generated by [Claude Code](https://claude.ai/code/session_016EzQgg3kWHer5jQZ775jkq)_