### PR TITLE
fix(feed): tighten post-detail header + smooth the transition

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -271,10 +271,13 @@ export default function FeedScreen() {
 
     navigation.setOptions({
       tabBarStyle: nativeDetailOpen ? { display: 'none' } : nativeTabBarStyle,
+      // Hide the "Feed" tab header while a post is open so the detail's own
+      // back/title bar becomes the screen header — no gap, no doubled header.
+      headerShown: !nativeDetailOpen,
     })
 
     return () => {
-      navigation.setOptions({ tabBarStyle: nativeTabBarStyle })
+      navigation.setOptions({ tabBarStyle: nativeTabBarStyle, headerShown: true })
     }
   }, [navigation, nativeDetailOpen, nativeTabBarStyle])
 
@@ -492,7 +495,6 @@ export default function FeedScreen() {
               colors={colors}
               insetsTop={insets.top}
               title="Post"
-              subtitle={selectedPost?.sourceTitle}
               hideAvatar
               onBack={closeDetail}
             />

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -476,45 +476,61 @@ export default function FeedScreen() {
       </ScrollView>
 
       {nativeDetailOpen ? (
-        <Animated.View
-          style={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-            backgroundColor: colors.surface,
-            transform: [{ translateX: detailTranslateX }],
-          }}
-        >
-          <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-            style={{ flex: 1, backgroundColor: colors.surface }}
+        <>
+          {/* Static opaque backdrop. Hiding the "Feed" tab header reflows the
+              feed list below; without this, the horizontal slide would expose
+              that upward shift on the way in and out. The panel slides over a
+              uniform surface instead. */}
+          <View
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              bottom: 0,
+              left: 0,
+              backgroundColor: colors.surface,
+            }}
+          />
+          <Animated.View
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              bottom: 0,
+              left: 0,
+              backgroundColor: colors.surface,
+              transform: [{ translateX: detailTranslateX }],
+            }}
           >
-            <NativeChatHeader
-              colors={colors}
-              insetsTop={insets.top}
-              title="Post"
-              hideAvatar
-              onBack={closeDetail}
-            />
-            <View style={{ flex: 1 }}>
-              {selectedPost ? (
-                <PostThread
-                  post={selectedPost}
-                  colors={colors}
-                  fullScreen
-                  bottomInset={insets.bottom}
-                  onPostChanged={loadBoards}
-                  onPostDeleted={() => {
-                    closeDetail()
-                    loadBoards()
-                  }}
-                />
-              ) : null}
-            </View>
-          </KeyboardAvoidingView>
-        </Animated.View>
+            <KeyboardAvoidingView
+              behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+              style={{ flex: 1, backgroundColor: colors.surface }}
+            >
+              <NativeChatHeader
+                colors={colors}
+                insetsTop={insets.top}
+                title="Post"
+                hideAvatar
+                onBack={closeDetail}
+              />
+              <View style={{ flex: 1 }}>
+                {selectedPost ? (
+                  <PostThread
+                    post={selectedPost}
+                    colors={colors}
+                    fullScreen
+                    bottomInset={insets.bottom}
+                    onPostChanged={loadBoards}
+                    onPostDeleted={() => {
+                      closeDetail()
+                      loadBoards()
+                    }}
+                  />
+                ) : null}
+              </View>
+            </KeyboardAvoidingView>
+          </Animated.View>
+        </>
       ) : null}
 
       <CreatePostSheet


### PR DESCRIPTION
## What

Fixes the mobile **feed post detail** view (tap a post in the Feed tab).

**Before:** the detail rendered its own back/title bar *below* the persistent "Feed" tab header, and `NativeChatHeader` re-applied the top safe-area inset — producing a doubled header and a large empty gap above "Back / Post". A redundant "Chinmaya Mission Boston" subtitle sat under "Post", duplicating the "… - Board" chip right below it.

**Changes:**
1. **Single, gap-free header** — hide the "Feed" tab header while a post is open so the detail's own back/title bar becomes the screen header (mirrors how the Explore screen hides its nav header).
2. **Drop the redundant subtitle** — remove the `<Center>` line under "Post"; it's already shown in the "`<Center>` - Board" chip directly below.
3. **Smooth transition** — hiding the tab header reflows the feed list beneath the sliding detail overlay, and the horizontal slide exposed that upward shift on the way in *and* out. A static opaque backdrop now sits behind the sliding panel, so it slides over a uniform surface with no visible layout shift.

## Files
- `app/(tabs)/feed.tsx`

## Verification
Built and driven in the iOS simulator (iPhone 16 Pro): opened a post, confirmed the single header with no gap and no subtitle, then screen-recorded the open/close transitions and stepped through the frames — the feed-list reflow is no longer exposed during the slide. Back navigation restores the Feed header and tab bar cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)