### PR TITLE
feat(boards): center page board CTA + post detail (#208)

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -22,13 +22,18 @@ import {
   Navigation,
   BadgeCheck,
   Users,
+  MessageSquare,
+  ChevronRight,
 } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useBoard, useCenterDetail } from '../../hooks/useApiData'
 import { Badge, UnderlineTabBar } from '../../components/ui'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
-import { ThreadPanel, boardPostToMessage } from '../../components/boards'
+import { useColors } from '../../hooks/useColors'
+import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import { PostThread, type FeedPost } from '../../components/feed'
+import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { useUser } from '../../components/contexts'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -199,9 +204,12 @@ export default function CenterDetailPage() {
   const { user } = useUser()
   const { center, events, loading } = useCenterDetail(id as string)
   const colors = useDetailColors()
+  const appColors = useColors()
   const [activeTab, setActiveTab] = useState('About')
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
+  const isVerified = !!user?.isVerified
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -221,6 +229,58 @@ export default function CenterDetailPage() {
     await createBoardPost('center', center.id, body)
     await refetchBoard()
   }
+
+  const openThreadPost = (message: BoardMessage) => {
+    if (!center?.id) return
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `center-${center.id}`,
+        kind: 'center',
+        parentId: center.id,
+        title: center.name,
+        subtitle: center.address || 'Center board',
+      })
+    )
+  }
+
+  const closeThreadPost = () => setThreadDetailPost(null)
+
+  // Thread tab: the board post list, or a tapped post's detail (replies +
+  // reactions + author actions) reusing the shared PostThread (#206).
+  const renderThreadTab = () =>
+    threadDetailPost ? (
+      <View style={{ paddingTop: 4 }}>
+        <Pressable
+          onPress={closeThreadPost}
+          accessibilityRole="button"
+          accessibilityLabel="Back to board"
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
+        >
+          <ChevronLeft size={20} color={appColors.accent} />
+          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+        </Pressable>
+        <PostThread
+          post={threadDetailPost}
+          colors={appColors}
+          onPostChanged={refetchBoard}
+          onPostDeleted={() => {
+            closeThreadPost()
+            refetchBoard()
+          }}
+        />
+      </View>
+    ) : (
+      <ThreadPanel
+        messages={boardMessages}
+        colors={colors}
+        emptyTitle="Be the first to post"
+        emptySubtitle={`Ask about rides, what to bring, or anything else for ${center?.name ?? 'this center'}.`}
+        composerPlaceholder="Write to the board..."
+        composerState={canPostToThread ? 'open' : 'locked'}
+        onSubmitPost={handleCreateThreadPost}
+        onMessagePress={openThreadPost}
+      />
+    )
 
   const handleShare = async () => {
     posthog?.capture('center_shared', { centerId: id })
@@ -450,20 +510,62 @@ export default function CenterDetailPage() {
                   </View>
                 ) : null}
               </View>
+
+              {/* #208 — center board CTA (tier-gated) */}
+              {isVerified ? (
+                <Pressable
+                  onPress={() => setActiveTab('Thread')}
+                  accessibilityRole="button"
+                  accessibilityLabel="Open center board"
+                  style={{
+                    marginTop: 20,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: 14,
+                    borderRadius: 14,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    backgroundColor: colors.iconBoxBg,
+                  }}
+                >
+                  <MessageSquare size={18} color="#E8862A" />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: colors.text }}>
+                      Open center board
+                    </Text>
+                    <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+                      {boardMessages.length > 0
+                        ? `${boardMessages.length} ${boardMessages.length === 1 ? 'post' : 'posts'} from members`
+                        : 'No posts yet — start the conversation'}
+                    </Text>
+                  </View>
+                  <ChevronRight size={18} color={colors.textSecondary} />
+                </Pressable>
+              ) : (
+                <View
+                  style={{
+                    marginTop: 20,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 12,
+                    padding: 14,
+                    borderRadius: 14,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    backgroundColor: colors.iconBoxBg,
+                  }}
+                >
+                  <MessageSquare size={18} color={colors.textSecondary} />
+                  <Text style={{ flex: 1, fontSize: 13, color: colors.textSecondary }}>
+                    Verified members can post on the center board.
+                  </Text>
+                </View>
+              )}
             </>
           )}
 
-          {activeTab === 'Thread' && (
-            <ThreadPanel
-              messages={boardMessages}
-              colors={colors}
-              emptyTitle="Be the first to post"
-              emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
-              composerPlaceholder="Write to the board..."
-              composerState={canPostToThread ? 'open' : 'locked'}
-              onSubmitPost={handleCreateThreadPost}
-            />
-          )}
+          {activeTab === 'Thread' && renderThreadTab()}
 
           {activeTab === 'Events' && (
             <>

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Linking, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Share2, MapPin, Globe, Phone, User, Navigation, BadgeCheck, Users } from 'lucide-react-native'
+import { ChevronLeft, ChevronRight, Share2, MapPin, Globe, Phone, User, Navigation, BadgeCheck, Users, MessageSquare } from 'lucide-react-native'
 import { useBoard, useCenterDetail } from '../../hooks/useApiData'
 import { useDetailColors } from '../../hooks/useDetailColors'
+import { useColors } from '../../hooks/useColors'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
-import { ThreadPanel, boardPostToMessage } from '../../components/boards'
+import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import { PostThread, type FeedPost } from '../../components/feed'
+import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { useUser } from '../../components/contexts'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildCenterJsonLd } from '../../components/seo/jsonLd'
@@ -54,7 +57,9 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   const posthog = usePostHog()
   const { center, events, loading } = useCenterDetail(centerId)
   const colors = useDetailColors()
+  const appColors = useColors()
   const [activeTab, setActiveTab] = useState('About')
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
 
   // Fire center_viewed once per center load. Mirrors the native page's
   // event so web traffic isn't missing from PostHog. (#analytics)
@@ -69,6 +74,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }, [loading, center?.id, center?.name, posthog])
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
+  const isVerified = !!user?.isVerified
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -77,6 +83,56 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
     await createBoardPost('center', center.id, body)
     await refetchBoard()
   }
+
+  const openThreadPost = (message: BoardMessage) => {
+    if (!center?.id) return
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `center-${center.id}`,
+        kind: 'center',
+        parentId: center.id,
+        title: center.name,
+        subtitle: center.address || 'Center board',
+      })
+    )
+  }
+
+  const closeThreadPost = () => setThreadDetailPost(null)
+
+  const renderThreadTab = () =>
+    threadDetailPost ? (
+      <View style={{ paddingTop: 4 }}>
+        <Pressable
+          onPress={closeThreadPost}
+          accessibilityRole="button"
+          accessibilityLabel="Back to board"
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
+        >
+          <ChevronLeft size={20} color={appColors.accent} />
+          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+        </Pressable>
+        <PostThread
+          post={threadDetailPost}
+          colors={appColors}
+          onPostChanged={refetchBoard}
+          onPostDeleted={() => {
+            closeThreadPost()
+            refetchBoard()
+          }}
+        />
+      </View>
+    ) : (
+      <ThreadPanel
+        messages={boardMessages}
+        colors={colors}
+        emptyTitle="Be the first to post"
+        emptySubtitle={`Ask about rides, what to bring, or anything else for ${center?.name ?? 'this center'}.`}
+        composerPlaceholder="Write to the board..."
+        composerState={canPostToThread ? 'open' : 'locked'}
+        onSubmitPost={handleCreateThreadPost}
+        onMessagePress={openThreadPost}
+      />
+    )
 
   const handleShare = () => {
     posthog?.capture('center_shared', { centerId: center?.id, source: 'web_detail' })
@@ -262,20 +318,60 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
               </View>
             </View>
             ) : null}
+
+            {/* #208 — center board CTA (tier-gated) */}
+            {isVerified ? (
+              <Pressable
+                onPress={() => setActiveTab('Thread')}
+                accessibilityRole="button"
+                accessibilityLabel="Open center board"
+                style={{
+                  marginTop: 20,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: 14,
+                  borderRadius: 14,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                  backgroundColor: colors.iconBoxBg,
+                }}
+              >
+                <MessageSquare size={18} color="#E8862A" />
+                <View style={{ flex: 1 }}>
+                  <Text style={{ color: colors.text, fontSize: 15 }}>Open center board</Text>
+                  <Text style={{ color: colors.textSecondary, fontSize: 12, marginTop: 2 }}>
+                    {boardMessages.length > 0
+                      ? `${boardMessages.length} ${boardMessages.length === 1 ? 'post' : 'posts'} from members`
+                      : 'No posts yet — start the conversation'}
+                  </Text>
+                </View>
+                <ChevronRight size={18} color={colors.textSecondary} />
+              </Pressable>
+            ) : (
+              <View
+                style={{
+                  marginTop: 20,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: 14,
+                  borderRadius: 14,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                  backgroundColor: colors.iconBoxBg,
+                }}
+              >
+                <MessageSquare size={18} color={colors.textSecondary} />
+                <Text style={{ flex: 1, color: colors.textSecondary, fontSize: 13 }}>
+                  Verified members can post on the center board.
+                </Text>
+              </View>
+            )}
             </>
           )}
 
-          {activeTab === 'Thread' && (
-            <ThreadPanel
-              messages={boardMessages}
-              colors={colors}
-              emptyTitle="Be the first to post"
-              emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
-              composerPlaceholder="Write to the board..."
-              composerState={canPostToThread ? 'open' : 'locked'}
-              onSubmitPost={handleCreateThreadPost}
-            />
-          )}
+          {activeTab === 'Thread' && renderThreadTab()}
 
           {activeTab === 'Events' && (
             <>

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -19,8 +19,11 @@ import { useBoard, useEventDetail } from '../../hooks/useApiData'
 import { useUser } from '../../components/contexts'
 import { Badge, UnderlineTabBar, Avatar, PrimaryButton, DestructiveButton } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
+import { useColors } from '../../hooks/useColors'
 import { createBoardPost, removeEvent } from '../../utils/api'
-import { ThreadPanel, boardPostToMessage } from '../../components/boards'
+import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import { PostThread, type FeedPost } from '../../components/feed'
+import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
@@ -562,7 +565,9 @@ export default function EventDetailPage() {
   const { event, attendees, loading, toggleRegistration, isToggling, isCreator } =
     useEventDetail(id as string, username, userId)
   const colors = useDetailColors()
+  const appColors = useColors()
   const hasTrackedView = useRef(false)
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
 
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
   const canEdit = isAdmin || isCreator
@@ -637,6 +642,71 @@ export default function EventDetailPage() {
     await createBoardPost('event', event.id, body)
     await refetchBoard()
   }
+
+  const openThreadPost = (message: BoardMessage) => {
+    if (!event?.id) return
+    posthog?.capture('event_board_post_opened', { eventId: id, postId: message.id })
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `event-${event.id}`,
+        kind: 'event',
+        parentId: event.id,
+        title: event.title,
+        subtitle: event.location || `${event.attendees ?? 0} going`,
+      })
+    )
+  }
+
+  const closeThreadPost = () => setThreadDetailPost(null)
+
+  // Thread tab content: either the post list (ThreadPanel) or, when a post is
+  // tapped, its detail (replies + reactions + author actions) reusing the same
+  // PostThread as the Connect Feed (#206). Rendered inline (not a Modal) so it
+  // works reliably on web inside the screen's ScrollView.
+  const renderThreadTab = () =>
+    threadDetailPost ? (
+      <View style={{ paddingTop: 6 }}>
+        <Pressable
+          onPress={closeThreadPost}
+          accessibilityRole="button"
+          accessibilityLabel="Back to board"
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 6,
+            paddingHorizontal: 16,
+            paddingVertical: 10,
+          }}
+        >
+          <ChevronLeft size={20} color={appColors.accent} />
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: appColors.accent }}>
+            Back to board
+          </Text>
+        </Pressable>
+        <View style={{ paddingHorizontal: 16 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              closeThreadPost()
+              refetchBoard()
+            }}
+          />
+        </View>
+      </View>
+    ) : (
+      <ThreadPanel
+        messages={eventBoardMessages}
+        colors={colors}
+        emptyTitle="Be the first to post"
+        emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event?.attendees ?? 0} people going.`}
+        composerPlaceholder="Write to the group..."
+        composerState={canPostToThread ? 'open' : 'locked'}
+        onSubmitPost={handleCreateThreadPost}
+        onMessagePress={openThreadPost}
+      />
+    )
 
   // ── Loading state ────────────────────────────────────────────────────
 
@@ -798,17 +868,7 @@ export default function EventDetailPage() {
             </View>
           )}
 
-          {activeTab === 'Thread' && (
-            <ThreadPanel
-              messages={eventBoardMessages}
-              colors={colors}
-              emptyTitle="Be the first to post"
-              emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event.attendees} people going.`}
-              composerPlaceholder="Write to the group..."
-              composerState={canPostToThread ? 'open' : 'locked'}
-              onSubmitPost={handleCreateThreadPost}
-            />
-          )}
+          {activeTab === 'Thread' && renderThreadTab()}
 
         </ScrollView>
 
@@ -908,17 +968,7 @@ export default function EventDetailPage() {
           </>
         )}
 
-        {activeTab === 'Thread' && (
-          <ThreadPanel
-            messages={eventBoardMessages}
-            colors={colors}
-            emptyTitle="Be the first to post"
-            emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event.attendees} people going.`}
-            composerPlaceholder="Write to the group..."
-            composerState={canPostToThread ? 'open' : 'locked'}
-            onSubmitPost={handleCreateThreadPost}
-          />
-        )}
+        {activeTab === 'Thread' && renderThreadTab()}
 
         {activeTab === 'Attendees' && (
           <View style={{ paddingTop: 8 }}>

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -13,7 +13,10 @@ import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
 import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import AuthPromptModal from '../../components/ui/AuthPromptModal'
 import { useDetailColors } from '../../hooks/useDetailColors'
-import { ThreadPanel, boardPostToMessage } from '../../components/boards'
+import { useColors } from '../../hooks/useColors'
+import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import { PostThread, type FeedPost } from '../../components/feed'
+import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildEventJsonLd } from '../../components/seo/jsonLd'
 
@@ -60,9 +63,11 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const { user } = useUser()
   const { event, loading, toggleRegistration, isToggling, attendees, isCreator } = useEventDetail(eventId, user?.username, user?.id)
   const colors = useDetailColors()
+  const appColors = useColors()
   const [activeTab, setActiveTab] = useState('Details')
   const [showAuthPrompt, setShowAuthPrompt] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
 
   const isPast = event?.date ? new Date(event.date + 'T23:59:59') < new Date() : false
   const canEdit = !!user && (isSuperAdmin(user) || isCreator)
@@ -77,6 +82,58 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
     await createBoardPost('event', event.id, body)
     await refetchBoard()
   }
+
+  const openThreadPost = (message: BoardMessage) => {
+    if (!event?.id) return
+    setThreadDetailPost(
+      buildFeedPostFromMessage(message, {
+        groupId: `event-${event.id}`,
+        kind: 'event',
+        parentId: event.id,
+        title: event.title,
+        subtitle: event.location || `${event.attendees ?? 0} going`,
+      })
+    )
+  }
+
+  const closeThreadPost = () => setThreadDetailPost(null)
+
+  // Thread tab: post list, or the tapped post's detail (replies + reactions +
+  // author actions) reusing the shared PostThread from the Connect Feed (#206).
+  const renderThreadTab = () =>
+    threadDetailPost ? (
+      <View style={{ paddingTop: 4 }}>
+        <Pressable
+          onPress={closeThreadPost}
+          accessibilityRole="button"
+          accessibilityLabel="Back to board"
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
+        >
+          <ChevronLeft size={20} color={appColors.accent} />
+          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+        </Pressable>
+        <PostThread
+          post={threadDetailPost}
+          colors={appColors}
+          onPostChanged={refetchBoard}
+          onPostDeleted={() => {
+            closeThreadPost()
+            refetchBoard()
+          }}
+        />
+      </View>
+    ) : (
+      <ThreadPanel
+        messages={eventBoardMessages}
+        colors={colors}
+        emptyTitle="Be the first to post"
+        emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event?.attendees ?? 0} people going.`}
+        composerPlaceholder="Write to the group..."
+        composerState={canPostToThread ? 'open' : 'locked'}
+        onSubmitPost={handleCreateThreadPost}
+        onMessagePress={openThreadPost}
+      />
+    )
 
   const handleDelete = async () => {
     if (!event) return
@@ -241,15 +298,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
             )}
           </>
         ) : activeTab === 'Thread' ? (
-          <ThreadPanel
-            messages={eventBoardMessages}
-            colors={colors}
-            emptyTitle="Be the first to post"
-            emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event.attendees} people going.`}
-            composerPlaceholder="Write to the group..."
-            composerState={canPostToThread ? 'open' : 'locked'}
-            onSubmitPost={handleCreateThreadPost}
-          />
+          renderThreadTab()
         ) : (
           <>
             <Text style={{ color: colors.textSecondary, fontSize: 14 }}>

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -1,5 +1,6 @@
 import type { User } from '../../src/auth/types'
 import type { BoardMessage, PersonSummary, VerificationKind } from '../boards/__mocks__/mockData'
+import type { GroupKind } from '../boards'
 import type { FeedPost, GroupBoard } from './types'
 
 const AVATAR_COLORS = ['#0F766E', '#1D4ED8', '#7C3AED', '#C2410C', '#0369A1', '#15803D']
@@ -78,26 +79,49 @@ export function optimisticReply(user: User | null, body: string, id: string): Bo
   }
 }
 
+export interface FeedPostContext {
+  groupId: string
+  kind: GroupKind
+  parentId: string
+  title: string
+  subtitle: string
+}
+
 /**
- * Flattens real board messages into the feed list shape. Each post keeps its
- * real API id (`postId`) for reply/pin/edit/delete calls, while `id` stays a
- * board-scoped compound key so selection/routing is unique across boards.
+ * Builds a single feed/detail post from a board message + its board context.
+ * Keeps the real API id (`postId`) for reply/pin/edit/delete calls, while `id`
+ * stays a board-scoped compound key unique across boards. Used by the Connect
+ * Feed and by per-board surfaces (event/center boards) so they share the same
+ * PostThread detail experience.
+ */
+export function buildFeedPostFromMessage(message: BoardMessage, ctx: FeedPostContext): FeedPost {
+  return {
+    ...message,
+    id: `${ctx.groupId}-${message.id}`,
+    postId: message.id,
+    sourceLabel: ctx.title,
+    sourceKind: ctx.kind,
+    sourceTitle: ctx.title,
+    sourceSubtitle: ctx.subtitle,
+    groupId: ctx.groupId,
+    groupKind: ctx.kind,
+    groupParentId: ctx.parentId,
+  }
+}
+
+/**
+ * Flattens real board messages into the feed list shape (pinned first).
  * Replies are fetched lazily in the detail thread, not synthesized here.
  */
 export function buildFeedPosts(groups: GroupBoard[]): FeedPost[] {
   const posts = groups.flatMap((group) =>
-    group.messages.map(
-      (message): FeedPost => ({
-        ...message,
-        id: `${group.id}-${message.id}`,
-        postId: message.id,
-        sourceLabel: group.title,
-        sourceKind: group.kind,
-        sourceTitle: group.title,
-        sourceSubtitle: group.subtitle,
+    group.messages.map((message) =>
+      buildFeedPostFromMessage(message, {
         groupId: group.id,
-        groupKind: group.kind,
-        groupParentId: group.parentId,
+        kind: group.kind,
+        parentId: group.parentId,
+        title: group.title,
+        subtitle: group.subtitle,
       })
     )
   )

--- a/packages/frontend/src/__tests__/feedData.test.ts
+++ b/packages/frontend/src/__tests__/feedData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildFeedPosts,
+  buildFeedPostFromMessage,
   authorFromUser,
   optimisticReply,
   canPinPosts,
@@ -70,6 +71,24 @@ describe('buildFeedPosts', () => {
     ]
     const ordered = buildFeedPosts(groups)
     expect(ordered[0].postId).toBe('post-2')
+  })
+})
+
+describe('buildFeedPostFromMessage', () => {
+  it('builds a detail post from a board message + event context', () => {
+    const post = buildFeedPostFromMessage(message('post-9', { replyCount: 4 }), {
+      groupId: 'event-evt1',
+      kind: 'event',
+      parentId: 'evt1',
+      title: 'Bhagavad Gita Study',
+      subtitle: 'Boston · 12 going',
+    })
+    expect(post.postId).toBe('post-9')
+    expect(post.groupParentId).toBe('evt1')
+    expect(post.groupKind).toBe('event')
+    expect(post.id).toBe('event-evt1-post-9')
+    expect(post.sourceTitle).toBe('Bhagavad Gita Study')
+    expect(post.replyCount).toBe(4)
   })
 })
 


### PR DESCRIPTION
**Lane B · #208 · BIG · stacked on #207** (base = `feat/ralph-207-event-board-detail`; retarget to v2 once #207 merges — depends on its `buildFeedPostFromMessage`).

Wires the center board into `/center/[id]` (native + web):

## What's in it
- **Tier-gated "Open center board" CTA** on the About tab: Verified+ get a card ("N posts from members" → opens the Thread tab); Basic users see a "Verified members can post on the center board" hint.
- Tapping a center board post opens the shared **PostThread** detail (replies + reactions + author actions), reusing #206/#207 — no duplicate UI.
- Normalized `[id].web.tsx` CRLF→LF (lone CRLF file; real change ~70 lines — `git diff -w`).

## Acceptance criteria
- [x] Verified user: "Open center board" CTA navigates to the board.
- [x] Basic user sees the gated CTA copy.
- [x] No regression on the existing center layout.
- [ ] Center admin in-place About edit → deferred to a follow-up issue (the `PUT /admin/centers/:id` client method exists; it's a separate admin concern).

## Verification
- `bash .ralph/verify.sh` → exit 0 — frontend **187**, backend 366, web build.
- **Web-verified** on the isolated local stack: About CTA (2 posts from members) → Thread → tapped post → detail with 2 real replies + composer (screenshots in Slack).

🤖 Lane B agent · feat/ralph-208-center-boards