### PR TITLE
feat(nav): move profile to top-right avatar, 3-tab native nav

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -7,7 +7,6 @@ import { House, Newspaper, Compass, Plus } from 'lucide-react-native'
 import SettingsPanel from '../../components/settings/SettingsPanel'
 import Logo from '../../components/ui/Logo'
 import TabHeader from '../../components/ui/TabHeader'
-import { Avatar } from '../../components/ui'
 import { usePostHog } from 'posthog-react-native'
 
 export default function TabLayout() {
@@ -257,26 +256,16 @@ export default function TabLayout() {
           <Tabs.Screen
             name="profile"
             options={{
+              // Profile is no longer a bottom-bar tab on native — it's reached via
+              // the avatar button in TabHeader (showProfile). href: null keeps the
+              // /profile route mounted/navigable and leaves web (WebHeader /
+              // WebBottomNav) untouched, while removing the native tab icon.
+              href: null,
               tabBarShowLabel: false,
               title: 'Profile',
               header: isDesktopWeb
                 ? () => <WebHeader />
-                : () => <TabHeader title="You" action="settings" />,
-              tabBarIcon: ({ size, focused }) => (
-                <Avatar
-                  image={user?.profileImage ?? undefined}
-                  name={
-                    user?.firstName
-                      ? `${user.firstName} ${user.lastName ?? ''}`.trim()
-                      : user?.username
-                  }
-                  size={size + 4}
-                  style={{
-                    borderWidth: focused ? 2 : 0,
-                    borderColor: '#E8862A',
-                  }}
-                />
-              ),
+                : () => <TabHeader title="You" action="settings" showProfile={false} />,
             }}
           />
         </Tabs>

--- a/packages/frontend/components/ui/TabHeader.tsx
+++ b/packages/frontend/components/ui/TabHeader.tsx
@@ -19,6 +19,12 @@ interface TabHeaderProps {
   action?: 'create' | 'notifications' | 'settings'
   onActionPress?: () => void
   rightContent?: React.ReactNode
+  /**
+   * Show the profile avatar as a top-right entry point to `/profile`.
+   * Native only — on web the profile entry lives in WebHeader / WebBottomNav.
+   * Defaults to true; pass false on the profile screen itself.
+   */
+  showProfile?: boolean
 }
 
 export default function TabHeader({
@@ -30,6 +36,7 @@ export default function TabHeader({
   action,
   onActionPress,
   rightContent,
+  showProfile = true,
 }: TabHeaderProps) {
   const router = useRouter()
   const { user } = useUser()
@@ -135,6 +142,31 @@ export default function TabHeader({
             })}
           >
             <ActionIcon />
+          </Pressable>
+        )}
+        {showProfile && Platform.OS !== 'web' && user && (
+          <Pressable
+            onPress={() => {
+              posthog?.capture('nav_profile_opened')
+              router.push('/profile')
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Profile"
+            hitSlop={8}
+            style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          >
+            <Avatar
+              image={user.profileImage ?? undefined}
+              name={
+                user.firstName
+                  ? `${user.firstName} ${user.lastName ?? ''}`.trim()
+                  : user.username
+              }
+              size={32}
+              style={
+                transparent ? { borderWidth: 1.5, borderColor: 'rgba(255,255,255,0.7)' } : undefined
+              }
+            />
           </Pressable>
         )}
       </View>


### PR DESCRIPTION
## What

Simplifies **native** navigation from 4 tabs to **3** (Home / Explore / Feed) by moving Profile out of the bottom tab bar into a consistent **avatar button in the top-right of every tab header**.

Motivation: simplify navigation (and the home screen) ahead of the MSC launch — the demo feedback was that the app felt busy. The web build *already* does this (avatar in `WebHeader`); this brings native in line.

## Changes
- **`TabHeader.tsx`** — new `showProfile` prop (default `true`) renders the user's avatar as a `/profile` entry point, shown on Home, Explore and Feed. **Native-only** (`Platform.OS !== 'web'`); on the profile screen itself it's passed `false`.
- **`(tabs)/_layout.tsx`** — profile `Tabs.Screen` set to `href: null`: removes the native tab icon while keeping `/profile` mounted and routable. Removed the now-dead `Avatar` tab-icon + import.

## Deliberately scoped to avoid colliding with other in-flight work
- **No web routing/nav changes.** Profile stays *inside* `(tabs)`, so on web it still renders within `WebHeader` / `WebBottomNav` — pixel-identical. This keeps the PR clear of the in-flight web-nav redesign branch (`redesign-web-nav-and-desktop`). The only shared file is `(tabs)/_layout.tsx`; the overlap is one line (the Explore header), a trivial merge.
- `/profile` route preserved — `WebBottomNav` and `SettingsPanel` links keep working.
- Branched cleanly off `v2` for independent mergeability (no dependency on draft PRs).

## Verification
- `tsc --noEmit` on the frontend: **0 errors in the changed files** (8 pre-existing baseline errors elsewhere, unrelated).
- ⚠️ **Not yet smoke-tested in the iOS simulator** (sandbox couldn't complete `npm install`). Recommend a quick simulator pass to confirm: 3 tabs render, avatar appears top-right on all three, tapping it opens `/profile`, and the profile screen's own header shows "You" + settings with no avatar.

## UX note
Profile opens as a tab-style screen (no back-arrow) — consistent with its *current* behavior (you return via the tabs). If we'd prefer a pushed screen with a back arrow, that's a follow-up (it touches root-stack routing + web chrome, so I kept it out of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)