### PR TITLE
feat(boards): real replies + working reply composer in post detail (#206)

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -25,9 +25,9 @@ import {
   NativeChatHeader,
   FeedWorkspace,
   PostThread,
-  type FeedPost,
   type GroupBoard,
 } from '../../components/feed'
+import { buildFeedPosts } from '../../components/feed/feedData'
 import type { DiscoverCenter, EventDisplay } from '../../utils/api'
 
 function formatEventDateLabel(date: string) {
@@ -135,30 +135,6 @@ function sortGroupsByDistance(groups: GroupBoard[]) {
 
 function matchesQuery(value: string, query: string) {
   return value.toLowerCase().includes(query.toLowerCase().trim())
-}
-
-function buildFeedPosts(groups: GroupBoard[]): FeedPost[] {
-  const posts = groups.flatMap((group) =>
-    group.messages.map((message) => {
-      const replies = group.messages.filter((candidate) => candidate.id !== message.id)
-      return {
-        ...message,
-        id: `${group.id}-${message.id}`,
-        sourceLabel: group.title,
-        sourceKind: group.kind,
-        sourceTitle: group.title,
-        sourceSubtitle: group.subtitle,
-        groupId: group.id,
-        groupKind: group.kind,
-        replyMessages: replies.slice(0, Math.max(message.replyCount ?? 2, 1)),
-      }
-    })
-  )
-
-  return posts.sort((a, b) => {
-    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
-    return a.id < b.id ? 1 : -1
-  })
 }
 
 export default function FeedScreen() {

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -1,9 +1,12 @@
-import React from 'react'
-import { ScrollView, Text, TextInput, View } from 'react-native'
+import React, { useEffect, useRef, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Send } from 'lucide-react-native'
 import { Avatar } from '../ui'
+import { useUser } from '../contexts'
 import type { AppColors } from '../../tokens'
-import type { BoardMessage } from '../boards'
+import { boardPostToMessage, type BoardMessage } from '../boards'
+import { createBoardPostReply, fetchBoardPostReplies } from '../../utils/api'
+import { authorFromUser, optimisticReply } from './feedData'
 import type { FeedPost } from './types'
 
 export function PostThread({
@@ -17,10 +20,73 @@ export function PostThread({
   fullScreen?: boolean
   bottomInset?: number
 }) {
-  const replies = post.replyMessages.slice(
-    0,
-    Math.max(post.replyCount ?? post.replyMessages.length, 1)
-  )
+  const { user } = useUser()
+  const author = authorFromUser(user)
+  const [replies, setReplies] = useState<BoardMessage[]>([])
+  const [loadingReplies, setLoadingReplies] = useState(true)
+  const [repliesLoaded, setRepliesLoaded] = useState(false)
+  const [repliesError, setRepliesError] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  const [sending, setSending] = useState(false)
+  const [sendError, setSendError] = useState<string | null>(null)
+  const reloadKey = useRef(0)
+
+  const loadReplies = () => {
+    reloadKey.current += 1
+    const requestId = reloadKey.current
+    setLoadingReplies(true)
+    setRepliesError(null)
+    fetchBoardPostReplies(post.postId)
+      .then((raw) => {
+        if (requestId !== reloadKey.current) return
+        setReplies(raw.map(boardPostToMessage))
+        setRepliesLoaded(true)
+      })
+      .catch((err: any) => {
+        if (requestId !== reloadKey.current) return
+        setRepliesError(err?.message || 'Could not load replies.')
+      })
+      .finally(() => {
+        if (requestId !== reloadKey.current) return
+        setLoadingReplies(false)
+      })
+  }
+
+  useEffect(() => {
+    loadReplies()
+    // Reset composer when switching between posts.
+    setDraft('')
+    setSendError(null)
+    setRepliesLoaded(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [post.postId])
+
+  const handleSend = async () => {
+    const body = draft.trim()
+    if (!body || sending) return
+    const tempId = `temp-${Date.now()}`
+    const pending = optimisticReply(user, body, tempId)
+    setReplies((prev) => [...prev, pending])
+    setDraft('')
+    setSendError(null)
+    setSending(true)
+    try {
+      const created = await createBoardPostReply(post.postId, body)
+      setReplies((prev) => prev.map((r) => (r.id === tempId ? boardPostToMessage(created) : r)))
+      setRepliesLoaded(true)
+    } catch (err: any) {
+      // Roll back the optimistic reply and give the user their text back.
+      setReplies((prev) => prev.filter((r) => r.id !== tempId))
+      setDraft(body)
+      setSendError(err?.message || 'Reply failed to send. Try again.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  // Until replies load, trust the post's own count instead of showing 0.
+  const replyCountLabel = repliesLoaded ? replies.length : (post.replyCount ?? 0)
+
   const content = (
     <View
       style={{
@@ -48,17 +114,66 @@ export function PostThread({
             color: colors.textFaint,
           }}
         >
-          {replies.length} {replies.length === 1 ? 'REPLY' : 'REPLIES'}
+          {replyCountLabel} {replyCountLabel === 1 ? 'REPLY' : 'REPLIES'}
         </Text>
         <View style={{ flex: 1, height: 1, backgroundColor: colors.border }} />
       </View>
 
-      <View style={{ gap: 16 }}>
-        {replies.map((reply) => (
-          <PostMessageBlock key={reply.id} message={reply} colors={colors} />
-        ))}
-      </View>
+      {repliesError ? (
+        <View style={{ paddingVertical: 12, gap: 8, alignItems: 'flex-start' }}>
+          <Text style={{ fontSize: 13, color: colors.textMuted }}>{repliesError}</Text>
+          <Pressable
+            onPress={loadReplies}
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading replies"
+            style={{
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: colors.border,
+              paddingHorizontal: 12,
+              paddingVertical: 6,
+            }}
+          >
+            <Text style={{ fontSize: 13, color: colors.accent }}>Retry</Text>
+          </Pressable>
+        </View>
+      ) : loadingReplies ? (
+        <View style={{ paddingVertical: 16, alignItems: 'center' }}>
+          <ActivityIndicator color={colors.accent} />
+        </View>
+      ) : replies.length === 0 ? (
+        <View style={{ paddingVertical: 12 }}>
+          <Text style={{ fontSize: 14, color: colors.textFaint }}>
+            No replies yet. Be the first to reply.
+          </Text>
+        </View>
+      ) : (
+        <View style={{ gap: 16 }}>
+          {replies.map((reply) => (
+            <PostMessageBlock key={reply.id} message={reply} colors={colors} />
+          ))}
+        </View>
+      )}
     </View>
+  )
+
+  const composer = (
+    <ThreadReplyComposer
+      colors={colors}
+      bottomInset={fullScreen ? bottomInset : 0}
+      compact={!fullScreen}
+      value={draft}
+      onChangeText={(text) => {
+        setDraft(text)
+        if (sendError) setSendError(null)
+      }}
+      onSend={handleSend}
+      sending={sending}
+      error={sendError}
+      authorInitials={author.initials}
+      authorName={author.name}
+      authorColor={author.accentColor}
+    />
   )
 
   return (
@@ -99,7 +214,7 @@ export function PostThread({
           >
             {content}
           </ScrollView>
-          <ThreadReplyComposer colors={colors} bottomInset={bottomInset} />
+          {composer}
         </>
       ) : (
         <View
@@ -112,7 +227,7 @@ export function PostThread({
           }}
         >
           {content}
-          <ThreadReplyComposer colors={colors} bottomInset={0} compact />
+          {composer}
         </View>
       )}
     </View>
@@ -208,39 +323,27 @@ function PostMessageBlock({
           {message.body}
         </Text>
 
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 7,
-            flexWrap: 'wrap',
-            marginTop: 10,
-          }}
-        >
-          {reactions.map((reaction, index) => (
-            <ReactionChip
-              key={`${reaction.emoji}-${index}`}
-              emoji={reaction.emoji}
-              count={reaction.count}
-              colors={colors}
-              active={index === 0}
-            />
-          ))}
-          {original ? (
-            <View
-              style={{
-                borderRadius: 999,
-                borderWidth: 1,
-                borderStyle: 'dashed',
-                borderColor: colors.border,
-                paddingHorizontal: 10,
-                paddingVertical: 5,
-              }}
-            >
-              <Text style={{ fontSize: 12, color: colors.textFaint }}>+ React</Text>
-            </View>
-          ) : null}
-        </View>
+        {reactions.length > 0 ? (
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 7,
+              flexWrap: 'wrap',
+              marginTop: 10,
+            }}
+          >
+            {reactions.map((reaction, index) => (
+              <ReactionChip
+                key={`${reaction.emoji}-${index}`}
+                emoji={reaction.emoji}
+                count={reaction.count}
+                colors={colors}
+                active={index === 0}
+              />
+            ))}
+          </View>
+        ) : null}
       </View>
     </View>
   )
@@ -281,11 +384,28 @@ function ThreadReplyComposer({
   colors,
   bottomInset,
   compact = false,
+  value,
+  onChangeText,
+  onSend,
+  sending,
+  error,
+  authorInitials,
+  authorName,
+  authorColor,
 }: {
   colors: AppColors
   bottomInset: number
   compact?: boolean
+  value: string
+  onChangeText: (text: string) => void
+  onSend: () => void
+  sending: boolean
+  error?: string | null
+  authorInitials: string
+  authorName: string
+  authorColor?: string
 }) {
+  const canSend = value.trim().length > 0 && !sending
   return (
     <View
       style={{
@@ -297,8 +417,11 @@ function ThreadReplyComposer({
         paddingBottom: compact ? 12 : Math.max(bottomInset, 8) + 8,
       }}
     >
+      {error ? (
+        <Text style={{ fontSize: 12, color: '#C2410C', marginBottom: 8 }}>{error}</Text>
+      ) : null}
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <Avatar name="Aditi Mehta" initials="AM" size={30} backgroundColor="#0478A5" />
+        <Avatar name={authorName} initials={authorInitials} size={30} backgroundColor={authorColor} />
         <View
           style={{
             flex: 1,
@@ -310,24 +433,39 @@ function ThreadReplyComposer({
           }}
         >
           <TextInput
-            editable={false}
+            value={value}
+            onChangeText={onChangeText}
+            onSubmitEditing={onSend}
+            editable={!sending}
+            returnKeyType="send"
+            multiline
             placeholder="Reply..."
             placeholderTextColor={colors.textFaint}
-            style={{ fontSize: 15, color: colors.text }}
+            style={{ fontSize: 15, color: colors.text, paddingVertical: 8 }}
           />
         </View>
-        <View
+        <Pressable
+          onPress={onSend}
+          disabled={!canSend}
+          accessibilityRole="button"
+          accessibilityLabel="Send reply"
+          accessibilityState={{ disabled: !canSend }}
           style={{
             width: 36,
             height: 36,
             borderRadius: 18,
             backgroundColor: colors.accent,
+            opacity: canSend ? 1 : 0.45,
             alignItems: 'center',
             justifyContent: 'center',
           }}
         >
-          <Send size={15} color="#FFFFFF" />
-        </View>
+          {sending ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Send size={15} color="#FFFFFF" />
+          )}
+        </Pressable>
       </View>
     </View>
   )

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -1,0 +1,83 @@
+import type { User } from '../../src/auth/types'
+import type { BoardMessage, PersonSummary, VerificationKind } from '../boards/__mocks__/mockData'
+import type { FeedPost, GroupBoard } from './types'
+
+const AVATAR_COLORS = ['#0F766E', '#1D4ED8', '#7C3AED', '#C2410C', '#0369A1', '#15803D']
+
+function colorFor(seed: string) {
+  const total = seed.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0)
+  return AVATAR_COLORS[total % AVATAR_COLORS.length]
+}
+
+function verificationFor(user: User): VerificationKind | undefined {
+  const level = user.verificationLevel ?? 0
+  if (level >= 107) return 'admin'
+  if (level >= 54) return 'sevak'
+  if (user.isVerified) return 'member'
+  return undefined
+}
+
+/**
+ * Builds a PersonSummary for the signed-in user so optimistic replies render
+ * with the same shape as server-mapped messages (see boardPostToMessage).
+ */
+export function authorFromUser(user: User | null): PersonSummary {
+  if (!user) {
+    return { id: 'me', name: 'You', initials: 'You' }
+  }
+  const name = [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || user.username
+  const initials = user.firstName
+    ? `${user.firstName[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase()
+    : user.username.slice(0, 2).toUpperCase()
+  return {
+    id: user.id || 'me',
+    name,
+    initials,
+    verification: verificationFor(user),
+    accentColor: colorFor(user.id || user.username),
+  }
+}
+
+/**
+ * Pending reply rendered immediately while the create request is in flight.
+ * Replaced by the server-mapped message on success, removed on failure.
+ */
+export function optimisticReply(user: User | null, body: string, id: string): BoardMessage {
+  return {
+    id,
+    author: authorFromUser(user),
+    timestamp: 'Sending…',
+    body,
+    replyCount: 0,
+  }
+}
+
+/**
+ * Flattens real board messages into the feed list shape. Each post keeps its
+ * real API id (`postId`) for reply/pin/edit/delete calls, while `id` stays a
+ * board-scoped compound key so selection/routing is unique across boards.
+ * Replies are fetched lazily in the detail thread, not synthesized here.
+ */
+export function buildFeedPosts(groups: GroupBoard[]): FeedPost[] {
+  const posts = groups.flatMap((group) =>
+    group.messages.map(
+      (message): FeedPost => ({
+        ...message,
+        id: `${group.id}-${message.id}`,
+        postId: message.id,
+        sourceLabel: group.title,
+        sourceKind: group.kind,
+        sourceTitle: group.title,
+        sourceSubtitle: group.subtitle,
+        groupId: group.id,
+        groupKind: group.kind,
+        groupParentId: group.parentId,
+      })
+    )
+  )
+
+  return posts.sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+    return a.id < b.id ? 1 : -1
+  })
+}

--- a/packages/frontend/components/feed/types.ts
+++ b/packages/frontend/components/feed/types.ts
@@ -16,10 +16,13 @@ export type GroupBoard = {
 }
 
 export type FeedPost = BoardMessage & {
+  // Board-scoped compound key (`${groupId}-${postId}`) — unique for selection/routing.
   groupId: string
   groupKind: GroupKind
+  // Real API ids used for reply/pin/edit/delete calls against the post's board.
+  postId: string
+  groupParentId: string
   sourceTitle: string
   sourceSubtitle: string
   sourceLabel: string
-  replyMessages: BoardMessage[]
 }

--- a/packages/frontend/src/__tests__/feedData.test.ts
+++ b/packages/frontend/src/__tests__/feedData.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildFeedPosts,
+  authorFromUser,
+  optimisticReply,
+} from '../../components/feed/feedData'
+import type { GroupBoard } from '../../components/feed/types'
+import type { BoardMessage } from '../../components/boards/__mocks__/mockData'
+
+function message(id: string, overrides: Partial<BoardMessage> = {}): BoardMessage {
+  return {
+    id,
+    author: { id: `u-${id}`, name: `User ${id}`, initials: 'U' },
+    timestamp: '10:00 AM',
+    body: `body ${id}`,
+    replyCount: 0,
+    ...overrides,
+  }
+}
+
+function group(id: string, parentId: string, messages: BoardMessage[]): GroupBoard {
+  return {
+    id,
+    kind: 'center',
+    title: `Group ${id}`,
+    eyebrow: '',
+    subtitle: 'sub',
+    meta: '',
+    preview: '',
+    unreadCount: 0,
+    messages,
+    parentId,
+  }
+}
+
+describe('buildFeedPosts', () => {
+  it('preserves the real API post id as postId and the board parentId', () => {
+    const groups = [group('center-abc', 'abc', [message('post-1')])]
+    const [post] = buildFeedPosts(groups)
+    expect(post.postId).toBe('post-1')
+    expect(post.groupParentId).toBe('abc')
+    expect(post.groupKind).toBe('center')
+    // Compound id stays unique across boards for selection/routing.
+    expect(post.id).toBe('center-abc-post-1')
+  })
+
+  it('does not fabricate replies from sibling posts', () => {
+    const groups = [
+      group('center-abc', 'abc', [
+        message('post-1', { replyCount: 3 }),
+        message('post-2'),
+        message('post-3'),
+      ]),
+    ]
+    const first = buildFeedPosts(groups).find((p) => p.postId === 'post-1')!
+    // replyCount is metadata from the API; the real replies are fetched lazily.
+    expect(first.replyCount).toBe(3)
+    expect((first as any).replyMessages).toBeUndefined()
+  })
+
+  it('sorts pinned posts ahead of unpinned', () => {
+    const groups = [
+      group('center-abc', 'abc', [
+        message('post-1'),
+        message('post-2', { pinned: true }),
+      ]),
+    ]
+    const ordered = buildFeedPosts(groups)
+    expect(ordered[0].postId).toBe('post-2')
+  })
+})
+
+describe('authorFromUser', () => {
+  it('uses full name and initials when available', () => {
+    const author = authorFromUser({
+      username: 'rkrishna',
+      firstName: 'Ravi',
+      lastName: 'Krishna',
+    } as any)
+    expect(author.name).toBe('Ravi Krishna')
+    expect(author.initials).toBe('RK')
+  })
+
+  it('falls back to username when no name is set', () => {
+    const author = authorFromUser({ username: 'rkrishna' } as any)
+    expect(author.name).toBe('rkrishna')
+    expect(author.initials).toBe('RK')
+  })
+
+  it('maps verification level to a badge tier', () => {
+    expect(authorFromUser({ username: 'a', verificationLevel: 120 } as any).verification).toBe('admin')
+    expect(authorFromUser({ username: 'a', verificationLevel: 54 } as any).verification).toBe('sevak')
+    expect(authorFromUser({ username: 'a', isVerified: true } as any).verification).toBe('member')
+    expect(authorFromUser({ username: 'a' } as any).verification).toBeUndefined()
+  })
+
+  it('returns a safe placeholder when there is no user', () => {
+    const author = authorFromUser(null)
+    expect(author.name).toBe('You')
+    expect(author.id).toBe('me')
+  })
+})
+
+describe('optimisticReply', () => {
+  it('builds a pending reply message carrying the typed body', () => {
+    const reply = optimisticReply({ username: 'rkrishna', firstName: 'Ravi' } as any, 'Hello there', 'temp-1')
+    expect(reply.id).toBe('temp-1')
+    expect(reply.body).toBe('Hello there')
+    expect(reply.author.name).toBe('Ravi')
+    expect(reply.replyCount).toBe(0)
+  })
+})

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -594,17 +594,19 @@ export async function createBoardPostReply(
   return data.reply
 }
 
-/** List replies under a board post, oldest first (#205 / GET /replies). */
+/**
+ * List replies under a board post, oldest first (#205 / GET /replies).
+ * Throws on failure so the post-detail thread can show a retryable error
+ * state (rather than masking a network/auth failure as an empty thread).
+ */
 export async function fetchBoardPostReplies(postId: string): Promise<BoardPostData[]> {
-  try {
-    const response = await authFetch(`/boards/posts/${encodeURIComponent(postId)}/replies`)
-    if (!response.ok) return []
-    const data = await response.json()
-    return data.replies ?? []
-  } catch (err: any) {
-    if (__DEV__) console.warn('[fetchBoardPostReplies]', err?.message || err)
-    return []
+  const response = await authFetch(`/boards/posts/${encodeURIComponent(postId)}/replies`)
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ message: 'Failed to load replies' }))
+    throw new Error(err.message || 'Failed to load replies')
   }
+  const data = await response.json()
+  return data.replies ?? []
 }
 
 /** Edit a board post body — author only, within the edit window (#205 / PATCH). */


### PR DESCRIPTION
**Lane B · #206 (slice 1 of 2) · BIG (user-visible UI)**

Wires the shared Connect **post-detail thread** (`PostThread` — used by the web
desktop right column, web-mobile, and the native slide-in overlay) to **live
boards data**, replacing fabricated mock replies and the dead reply composer.

Built on top of #271 (pinned-state mapping), which was incorporated into v2 first.

## What's in this slice
- **Real replies** — `fetchBoardPostReplies(post.postId)` mapped with `boardPostToMessage`; loading spinner → list, **retryable error** state, and **empty** state ("No replies yet. Be the first to reply.").
- **Working reply composer** — was `editable={false}` with a hardcoded "Aditi Mehta" avatar. Now controlled, posts via `createBoardPostReply(post.postId, body)` with an **optimistic insert** that **rolls back + restores the typed text** on failure (inline send-error). Uses the signed-in user's avatar.
- **Real-id plumbing** — `FeedPost` gains `postId` (the real API id) + `groupParentId`; the compound `id` stays for feed selection/routing only. `buildFeedPosts` + optimistic-author logic extracted to pure, unit-tested `feedData.ts`. Removed the fabricated sibling-reply synthesis.
- `fetchBoardPostReplies` now **throws on failure** (it silently returned `[]`, masking errors as an empty thread; `PostThread` is its only consumer).

## Acceptance criteria touched
- [x] Reply composer in post detail posts to backend (optimistic + rollback).
- [x] Loading / error / empty states across the detail surface.
- [ ] (slice 2) pin/edit/delete action menus, optimistic reactions, standalone `feed/[id]` route.

## Verification
- `bash .ralph/verify.sh` → **exit 0** — frontend **181** vitest, backend **366**, web build green.
- New units: `src/__tests__/feedData.test.ts` (8 — id mapping, no fabricated replies, pinned-first, optimistic author).
- Reply/feed contract proven by the existing 366 backend tests.
- Independent code-reviewer pass; high-confidence findings fixed (swallowed-error, perf, send/fetch error split).

## ⚠️ Evidence gap (environment, not code) — escalation
Authenticated **success-path web video is blocked**: the **v2preview worker is stale** — `/boards/posts/:id/replies` (and pin/edit/delete) **404 on `chinmaya-janata-api-v2preview`** even though merged on v2 (post *creation* works there). The local `:8787` backend 500s on `/auth/register`. This blocks **all** Lane B live boards-UI QA. Requesting a **v2preview redeploy** (then I'll capture the success video) or approval on tests + review.

## Risk
Frontend-only, no migration, no new dependency. The one shared-file edit (`fetchBoardPostReplies` throwing) has a single consumer (this PR).

🤖 Lane B agent · feat/ralph-206-feed-wiring