### PR TITLE
feat(intro): pre-auth 'What is Janata' first-timer explainer

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -28,6 +28,7 @@ import {
 } from '../components/contexts'
 import { ErrorBoundary, ErrorBoundaryWithAnalytics } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
+import { getIntroShown } from '../utils/introStorage'
 import '../globals.css'
 
 export const unstable_settings = {
@@ -111,6 +112,23 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
   const router = useRouter()
   const isAuthenticated = !!user
   const { width } = useWindowDimensions()
+  // First-timer explainer gate. null = not yet resolved (don't redirect yet).
+  const [introShown, setIntroShown] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    let active = true
+    getIntroShown()
+      .then((seen) => {
+        if (active) setIntroShown(seen)
+      })
+      .catch(() => {
+        // On any failure, treat as "shown" so we never trap the user pre-auth.
+        if (active) setIntroShown(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
   // Mirrors the desktop WebHeader, which shows its nav regardless of auth —
   // only hide on the full-screen landing/auth/onboarding flows.
   const showBottomNav =
@@ -118,7 +136,8 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
     width < 768 &&
     !pathname.startsWith('/auth') &&
     !pathname.startsWith('/onboarding') &&
-    pathname !== '/landing'
+    pathname !== '/landing' &&
+    pathname !== '/intro'
 
   useEffect(() => {
     if (!loading) {
@@ -128,14 +147,27 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
 
   useEffect(() => {
     if (loading) return
+    // Wait until the intro-shown flag has resolved before redirecting, so we
+    // don't briefly route a first-timer to landing/auth before /intro.
+    if (introShown === null) return
 
     const inAuthGroup = pathname.startsWith('/auth')
     const inOnboardingGroup = pathname.startsWith('/onboarding')
     const inLandingPage = pathname === '/landing'
+    const inIntroPage = pathname === '/intro'
 
     if (!isAuthenticated) {
+      // First-run-only: an unauthenticated user who has not seen the explainer
+      // is routed to /intro before landing/auth. Skip → /auth always works
+      // (it sets intro-shown), so the user is never trapped here.
+      if (!introShown && !inIntroPage && !inAuthGroup) {
+        router.replace('/intro')
+        return
+      }
+
       const isPublicPage =
         inAuthGroup ||
+        inIntroPage ||
         inLandingPage ||
         pathname === '/' ||
         pathname.startsWith('/(tabs)') ||
@@ -153,6 +185,11 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
         router.replace('/landing')
       }
     } else {
+      // Authenticated users never see the intro; if they land on it, move on.
+      if (inIntroPage) {
+        router.replace('/')
+        return
+      }
       const isComplete = user.profileComplete || (!!user.firstName && !!user.lastName)
 
       if (!isComplete) {
@@ -165,7 +202,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
         }
       }
     }
-  }, [user, loading, pathname, isAuthenticated])
+  }, [user, loading, pathname, isAuthenticated, introShown])
 
   const navTheme = isDark ? DarkTheme : DefaultTheme
   const prevIsDark = useRef(isDark)
@@ -190,6 +227,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
         <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="auth" options={{ headerShown: false }} />
+          <Stack.Screen name="intro" options={{ headerShown: false, gestureEnabled: false }} />
           <Stack.Screen name="landing" options={{ headerShown: false }} />
           <Stack.Screen name="onboarding" options={{ headerShown: false, gestureEnabled: false }} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -157,10 +157,13 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
     const inIntroPage = pathname === '/intro'
 
     if (!isAuthenticated) {
-      // First-run-only: an unauthenticated user who has not seen the explainer
-      // is routed to /intro before landing/auth. Skip → /auth always works
-      // (it sets intro-shown), so the user is never trapped here.
-      if (!introShown && !inIntroPage && !inAuthGroup) {
+      // First-run-only: an unauthenticated first-timer is shown /intro ONLY when
+      // they hit the natural entry surface (root or landing). Public deep links
+      // (/events/:id, /center/:id, /feed, /explore, SEO pages) are NOT
+      // intercepted, so shared/indexed links open directly. Skip → /auth always
+      // works (it sets intro-shown), so the user is never trapped.
+      const isEntrySurface = pathname === '/' || inLandingPage
+      if (!introShown && isEntrySurface && !inIntroPage) {
         router.replace('/intro')
         return
       }

--- a/packages/frontend/app/intro.tsx
+++ b/packages/frontend/app/intro.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { IntroPager } from '../components/intro'
+
+/**
+ * Pre-auth "What is Janata" first-timer explainer.
+ * Shown once before login; gated in _layout.tsx via getIntroShown().
+ */
+export default function IntroScreen() {
+  return (
+    <SafeAreaView className="flex-1 bg-white dark:bg-neutral-900">
+      <IntroPager />
+    </SafeAreaView>
+  )
+}

--- a/packages/frontend/components/intro/IntroCard.tsx
+++ b/packages/frontend/components/intro/IntroCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+import type { IntroStep } from './IntroSteps'
+
+type IntroCardProps = {
+  step: IntroStep
+  /** Width of the pager viewport so each card fills exactly one page. */
+  width: number
+}
+
+/**
+ * A single full-bleed intro card: emoji visual, headline, and supporting body.
+ * Sized to fill one pager page; content is vertically centered and breathable.
+ */
+export default function IntroCard({ step, width }: IntroCardProps) {
+  return (
+    <View style={{ width }} className="flex-1 items-center justify-center px-6">
+      <View className="w-full max-w-md items-center gap-6">
+        {/* Visual */}
+        <View className="h-28 w-28 items-center justify-center rounded-full bg-primary-soft dark:bg-primary/10">
+          <Text className="text-6xl" accessibilityElementsHidden importantForAccessibility="no">
+            {step.emoji}
+          </Text>
+        </View>
+
+        {/* Copy */}
+        <View className="gap-3">
+          <Text className="text-3xl font-sans font-bold text-content dark:text-content-dark text-center">
+            {step.title}
+          </Text>
+          <Text className="text-lg font-sans text-stone-500 dark:text-stone-400 text-center leading-7">
+            {step.body}
+          </Text>
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/packages/frontend/components/intro/IntroPager.tsx
+++ b/packages/frontend/components/intro/IntroPager.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  FlatList,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
+  type ListRenderItemInfo,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import { PrimaryButton } from '../ui'
+import IntroCard from './IntroCard'
+import { INTRO_STEPS, type IntroStep } from './IntroSteps'
+import { setIntroShown } from '../../utils/introStorage'
+
+/**
+ * Horizontal swipeable pager for the first-timer explainer.
+ * - Paged FlatList of IntroCards
+ * - Progress dots reflecting the active page
+ * - "Next" advances; "Get started" on the last page finishes
+ * - "Skip" jumps straight to auth
+ * Finishing or skipping marks the intro as shown and routes to /auth.
+ */
+export default function IntroPager() {
+  const router = useRouter()
+  const { width } = useWindowDimensions()
+  // Cap the page width so cards stay readable on wide web viewports.
+  const pageWidth = Math.min(width, 560)
+  const [index, setIndex] = useState(0)
+  const listRef = useRef<FlatList<IntroStep>>(null)
+
+  const isLast = index >= INTRO_STEPS.length - 1
+
+  const finish = useCallback(async () => {
+    await setIntroShown(true)
+    router.replace('/auth')
+  }, [router])
+
+  const handleNext = useCallback(() => {
+    if (isLast) {
+      void finish()
+      return
+    }
+    const next = index + 1
+    listRef.current?.scrollToOffset({ offset: next * pageWidth, animated: true })
+    setIndex(next)
+  }, [isLast, finish, index, pageWidth])
+
+  const handleMomentumEnd = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const page = Math.round(e.nativeEvent.contentOffset.x / pageWidth)
+      if (page !== index) setIndex(page)
+    },
+    [index, pageWidth],
+  )
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<IntroStep>) => <IntroCard step={item} width={pageWidth} />,
+    [pageWidth],
+  )
+
+  return (
+    <View className="flex-1 w-full self-center" style={{ maxWidth: 560 }}>
+      {/* Skip */}
+      <View className="flex-row justify-end px-6 pt-2">
+        <Pressable
+          onPress={() => void finish()}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Skip intro"
+        >
+          <Text className="text-base font-sans text-stone-400 dark:text-stone-500">Skip</Text>
+        </Pressable>
+      </View>
+
+      {/* Pager */}
+      <FlatList
+        ref={listRef}
+        data={INTRO_STEPS}
+        keyExtractor={(_, i) => `intro-${i}`}
+        renderItem={renderItem}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={handleMomentumEnd}
+        getItemLayout={(_, i) => ({ length: pageWidth, offset: pageWidth * i, index: i })}
+        className="flex-1"
+      />
+
+      {/* Progress dots */}
+      <View className="flex-row justify-center items-center gap-2 py-4">
+        {INTRO_STEPS.map((_, i) => (
+          <View
+            key={i}
+            className={`h-2 rounded-full ${
+              i === index ? 'w-6 bg-primary' : 'w-2 bg-muted/30 dark:bg-muted-dark/30'
+            }`}
+          />
+        ))}
+      </View>
+
+      {/* CTA */}
+      <View className="px-6 pb-6">
+        <PrimaryButton onPress={handleNext} style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}>
+          {isLast ? 'Get started' : 'Next'}
+        </PrimaryButton>
+      </View>
+    </View>
+  )
+}

--- a/packages/frontend/components/intro/IntroSteps.ts
+++ b/packages/frontend/components/intro/IntroSteps.ts
@@ -1,0 +1,33 @@
+/**
+ * IntroSteps.ts
+ *
+ * Card definitions for the pre-auth "What is Janata" first-timer explainer.
+ * Copy is the verbatim elevator pitch — kept short, warm, and on-brand.
+ */
+
+export type IntroStep = {
+  /** Decorative emoji shown above the title. */
+  emoji: string
+  /** Short, punchy headline. */
+  title: string
+  /** Supporting paragraph. */
+  body: string
+}
+
+export const INTRO_STEPS: IntroStep[] = [
+  {
+    emoji: '🧭',
+    title: 'Find your center. Grow together.',
+    body: 'One place where any CHYK can find events and centers nearby, RSVP in a tap, and connect with the community — beyond your group chat.',
+  },
+  {
+    emoji: '🗺️',
+    title: '50+ centers, finally in one place.',
+    body: 'Events used to be scattered across WhatsApp, email, and flyers. Janata puts every center and event on one map every CHYK is checking.',
+  },
+  {
+    emoji: '🪔',
+    title: 'Made by sevaks. Run by CHYKs.',
+    body: 'Janata is volunteer-led — built and maintained entirely by CHYKs across centers. Join, discover events, and help your community grow.',
+  },
+]

--- a/packages/frontend/components/intro/index.ts
+++ b/packages/frontend/components/intro/index.ts
@@ -1,0 +1,6 @@
+import IntroCard from './IntroCard'
+import IntroPager from './IntroPager'
+import { INTRO_STEPS, type IntroStep } from './IntroSteps'
+
+export { IntroCard, IntroPager, INTRO_STEPS }
+export type { IntroStep }

--- a/packages/frontend/utils/introStorage.ts
+++ b/packages/frontend/utils/introStorage.ts
@@ -1,0 +1,96 @@
+/**
+ * introStorage.ts
+ *
+ * Utility functions for storing first-timer intro explainer "seen" state.
+ * Mirrors onboardingStorage.ts: dual web (localStorage + cookie) / native
+ * (AsyncStorage) persistence so the explainer is shown exactly once per device.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Platform } from 'react-native'
+
+const INTRO_KEY = '@intro_shown'
+
+const setCookie = (name: string, value: string, days: number) => {
+  if (typeof document === 'undefined') return
+  let expires = ''
+  if (days) {
+    const date = new Date()
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
+    expires = '; expires=' + date.toUTCString()
+  }
+  document.cookie = name + '=' + (value || '') + expires + '; path=/'
+}
+
+const getCookie = (name: string) => {
+  if (typeof document === 'undefined') return null
+  const nameEQ = name + '='
+  const ca = document.cookie.split(';')
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i]
+    while (c.charAt(0) === ' ') c = c.substring(1, c.length)
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length)
+  }
+  return null
+}
+
+const eraseCookie = (name: string) => {
+  if (typeof document === 'undefined') return
+  document.cookie = name + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;'
+}
+
+export const setIntroShown = async (value: boolean): Promise<void> => {
+  try {
+    const serialized = value ? '1' : '0'
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined') {
+        try {
+          localStorage.setItem(INTRO_KEY, serialized)
+        } catch (e) {}
+        setCookie(INTRO_KEY, serialized, 365)
+      }
+    } else {
+      await AsyncStorage.setItem(INTRO_KEY, serialized)
+    }
+  } catch (error) {
+    if (__DEV__) console.error('Error storing intro state:', error)
+  }
+}
+
+export const getIntroShown = async (): Promise<boolean> => {
+  try {
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined') {
+        try {
+          const stored = localStorage.getItem(INTRO_KEY)
+          if (stored) return stored === '1'
+        } catch (e) {}
+        const cookie = getCookie(INTRO_KEY)
+        return cookie === '1'
+      }
+      return false
+    }
+    const value = await AsyncStorage.getItem(INTRO_KEY)
+    return value === '1'
+  } catch (error) {
+    if (__DEV__) console.error('Error retrieving intro state:', error)
+    return false
+  }
+}
+
+export const clearIntroShown = async (): Promise<void> => {
+  try {
+    if (Platform.OS === 'web') {
+      if (typeof window !== 'undefined') {
+        try {
+          localStorage.removeItem(INTRO_KEY)
+        } catch (e) {}
+        eraseCookie(INTRO_KEY)
+      }
+    } else {
+      await AsyncStorage.removeItem(INTRO_KEY)
+    }
+  } catch (error) {
+    if (__DEV__) console.error('Error clearing intro state:', error)
+  }
+}


### PR DESCRIPTION
Pre-auth, first-run-only swipeable explainer (Ram ji's #1 ask). 3 cards using the elevator-pitch copy + Skip/Get-started → /auth.

- New: introStorage (mirrors onboardingStorage, key @intro_shown), components/intro/*, app/intro.tsx; wired into _layout routing.
- Gate intercepts ONLY the entry surface (/ and /landing) for unauthenticated first-timers — public deep links (/events/:id, /center/:id, /feed, SEO) open directly. Authed users never see it; Skip always works (never traps).

Tested: 187/187 frontend tests; root typecheck clean. Web smoke (headless): /, /intro, /auth, /explore all render, 0 console errors, live data flows.