### PR TITLE
feat(detail): unify center + event detail into one feed-style scroll

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -1,15 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { DetailSkeleton } from '../../components/ui/Skeleton'
-import {
-  View,
-  Text,
-  ScrollView,
-  Image,
-  Pressable,
-  Linking,
-  ActivityIndicator,
-  Share,
-} from 'react-native'
+import { View, Text, ScrollView, Image, Pressable, Linking, Share } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import {
@@ -19,15 +10,13 @@ import {
   Globe,
   Phone,
   User,
-  Navigation,
   BadgeCheck,
   Users,
-  MessageSquare,
-  ChevronRight,
+  Lock,
 } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useBoard, useCenterDetail } from '../../hooks/useApiData'
-import { Badge, UnderlineTabBar } from '../../components/ui'
+import { DetailSection } from '../../components/ui'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
@@ -92,67 +81,31 @@ function HeaderBar({
   isVerified?: boolean
 }) {
   return (
-    <View
-      style={{
-        paddingHorizontal: 16,
-        paddingTop: 8,
-        paddingBottom: 12,
-        borderBottomWidth: 1,
-        borderBottomColor: colors.border,
-        gap: 10,
-      }}
-    >
+    <View style={{ paddingHorizontal: 16, paddingTop: 8, paddingBottom: 14, gap: 12 }}>
       {/* Top row: back + share */}
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
         <Pressable
           onPress={onBack}
           accessibilityRole="button"
           accessibilityLabel="Back"
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 4,
-            padding: 8,
-            minHeight: 44,
-            minWidth: 44,
-          }}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 4, padding: 8, minHeight: 44, minWidth: 44 }}
         >
           <ChevronLeft size={20} color={colors.iconHeader} />
-          <Text
-            style={{
-              fontSize: 14,
-              color: colors.iconHeader,
-            }}
-          >
-            Back
-          </Text>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.iconHeader }}>Back</Text>
         </Pressable>
 
         <Pressable
           onPress={onShare}
           accessibilityRole="button"
           accessibilityLabel="Share this center"
-          style={{
-            padding: 8,
-            minHeight: 44,
-            minWidth: 44,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
         >
           <ShareIcon size={18} color={colors.iconHeader} />
         </Pressable>
       </View>
 
-      {/* Title row */}
-      <Text
-        style={{
-          fontFamily: 'Inclusive Sans',
-          fontSize: 20,
-          color: colors.text,
-          lineHeight: 26,
-        }}
-      >
+      {/* Title */}
+      <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 26, color: colors.text, lineHeight: 32 }}>
         {title}
       </Text>
 
@@ -161,35 +114,46 @@ function HeaderBar({
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
           {memberCount > 0 && (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-              <Users size={13} color={colors.textSecondary} />
-              <Text
-                style={{
-                  fontSize: 13,
-                  color: colors.textSecondary,
-                }}
-              >
+              <Users size={14} color={colors.textSecondary} />
+              <Text style={{ fontSize: 13, color: colors.textSecondary }}>
                 {memberCount} {memberCount === 1 ? 'member' : 'members'}
               </Text>
             </View>
           )}
-          {memberCount > 0 && isVerified && (
-            <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>
-          )}
+          {memberCount > 0 && isVerified && <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>}
           {isVerified && (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-              <BadgeCheck size={13} color="#E8862A" />
-              <Text
-                style={{
-                  fontSize: 13,
-                  color: '#E8862A',
-                }}
-              >
-                Verified
-              </Text>
+              <BadgeCheck size={14} color="#E8862A" />
+              <Text style={{ fontSize: 13, color: '#E8862A' }}>Verified</Text>
             </View>
           )}
         </View>
       )}
+    </View>
+  )
+}
+
+// ── Locked board hint ─────────────────────────────────────────────────────
+
+function LockedBoard({ colors }: { colors: DetailColors }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.iconBoxBg,
+      }}
+    >
+      <Lock size={18} color={colors.textSecondary} />
+      <Text style={{ flex: 1, fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}>
+        Verified members of this center can post and reply on the board.
+      </Text>
     </View>
   )
 }
@@ -205,11 +169,9 @@ export default function CenterDetailPage() {
   const { center, events, loading } = useCenterDetail(id as string)
   const colors = useDetailColors()
   const appColors = useColors()
-  const [activeTab, setActiveTab] = useState('About')
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
-  const isVerified = !!user?.isVerified
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -244,43 +206,6 @@ export default function CenterDetailPage() {
   }
 
   const closeThreadPost = () => setThreadDetailPost(null)
-
-  // Thread tab: the board post list, or a tapped post's detail (replies +
-  // reactions + author actions) reusing the shared PostThread (#206).
-  const renderThreadTab = () =>
-    threadDetailPost ? (
-      <View style={{ paddingTop: 4 }}>
-        <Pressable
-          onPress={closeThreadPost}
-          accessibilityRole="button"
-          accessibilityLabel="Back to board"
-          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
-        >
-          <ChevronLeft size={20} color={appColors.accent} />
-          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
-        </Pressable>
-        <PostThread
-          post={threadDetailPost}
-          colors={appColors}
-          onPostChanged={refetchBoard}
-          onPostDeleted={() => {
-            closeThreadPost()
-            refetchBoard()
-          }}
-        />
-      </View>
-    ) : (
-      <ThreadPanel
-        messages={boardMessages}
-        colors={colors}
-        emptyTitle="Be the first to post"
-        emptySubtitle={`Ask about rides, what to bring, or anything else for ${center?.name ?? 'this center'}.`}
-        composerPlaceholder="Write to the board..."
-        composerState={canPostToThread ? 'open' : 'locked'}
-        onSubmitPost={handleCreateThreadPost}
-        onMessagePress={openThreadPost}
-      />
-    )
 
   const handleShare = async () => {
     posthog?.capture('center_shared', { centerId: id })
@@ -327,27 +252,46 @@ export default function CenterDetailPage() {
   if (!center) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }} edges={['top']}>
-        <View
-          style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 }}
-        >
-          <Text
-            style={{
-              fontSize: 22,
-              fontFamily: 'Inclusive Sans',
-              color: colors.text,
-              marginBottom: 16,
-            }}
-          >
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 }}>
+          <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, marginBottom: 16 }}>
             Center not found
           </Text>
+          <Pressable onPress={() => router.back()} style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}>
+            <Text style={{ fontSize: 16, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>Go Back</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  // ── Focused thread view (a board post + its replies) ─────────────────
+
+  if (threadDetailPost) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: appColors.bg }} edges={['top']}>
+        <View style={{ paddingTop: 6 }}>
           <Pressable
-            onPress={() => router.back()}
-            style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}
+            onPress={closeThreadPost}
+            accessibilityRole="button"
+            accessibilityLabel="Back to board"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 12 }}
           >
-            <Text style={{ fontSize: 16, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>
-              Go Back
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: appColors.accent }}>
+              Back to board
             </Text>
           </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              closeThreadPost()
+              refetchBoard()
+            }}
+          />
         </View>
       </SafeAreaView>
     )
@@ -355,6 +299,9 @@ export default function CenterDetailPage() {
 
   // Strip protocol for website display
   const displayWebsite = (center.website ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '')
+
+  // ── Sectioned detail (Details → Upcoming Events → Board) ─────────────
+
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }} edges={['top']}>
       <HeaderBar
@@ -368,310 +315,170 @@ export default function CenterDetailPage() {
 
       <ScrollView
         style={{ flex: 1 }}
-        contentContainerStyle={{ paddingBottom: 40 }}
+        contentContainerStyle={{ paddingBottom: 32 }}
+        keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
         {/* Hero image — edge-to-edge */}
         {center.image ? (
-          <Image
-            source={{ uri: center.image }}
-            style={{ width: '100%', height: 200 }}
-            resizeMode="cover"
-          />
+          <Image source={{ uri: center.image }} style={{ width: '100%', height: 200, marginBottom: 4 }} resizeMode="cover" />
         ) : null}
 
-        <View style={{ paddingTop: 8 }}>
-          <UnderlineTabBar
-            tabs={['About', 'Thread', 'Events']}
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            counts={{ Thread: boardMessages.length, Events: events.length }}
-          />
-        </View>
-
-        {/* Content area */}
-        <View style={{ paddingHorizontal: 20, paddingTop: 20, paddingBottom: 32 }}>
-          {activeTab === 'About' && (
-            <>
-              {/* Point of contact subtitle */}
-              {center.pointOfContact ? (
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 13,
-                    color: colors.textSecondary,
-                    marginBottom: 16,
-                  }}
-                >
-                  Point of Contact: {center.pointOfContact}
+        {/* DETAILS */}
+        <DetailSection title="Details" first>
+          <View style={{ gap: 16 }}>
+            {center.pointOfContact ? (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+                <MetaIcon icon={User} color="#E8862A" colors={colors} />
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
+                  Contact: {center.pointOfContact}
                 </Text>
-              ) : null}
-
-              {/* Meta rows */}
-              <View style={{ gap: 16 }}>
-                {/* Address */}
-                {center.address ? (
-                  <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
-                    <MetaIcon icon={MapPin} color="#E8862A" colors={colors} />
-                    <View style={{ flex: 1, gap: 8 }}>
-                      <Text
-                        style={{
-                          fontSize: 14,
-                          color: colors.text,
-                          lineHeight: 20,
-                        }}
-                      >
-                        {center.address}
-                      </Text>
-                      <Pressable
-                        onPress={handleAddressPress}
-                        style={{ alignSelf: 'flex-start', paddingVertical: 4 }}
-                        accessibilityLabel="Get directions"
-                      >
-                        <Text
-                          style={{
-                            fontSize: 14,
-                            color: '#E8862A',
-                          }}
-                        >
-                          Get directions →
-                        </Text>
-                      </Pressable>
-                    </View>
-                  </View>
-                ) : null}
-
-                {/* Website */}
-                {center.website ? (
-                  <Pressable
-                    onPress={handleWebsitePress}
-                    style={{ flexDirection: 'row', alignItems: 'center', gap: 12, minHeight: 44 }}
-                  >
-                    <MetaIcon icon={Globe} color="#E8862A" colors={colors} />
-                    <Text
-                      style={{
-                        fontSize: 14,
-                        color: '#E8862A',
-                        lineHeight: 20,
-                        flex: 1,
-                      }}
-                      numberOfLines={1}
-                    >
-                      {displayWebsite}
-                    </Text>
-                  </Pressable>
-                ) : null}
-
-                {/* Phone */}
-                {center.phone ? (
-                  <Pressable
-                    onPress={handlePhonePress}
-                    style={{ flexDirection: 'row', alignItems: 'center', gap: 12, minHeight: 44 }}
-                  >
-                    <MetaIcon icon={Phone} color="#E8862A" colors={colors} />
-                    <Text
-                      style={{
-                        fontSize: 14,
-                        color: colors.text,
-                        lineHeight: 20,
-                        flex: 1,
-                      }}
-                    >
-                      {center.phone}
-                    </Text>
-                  </Pressable>
-                ) : null}
-
-                {/* Acharya */}
-                {center.acharya ? (
-                  <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
-                    <MetaIcon icon={User} color="#E8862A" colors={colors} />
-                    <View style={{ flex: 1, justifyContent: 'center' }}>
-                      <Text
-                        style={{
-                          fontSize: 14,
-                          color: colors.text,
-                          lineHeight: 20,
-                        }}
-                      >
-                        {center.acharya}
-                      </Text>
-                      <Text
-                        style={{
-                          fontSize: 13,
-                          color: colors.textSecondary,
-                          lineHeight: 18,
-                          marginTop: 2,
-                        }}
-                      >
-                        Resident Acharya
-                      </Text>
-                    </View>
-                  </View>
-                ) : null}
               </View>
+            ) : null}
 
-              {/* #208 — center board CTA (tier-gated) */}
-              {isVerified ? (
+            {/* Address */}
+            {center.address ? (
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
+                <MetaIcon icon={MapPin} color="#E8862A" colors={colors} />
+                <View style={{ flex: 1, gap: 6 }}>
+                  <Text style={{ fontSize: 14, color: colors.text, lineHeight: 20 }}>{center.address}</Text>
+                  <Pressable
+                    onPress={handleAddressPress}
+                    style={{ alignSelf: 'flex-start', paddingVertical: 2 }}
+                    accessibilityLabel="Get directions"
+                  >
+                    <Text style={{ fontSize: 14, color: '#E8862A' }}>Get directions →</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ) : null}
+
+            {/* Website */}
+            {center.website ? (
+              <Pressable
+                onPress={handleWebsitePress}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 12, minHeight: 44 }}
+              >
+                <MetaIcon icon={Globe} color="#E8862A" colors={colors} />
+                <Text style={{ fontSize: 14, color: '#E8862A', lineHeight: 20, flex: 1 }} numberOfLines={1}>
+                  {displayWebsite}
+                </Text>
+              </Pressable>
+            ) : null}
+
+            {/* Phone */}
+            {center.phone ? (
+              <Pressable
+                onPress={handlePhonePress}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 12, minHeight: 44 }}
+              >
+                <MetaIcon icon={Phone} color="#E8862A" colors={colors} />
+                <Text style={{ fontSize: 14, color: colors.text, lineHeight: 20, flex: 1 }}>{center.phone}</Text>
+              </Pressable>
+            ) : null}
+
+            {/* Acharya */}
+            {center.acharya ? (
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
+                <MetaIcon icon={User} color="#E8862A" colors={colors} />
+                <View style={{ flex: 1, justifyContent: 'center' }}>
+                  <Text style={{ fontSize: 14, color: colors.text, lineHeight: 20 }}>{center.acharya}</Text>
+                  <Text style={{ fontSize: 13, color: colors.textSecondary, lineHeight: 18, marginTop: 2 }}>
+                    Resident Acharya
+                  </Text>
+                </View>
+              </View>
+            ) : null}
+          </View>
+        </DetailSection>
+
+        {/* UPCOMING EVENTS */}
+        {events.length > 0 ? (
+          <DetailSection title="Upcoming Events" count={events.length} contentStyle={{ gap: 8 }}>
+            {events.map((event) => {
+              const { month, day } = formatDateCallout(event.date)
+              return (
                 <Pressable
-                  onPress={() => setActiveTab('Thread')}
-                  accessibilityRole="button"
-                  accessibilityLabel="Open center board"
+                  key={event.id}
+                  onPress={() => handleEventPress(event)}
                   style={{
-                    marginTop: 20,
                     flexDirection: 'row',
                     alignItems: 'center',
-                    gap: 12,
-                    padding: 14,
-                    borderRadius: 14,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    backgroundColor: colors.iconBoxBg,
+                    backgroundColor: colors.cardBg,
+                    borderRadius: 12,
+                    paddingVertical: 12,
+                    paddingHorizontal: 14,
+                    minHeight: 44,
                   }}
                 >
-                  <MessageSquare size={18} color="#E8862A" />
-                  <View style={{ flex: 1 }}>
-                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: colors.text }}>
-                      Open center board
+                  <View style={{ width: 52, alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                    <Text
+                      style={{
+                        fontFamily: 'Inclusive Sans',
+                        fontSize: 11,
+                        color: '#E8862A',
+                        textTransform: 'uppercase',
+                        lineHeight: 14,
+                      }}
+                    >
+                      {month}
                     </Text>
-                    <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
-                      {boardMessages.length > 0
-                        ? `${boardMessages.length} ${boardMessages.length === 1 ? 'post' : 'posts'} from members`
-                        : 'No posts yet — start the conversation'}
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 22, color: colors.text, lineHeight: 28 }}>
+                      {day}
                     </Text>
                   </View>
-                  <ChevronRight size={18} color={colors.textSecondary} />
+
+                  <View style={{ width: 1, backgroundColor: colors.border, alignSelf: 'stretch', marginHorizontal: 12 }} />
+
+                  <View style={{ flex: 1 }}>
+                    <Text
+                      style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text, lineHeight: 20 }}
+                      numberOfLines={2}
+                    >
+                      {event.title}
+                    </Text>
+                    <Text
+                      style={{
+                        fontFamily: 'Inclusive Sans',
+                        fontSize: 12,
+                        color: colors.textSecondary,
+                        lineHeight: 16,
+                        marginTop: 2,
+                      }}
+                    >
+                      {event.time}
+                      {event.attendees > 0 ? ` · ${event.attendees} attending` : ''}
+                    </Text>
+                  </View>
                 </Pressable>
-              ) : (
-                <View
-                  style={{
-                    marginTop: 20,
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: 12,
-                    padding: 14,
-                    borderRadius: 14,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    backgroundColor: colors.iconBoxBg,
-                  }}
-                >
-                  <MessageSquare size={18} color={colors.textSecondary} />
-                  <Text style={{ flex: 1, fontSize: 13, color: colors.textSecondary }}>
-                    Verified members can post on the center board.
-                  </Text>
-                </View>
-              )}
-            </>
+              )
+            })}
+          </DetailSection>
+        ) : null}
+
+        {/* BOARD — feed-style posts. Tapping a post opens the focused thread. */}
+        <DetailSection
+          title="Board"
+          count={canPostToThread ? boardMessages.length : undefined}
+          contentStyle={{ paddingHorizontal: 0 }}
+        >
+          {canPostToThread ? (
+            <ThreadPanel
+              messages={boardMessages}
+              colors={colors}
+              emptyTitle="Be the first to post"
+              emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
+              composerPlaceholder="Write to the board..."
+              composerState="open"
+              onSubmitPost={handleCreateThreadPost}
+              onMessagePress={openThreadPost}
+            />
+          ) : (
+            <View style={{ paddingHorizontal: 20 }}>
+              <LockedBoard colors={colors} />
+            </View>
           )}
-
-          {activeTab === 'Thread' && renderThreadTab()}
-
-          {activeTab === 'Events' && (
-            <>
-              {events.length > 0 ? (
-                <View style={{ gap: 8 }}>
-                  {events.map((event) => {
-                    const { month, day } = formatDateCallout(event.date)
-                    return (
-                      <Pressable
-                        key={event.id}
-                        onPress={() => handleEventPress(event)}
-                        style={{
-                          flexDirection: 'row',
-                          alignItems: 'center',
-                          backgroundColor: colors.cardBg,
-                          borderRadius: 8,
-                          paddingVertical: 12,
-                          paddingHorizontal: 14,
-                          minHeight: 44,
-                        }}
-                      >
-                        <View
-                          style={{
-                            width: 52,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0,
-                          }}
-                        >
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 11,
-                              color: '#E8862A',
-                              textTransform: 'uppercase',
-                              lineHeight: 14,
-                            }}
-                          >
-                            {month}
-                          </Text>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 22,
-                              color: colors.text,
-                              lineHeight: 28,
-                            }}
-                          >
-                            {day}
-                          </Text>
-                        </View>
-
-                        <View
-                          style={{
-                            width: 1,
-                            backgroundColor: colors.border,
-                            alignSelf: 'stretch',
-                            marginHorizontal: 12,
-                          }}
-                        />
-
-                        <View style={{ flex: 1 }}>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 14,
-                              color: colors.text,
-                              lineHeight: 20,
-                            }}
-                            numberOfLines={2}
-                          >
-                            {event.title}
-                          </Text>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 12,
-                              color: colors.textSecondary,
-                              lineHeight: 16,
-                              marginTop: 2,
-                            }}
-                          >
-                            {event.time}
-                            {event.attendees > 0 ? ` \u00B7 ${event.attendees} attending` : ''}
-                          </Text>
-                        </View>
-                      </Pressable>
-                    )
-                  })}
-                </View>
-              ) : (
-                <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-                  <Text
-                    style={{
-                      fontFamily: 'Inclusive Sans',
-                      fontSize: 14,
-                      color: colors.textSecondary,
-                    }}
-                  >
-                    No upcoming events yet
-                  </Text>
-                </View>
-              )}
-            </>
-          )}
-        </View>
+        </DetailSection>
       </ScrollView>
     </SafeAreaView>
   )

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, ScrollView, Image, Pressable, ActivityIndicator, Linking, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, ChevronRight, Share2, MapPin, Globe, Phone, User, Navigation, BadgeCheck, Users, MessageSquare } from 'lucide-react-native'
+import { ChevronLeft, Share2, MapPin, Globe, Phone, User, BadgeCheck, Users, Lock } from 'lucide-react-native'
 import { useBoard, useCenterDetail } from '../../hooks/useApiData'
-import { useDetailColors } from '../../hooks/useDetailColors'
+import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
-import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
+import { DetailSection } from '../../components/ui'
 import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
@@ -51,6 +51,29 @@ function formatDateCallout(dateStr: string): { month: string; day: string } {
   return { month, day }
 }
 
+function LockedBoard({ colors }: { colors: DetailColors }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.iconBoxBg,
+      }}
+    >
+      <Lock size={18} color={colors.textSecondary} />
+      <Text style={{ flex: 1, fontSize: 13, color: colors.textSecondary }}>
+        Verified members of this center can post and reply on the board.
+      </Text>
+    </View>
+  )
+}
+
 function MobileCenterDetail({ centerId }: { centerId: string }) {
   const router = useRouter()
   const { user } = useUser()
@@ -58,7 +81,6 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   const { center, events, loading } = useCenterDetail(centerId)
   const colors = useDetailColors()
   const appColors = useColors()
-  const [activeTab, setActiveTab] = useState('About')
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
 
   // Fire center_viewed once per center load. Mirrors the native page's
@@ -74,7 +96,6 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }, [loading, center?.id, center?.name, posthog])
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
-  const isVerified = !!user?.isVerified
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -99,43 +120,8 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
 
   const closeThreadPost = () => setThreadDetailPost(null)
 
-  const renderThreadTab = () =>
-    threadDetailPost ? (
-      <View style={{ paddingTop: 4 }}>
-        <Pressable
-          onPress={closeThreadPost}
-          accessibilityRole="button"
-          accessibilityLabel="Back to board"
-          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
-        >
-          <ChevronLeft size={20} color={appColors.accent} />
-          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
-        </Pressable>
-        <PostThread
-          post={threadDetailPost}
-          colors={appColors}
-          onPostChanged={refetchBoard}
-          onPostDeleted={() => {
-            closeThreadPost()
-            refetchBoard()
-          }}
-        />
-      </View>
-    ) : (
-      <ThreadPanel
-        messages={boardMessages}
-        colors={colors}
-        emptyTitle="Be the first to post"
-        emptySubtitle={`Ask about rides, what to bring, or anything else for ${center?.name ?? 'this center'}.`}
-        composerPlaceholder="Write to the board..."
-        composerState={canPostToThread ? 'open' : 'locked'}
-        onSubmitPost={handleCreateThreadPost}
-        onMessagePress={openThreadPost}
-      />
-    )
-
   const handleShare = () => {
-    posthog?.capture('center_shared', { centerId: center?.id, source: 'web_detail' })
+    posthog?.capture('center_shared', { centerId: center?.id ?? '', source: 'web_detail' })
     if (typeof navigator !== 'undefined' && navigator.share) {
       navigator.share({ title: center?.name || 'Center', text: `Check out ${center?.name} on Chinmaya Janata!` }).catch(() => {})
     } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -163,7 +149,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }
 
   const handleEventPress = (event: EventDisplay) => {
-    posthog?.capture('center_event_pressed', { centerId: center?.id, eventId: event.id, source: 'web_detail' })
+    posthog?.capture('center_event_pressed', { centerId: center?.id ?? '', eventId: event.id, source: 'web_detail' })
     router.push(`/events/${event.id}`)
   }
 
@@ -186,6 +172,36 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
     )
   }
 
+  // ── Focused thread view (a board post + its replies) ─────────────────
+  if (threadDetailPost) {
+    return (
+      <View style={{ flex: 1, backgroundColor: appColors.bg }}>
+        <View style={{ paddingTop: 12 }}>
+          <Pressable
+            onPress={closeThreadPost}
+            accessibilityRole="button"
+            accessibilityLabel="Back to board"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
+          >
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              closeThreadPost()
+              refetchBoard()
+            }}
+          />
+        </View>
+      </View>
+    )
+  }
+
   const displayWebsite = (center.website ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '')
   const seoTitle = center.name || 'Center'
   const seoDesc =
@@ -204,7 +220,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
         jsonLd={centerJsonLd}
       />
       {/* Header */}
-      <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8, gap: 10 }}>
+      <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 12, gap: 12 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
           <Pressable
             onPress={() => router.back()}
@@ -215,32 +231,25 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
             <ChevronLeft size={20} color={colors.textSecondary} />
             <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Back</Text>
           </Pressable>
-          <Pressable
-            onPress={handleShare}
-            accessibilityRole="button"
-            accessibilityLabel="Share this center"
-            style={{ padding: 8 }}
-          >
+          <Pressable onPress={handleShare} accessibilityRole="button" accessibilityLabel="Share this center" style={{ padding: 8 }}>
             <Share2 size={18} color={colors.textSecondary} />
           </Pressable>
         </View>
-        <Text style={{ fontSize: 22, fontWeight: 'bold', color: colors.text }}>{center.name}</Text>
+        <Text style={{ fontSize: 26, fontWeight: 'bold', color: colors.text }}>{center.name}</Text>
         {(center.memberCount > 0 || center.isVerified) && (
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
             {center.memberCount > 0 && (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                <Users size={13} color={colors.textSecondary} />
+                <Users size={14} color={colors.textSecondary} />
                 <Text style={{ fontSize: 13, color: colors.textSecondary }}>
                   {center.memberCount} {center.memberCount === 1 ? 'member' : 'members'}
                 </Text>
               </View>
             )}
-            {center.memberCount > 0 && center.isVerified && (
-              <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>
-            )}
+            {center.memberCount > 0 && center.isVerified && <Text style={{ fontSize: 13, color: colors.textMuted }}>·</Text>}
             {center.isVerified && (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                <BadgeCheck size={13} color="#E8862A" />
+                <BadgeCheck size={14} color="#E8862A" />
                 <Text style={{ fontSize: 13, color: '#E8862A' }}>Verified</Text>
               </View>
             )}
@@ -248,173 +257,114 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
         )}
       </View>
 
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 40 }}>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 40 }} keyboardShouldPersistTaps="handled">
         {/* Hero image */}
         {center.image ? (
-          <Image source={{ uri: center.image }} style={{ width: '100%', height: 200 }} resizeMode="cover" />
+          <Image source={{ uri: center.image }} style={{ width: '100%', height: 200, marginBottom: 4 }} resizeMode="cover" />
         ) : null}
 
-        <View style={{ paddingTop: 8 }}>
-          <UnderlineTabBar
-            tabs={['About', 'Thread', 'Events']}
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            counts={{ Thread: boardMessages.length, Events: events.length }}
-          />
-        </View>
-
-        <View style={{ paddingHorizontal: 16, paddingTop: 20, gap: 16 }}>
-          {activeTab === 'About' && (
-            <>
-          {/* Point of contact */}
-          {center.pointOfContact ? (
-            <Text style={{ color: colors.textSecondary, fontSize: 13 }}>
-              Point of Contact: {center.pointOfContact}
-            </Text>
-          ) : null}
-
-          {/* Address */}
-          {center.address ? (
-            <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>
-              <MapPin size={18} color="#E8862A" style={{ marginTop: 2 }} />
-              <View style={{ flex: 1, gap: 8 }}>
-                <Text style={{ color: colors.text, fontSize: 15 }}>{center.address}</Text>
-                <Pressable
-                  onPress={handleAddressPress}
-                  style={{ alignSelf: 'flex-start', paddingVertical: 4 }}
-                  accessibilityLabel="Get directions"
-                >
-                  <Text style={{ color: '#E8862A', fontSize: 14, fontWeight: '600', fontFamily: 'Inclusive Sans' }}>
-                    Get directions →
-                  </Text>
-                </Pressable>
+        {/* DETAILS */}
+        <DetailSection title="Details" first>
+          <View style={{ gap: 16 }}>
+            {center.pointOfContact ? (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <User size={18} color="#E8862A" />
+                <Text style={{ color: colors.text, fontSize: 15 }}>Contact: {center.pointOfContact}</Text>
               </View>
-            </View>
-          ) : null}
-
-          {/* Website */}
-          {center.website ? (
-            <Pressable onPress={handleWebsitePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <Globe size={18} color="#E8862A" />
-              <Text style={{ color: '#E8862A', fontSize: 15, flex: 1 }} numberOfLines={1}>{displayWebsite}</Text>
-            </Pressable>
-          ) : null}
-
-          {/* Phone */}
-          {center.phone ? (
-            <Pressable onPress={handlePhonePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <Phone size={18} color="#E8862A" />
-              <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{center.phone}</Text>
-            </Pressable>
-          ) : null}
-
-          {/* Acharya */}
-          {center.acharya ? (
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <User size={18} color="#E8862A" />
-              <View style={{ flex: 1 }}>
-                <Text style={{ color: colors.text, fontSize: 15 }}>{center.acharya}</Text>
-                <Text style={{ color: colors.textSecondary, fontSize: 13 }}>Resident Acharya</Text>
-              </View>
-            </View>
             ) : null}
 
-            {/* #208 — center board CTA (tier-gated) */}
-            {isVerified ? (
-              <Pressable
-                onPress={() => setActiveTab('Thread')}
-                accessibilityRole="button"
-                accessibilityLabel="Open center board"
-                style={{
-                  marginTop: 20,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 12,
-                  padding: 14,
-                  borderRadius: 14,
-                  borderWidth: 1,
-                  borderColor: colors.border,
-                  backgroundColor: colors.iconBoxBg,
-                }}
-              >
-                <MessageSquare size={18} color="#E8862A" />
-                <View style={{ flex: 1 }}>
-                  <Text style={{ color: colors.text, fontSize: 15 }}>Open center board</Text>
-                  <Text style={{ color: colors.textSecondary, fontSize: 12, marginTop: 2 }}>
-                    {boardMessages.length > 0
-                      ? `${boardMessages.length} ${boardMessages.length === 1 ? 'post' : 'posts'} from members`
-                      : 'No posts yet — start the conversation'}
-                  </Text>
+            {center.address ? (
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>
+                <MapPin size={18} color="#E8862A" style={{ marginTop: 2 }} />
+                <View style={{ flex: 1, gap: 6 }}>
+                  <Text style={{ color: colors.text, fontSize: 15 }}>{center.address}</Text>
+                  <Pressable onPress={handleAddressPress} style={{ alignSelf: 'flex-start', paddingVertical: 2 }} accessibilityLabel="Get directions">
+                    <Text style={{ color: '#E8862A', fontSize: 14, fontWeight: '600' }}>Get directions →</Text>
+                  </Pressable>
                 </View>
-                <ChevronRight size={18} color={colors.textSecondary} />
-              </Pressable>
-            ) : (
-              <View
-                style={{
-                  marginTop: 20,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 12,
-                  padding: 14,
-                  borderRadius: 14,
-                  borderWidth: 1,
-                  borderColor: colors.border,
-                  backgroundColor: colors.iconBoxBg,
-                }}
-              >
-                <MessageSquare size={18} color={colors.textSecondary} />
-                <Text style={{ flex: 1, color: colors.textSecondary, fontSize: 13 }}>
-                  Verified members can post on the center board.
-                </Text>
               </View>
-            )}
-            </>
-          )}
+            ) : null}
 
-          {activeTab === 'Thread' && renderThreadTab()}
+            {center.website ? (
+              <Pressable onPress={handleWebsitePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Globe size={18} color="#E8862A" />
+                <Text style={{ color: '#E8862A', fontSize: 15, flex: 1 }} numberOfLines={1}>{displayWebsite}</Text>
+              </Pressable>
+            ) : null}
 
-          {activeTab === 'Events' && (
-            <>
-              {events.length > 0 ? (
-                <View style={{ gap: 8 }}>
-                  {events.map((event) => {
-                    const { month, day } = formatDateCallout(event.date)
-                    return (
-                      <Pressable
-                        key={event.id}
-                        onPress={() => handleEventPress(event)}
-                        style={{
-                          flexDirection: 'row',
-                          alignItems: 'center',
-                          backgroundColor: colors.cardBg,
-                          borderRadius: 8,
-                          paddingVertical: 12,
-                          paddingHorizontal: 14,
-                        }}
-                      >
-                        <View style={{ width: 52, alignItems: 'center' }}>
-                          <Text style={{ fontSize: 11, fontWeight: '600', color: '#E8862A', textTransform: 'uppercase' }}>{month}</Text>
-                          <Text style={{ fontSize: 22, fontWeight: '600', color: colors.text }}>{day}</Text>
-                        </View>
-                        <View style={{ width: 1, backgroundColor: colors.border, alignSelf: 'stretch', marginHorizontal: 12 }} />
-                        <View style={{ flex: 1 }}>
-                          <Text style={{ fontSize: 14, fontWeight: '600', color: colors.text }} numberOfLines={2}>{event.title}</Text>
-                          <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
-                            {event.time}{event.attendees > 0 ? ` · ${event.attendees} attending` : ''}
-                          </Text>
-                        </View>
-                      </Pressable>
-                    )
-                  })}
+            {center.phone ? (
+              <Pressable onPress={handlePhonePress} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <Phone size={18} color="#E8862A" />
+                <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{center.phone}</Text>
+              </Pressable>
+            ) : null}
+
+            {center.acharya ? (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                <User size={18} color="#E8862A" />
+                <View style={{ flex: 1 }}>
+                  <Text style={{ color: colors.text, fontSize: 15 }}>{center.acharya}</Text>
+                  <Text style={{ color: colors.textSecondary, fontSize: 13 }}>Resident Acharya</Text>
                 </View>
-              ) : (
-                <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-                  <Text style={{ fontSize: 14, color: colors.textSecondary }}>No upcoming events yet</Text>
-                </View>
-              )}
-            </>
+              </View>
+            ) : null}
+          </View>
+        </DetailSection>
+
+        {/* UPCOMING EVENTS */}
+        {events.length > 0 ? (
+          <DetailSection title="Upcoming Events" count={events.length} contentStyle={{ gap: 8 }}>
+            {events.map((event) => {
+              const { month, day } = formatDateCallout(event.date)
+              return (
+                <Pressable
+                  key={event.id}
+                  onPress={() => handleEventPress(event)}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    backgroundColor: colors.cardBg,
+                    borderRadius: 12,
+                    paddingVertical: 12,
+                    paddingHorizontal: 14,
+                  }}
+                >
+                  <View style={{ width: 52, alignItems: 'center' }}>
+                    <Text style={{ fontSize: 11, fontWeight: '600', color: '#E8862A', textTransform: 'uppercase' }}>{month}</Text>
+                    <Text style={{ fontSize: 22, fontWeight: '600', color: colors.text }}>{day}</Text>
+                  </View>
+                  <View style={{ width: 1, backgroundColor: colors.border, alignSelf: 'stretch', marginHorizontal: 12 }} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ fontSize: 14, fontWeight: '600', color: colors.text }} numberOfLines={2}>{event.title}</Text>
+                    <Text style={{ fontSize: 12, color: colors.textSecondary, marginTop: 2 }}>
+                      {event.time}{event.attendees > 0 ? ` · ${event.attendees} attending` : ''}
+                    </Text>
+                  </View>
+                </Pressable>
+              )
+            })}
+          </DetailSection>
+        ) : null}
+
+        {/* BOARD */}
+        <DetailSection title="Board" count={canPostToThread ? boardMessages.length : undefined} contentStyle={{ paddingHorizontal: 0 }}>
+          {canPostToThread ? (
+            <ThreadPanel
+              messages={boardMessages}
+              colors={colors}
+              emptyTitle="Be the first to post"
+              emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
+              composerPlaceholder="Write to the board..."
+              composerState="open"
+              onSubmitPost={handleCreateThreadPost}
+              onMessagePress={openThreadPost}
+            />
+          ) : (
+            <View style={{ paddingHorizontal: 16 }}>
+              <LockedBoard colors={colors} />
+            </View>
           )}
-        </View>
+        </DetailSection>
       </ScrollView>
     </View>
   )

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -11,13 +11,14 @@ import {
   User,
   Clock,
   CheckCircle,
+  Lock,
   Pencil,
   Trash2,
 } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
 import { useBoard, useEventDetail } from '../../hooks/useApiData'
 import { useUser } from '../../components/contexts'
-import { Badge, UnderlineTabBar, Avatar, PrimaryButton, DestructiveButton } from '../../components/ui'
+import { Badge, Avatar, PrimaryButton, DestructiveButton, DetailSection } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
 import { createBoardPost, removeEvent } from '../../utils/api'
@@ -80,12 +81,23 @@ function formatRelativeDateTime(dateStr: string, timeStr: string): string {
   return `${relative} · ${absolute}`
 }
 
-function formatEventDateLabel(dateStr: string): string {
-  const d = new Date(`${dateStr}T00:00:00`)
-  if (Number.isNaN(d.getTime())) return dateStr.toUpperCase()
-  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
-  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
-  return `${weekday}, ${month} ${d.getDate()}`
+// Split an address like "129 Woodbury Rd, Woodbury, NY - 11797, US" into
+// the street segment and the rest using the first comma as the boundary.
+function splitStreet(addr: string): string {
+  const i = addr.indexOf(',')
+  return i === -1 ? addr : addr.slice(0, i).trim()
+}
+function splitRest(addr: string): string {
+  const i = addr.indexOf(',')
+  return i === -1 ? '' : addr.slice(i + 1).trim()
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return 'official site'
+  }
 }
 
 // ── Sub-components ───────────────────────────────────────────────────────
@@ -122,7 +134,7 @@ function AvatarStack({
   attendees: { image?: string; initials?: string; name: string }[]
   colors: DetailColors
 }) {
-  const shown = attendees.slice(0, 3)
+  const shown = attendees.slice(0, 5)
   return (
     <View style={{ flexDirection: 'row', marginLeft: 4 }}>
       {shown.map((a, i) => (
@@ -131,7 +143,7 @@ function AvatarStack({
           image={a.image}
           initials={a.initials}
           name={a.name}
-          size={24}
+          size={28}
           style={{
             borderWidth: 2,
             borderColor: colors.avatarBorder,
@@ -173,10 +185,8 @@ function HeaderBar({
       style={{
         paddingHorizontal: 16,
         paddingTop: 8,
-        paddingBottom: 12,
-        borderBottomWidth: isRegistered ? 0 : 1,
-        borderBottomColor: colors.border,
-        gap: 10,
+        paddingBottom: 14,
+        gap: 12,
       }}
     >
       {/* Top row: back + actions */}
@@ -195,13 +205,7 @@ function HeaderBar({
           }}
         >
           <ChevronLeft size={20} color={colors.iconHeader} />
-          <Text
-            style={{
-              fontFamily: 'Inclusive Sans',
-              fontSize: 14,
-              color: colors.iconHeader,
-            }}
-          >
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.iconHeader }}>
             Back
           </Text>
         </Pressable>
@@ -213,13 +217,7 @@ function HeaderBar({
                 onEdit?.()
                 router.push(`/events/form?id=${eventId}`)
               }}
-              style={{
-                padding: 8,
-                minHeight: 44,
-                minWidth: 44,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
               accessibilityLabel="Edit event"
             >
               <Pencil size={18} color={colors.iconHeader} />
@@ -228,13 +226,7 @@ function HeaderBar({
           {eventId && isAdmin && onDelete && (
             <Pressable
               onPress={onDelete}
-              style={{
-                padding: 8,
-                minHeight: 44,
-                minWidth: 44,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
               accessibilityLabel="Delete event"
             >
               <Trash2 size={18} color="#DC2626" />
@@ -251,13 +243,7 @@ function HeaderBar({
               }}
               accessibilityRole="button"
               accessibilityLabel="Share this event"
-              style={{
-                padding: 8,
-                minHeight: 44,
-                minWidth: 44,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              style={{ padding: 8, minHeight: 44, minWidth: 44, alignItems: 'center', justifyContent: 'center' }}
             >
               <Share2 size={18} color={colors.iconHeader} />
             </Pressable>
@@ -271,15 +257,15 @@ function HeaderBar({
           style={{
             flex: 1,
             fontFamily: 'Inclusive Sans',
-            fontSize: 20,
+            fontSize: 26,
             color: colors.text,
-            lineHeight: 26,
+            lineHeight: 32,
           }}
         >
           {title}
         </Text>
         {isRegistered && (
-          <View style={{ marginTop: 3 }}>
+          <View style={{ marginTop: 5 }}>
             <Badge label="Going" variant="going" />
           </View>
         )}
@@ -288,62 +274,60 @@ function HeaderBar({
   )
 }
 
-// ── Meta section ─────────────────────────────────────────────────────────
+// ── Details section content ──────────────────────────────────────────────
 
-function MetaSection({
+function DetailsContent({
   event,
   attendees,
   isPast,
   colors,
 }: {
-  event: { location: string; address?: string; attendees: number; pointOfContact?: string; signupUrl?: string | null; allowJanataSignup?: boolean }
-  attendees: { image?: string; initials?: string; name: string; subtitle: string }[]
+  event: {
+    date: string
+    time: string
+    location: string
+    address?: string
+    attendees: number
+    pointOfContact?: string
+    description?: string
+    signupUrl?: string | null
+    allowJanataSignup?: boolean
+  }
+  attendees: { image?: string; initials?: string; name: string }[]
   isPast?: boolean
   colors: DetailColors
 }) {
   const iconColor = isPast ? colors.textMuted : '#E8862A'
-  const attendLabel = `${event.attendees} on Janata`
+  const loc = (event.location || '').trim()
+  const addr = (event.address || '').trim()
+  const dupe = loc && addr && loc === addr
+  const line1 = dupe ? splitStreet(addr) : loc
+  const line2 = dupe ? splitRest(addr) : addr
 
   return (
     <View style={{ gap: 16 }}>
-      {/* Location — when location and address are the same value (common
-          when the venue isn't named separately), split into "street" /
-          "city, state, zip" so the second line isn't a duplicate. */}
-      {(() => {
-        const loc = (event.location || '').trim()
-        const addr = (event.address || '').trim()
-        const dupe = loc && addr && loc === addr
-        const line1 = dupe ? splitStreet(addr) : loc
-        const line2 = dupe ? splitRest(addr) : addr
-        return (
-          <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
-            <MetaIcon icon={MapPin} color={iconColor} colors={colors} />
-            <View style={{ flex: 1, gap: 2, justifyContent: 'center' }}>
-              {line1 ? (
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
-                  {line1}
-                </Text>
-              ) : null}
-              {line2 ? (
-                <Text
-                  style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}
-                >
-                  {line2}
-                </Text>
-              ) : null}
-            </View>
-          </View>
-        )
-      })()}
+      {/* Date & time */}
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <MetaIcon icon={Clock} color={iconColor} colors={colors} />
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
+          {formatRelativeDateTime(event.date, event.time)}
+        </Text>
+      </View>
 
-      {/* Attendees — hidden when external signup is exclusive (no native RSVP) */}
-      {!(event.signupUrl && !event.allowJanataSignup) && (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <MetaIcon icon={Users} color={iconColor} colors={colors} />
-          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
-            {attendLabel}
-          </Text>
-          <AvatarStack attendees={attendees} colors={colors} />
+      {/* Location */}
+      {(line1 || line2) && (
+        <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
+          <MetaIcon icon={MapPin} color={iconColor} colors={colors} />
+          <View style={{ flex: 1, gap: 2, justifyContent: 'center' }}>
+            {line1 ? (
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>{line1}</Text>
+            ) : null}
+            {line2 ? (
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}>
+                {line2}
+              </Text>
+            ) : null}
+          </View>
         </View>
       )}
 
@@ -356,37 +340,65 @@ function MetaSection({
           </Text>
         </View>
       ) : null}
+
+      {/* About */}
+      {event.description ? (
+        <Text
+          style={{
+            fontFamily: 'Inclusive Sans',
+            fontSize: 14,
+            color: colors.textSecondary,
+            lineHeight: 21,
+            marginTop: 2,
+          }}
+        >
+          {event.description}
+        </Text>
+      ) : null}
     </View>
   )
 }
 
-// ── About section ────────────────────────────────────────────────────────
+// ── Attendees section content ────────────────────────────────────────────
 
-function AboutSection({ description, colors }: { description?: string; colors: DetailColors }) {
-  if (!description) return null
+function AttendeesContent({
+  attendees,
+  colors,
+}: {
+  attendees: { image?: string; initials?: string; name: string; subtitle: string }[]
+  colors: DetailColors
+}) {
+  if (attendees.length === 0) {
+    return (
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 4 }}>
+        <Users size={18} color={colors.textMuted} />
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textSecondary }}>
+          No attendees yet — be the first to RSVP.
+        </Text>
+      </View>
+    )
+  }
   return (
-    <View style={{ gap: 12 }}>
-      <Text
-        style={{
-          fontFamily: 'Inclusive Sans',
-          fontSize: 11,
-          color: colors.textMuted,
-          letterSpacing: 0.5,
-          textTransform: 'uppercase',
-        }}
-      >
-        About
-      </Text>
-      <Text
-        style={{
-          fontFamily: 'Inclusive Sans',
-          fontSize: 14,
-          color: colors.textSecondary,
-          lineHeight: 20,
-        }}
-      >
-        {description}
-      </Text>
+    <View>
+      {attendees.map((attendee, index) => (
+        <View
+          key={index}
+          style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 10, gap: 12 }}
+        >
+          <Avatar image={attendee.image} initials={attendee.initials} name={attendee.name} size={40} />
+          <View style={{ flex: 1, gap: 2 }}>
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
+              {attendee.name}
+            </Text>
+            {attendee.subtitle ? (
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textSecondary }}>
+                {attendee.subtitle}
+              </Text>
+            ) : null}
+          </View>
+          {index === 0 && <Badge label="HOST" variant="host" />}
+        </View>
+      ))}
     </View>
   )
 }
@@ -402,6 +414,7 @@ function AttendedBanner({ count, colors }: { count: number; colors: DetailColors
         padding: 12,
         paddingHorizontal: 16,
         gap: 4,
+        marginBottom: 4,
       }}
     >
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
@@ -411,9 +424,7 @@ function AttendedBanner({ count, colors }: { count: number; colors: DetailColors
         </Text>
       </View>
       {count > 1 && (
-        <Text
-          style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: '#059669', marginLeft: 26 }}
-        >
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: '#059669', marginLeft: 26 }}>
           Along with {count - 1} others
         </Text>
       )}
@@ -421,27 +432,7 @@ function AttendedBanner({ count, colors }: { count: number; colors: DetailColors
   )
 }
 
-// ── Action bar ───────────────────────────────────────────────────────────
-
-// Split an address like "129 Woodbury Rd, Woodbury, NY - 11797, US" into
-// the street segment ("129 Woodbury Rd") and the rest ("Woodbury, NY - 11797, US")
-// using the first comma as the boundary.
-function splitStreet(addr: string): string {
-  const i = addr.indexOf(',')
-  return i === -1 ? addr : addr.slice(0, i).trim()
-}
-function splitRest(addr: string): string {
-  const i = addr.indexOf(',')
-  return i === -1 ? '' : addr.slice(i + 1).trim()
-}
-
-function hostnameOf(url: string): string {
-  try {
-    return new URL(url).hostname.replace(/^www\./, '')
-  } catch {
-    return 'official site'
-  }
-}
+// ── Action bar (RSVP) ──────────────────────────────────────────────────────
 
 function ActionBar({
   isRegistered,
@@ -471,8 +462,6 @@ function ActionBar({
     backgroundColor: colors.panelBg,
   } as const
 
-  // External signup + admin opted into Janata as alternate. Janata primary,
-  // external secondary.
   if (signupUrl && allowJanataSignup) {
     return (
       <View style={{ ...wrapperStyle, gap: 8 }}>
@@ -498,7 +487,6 @@ function ActionBar({
     )
   }
 
-  // External signup is exclusive.
   if (signupUrl) {
     return (
       <View style={wrapperStyle}>
@@ -550,6 +538,31 @@ function ActionBar({
   )
 }
 
+// ── Locked board hint (shown in Comments when board isn't accessible) ──────
+
+function LockedComments({ colors }: { colors: DetailColors }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.iconBoxBg,
+      }}
+    >
+      <Lock size={18} color={colors.textSecondary} />
+      <Text style={{ flex: 1, fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}>
+        RSVP to join the conversation — ask about carpooling, what to bring, and more.
+      </Text>
+    </View>
+  )
+}
+
 // ── Main component ───────────────────────────────────────────────────────
 
 export default function EventDetailPage() {
@@ -559,7 +572,6 @@ export default function EventDetailPage() {
   const posthog = usePostHog()
   const userContext = useUser()
   const { user, authStatus } = userContext
-  const [activeTab, setActiveTab] = useState('Details')
   const username = authStatus === 'authenticated' ? user?.username : undefined
   const userId = authStatus === 'authenticated' ? user?.id : undefined
   const { event, attendees, loading, toggleRegistration, isToggling, isCreator } =
@@ -573,23 +585,16 @@ export default function EventDetailPage() {
   const canEdit = isAdmin || isCreator
 
   const isPast = event?.date ? new Date(event.date + 'T23:59:59') < new Date() : false
-  const canAccessEventBoard =
-    !!user && !!event?.id && (!!event.isRegistered || isCreator || isAdmin)
+  const canAccessEventBoard = !!user && !!event?.id && (!!event.isRegistered || isCreator || isAdmin)
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('event', event?.id, canAccessEventBoard)
   const eventBoardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
-  // Track event viewed
   useEffect(() => {
     if (!loading && event && !hasTrackedView.current) {
       hasTrackedView.current = true
       posthog?.capture('event_viewed', { eventId: id, title: event.title, isPast })
     }
   }, [loading, event, id, isPast, posthog])
-
-  const handleTabChange = (newTab: string) => {
-    posthog?.capture('event_tab_changed', { tab: newTab, eventId: id })
-    setActiveTab(newTab)
-  }
 
   const handleEditPress = () => {
     posthog?.capture('event_edit_opened', { eventId: id })
@@ -659,55 +664,6 @@ export default function EventDetailPage() {
 
   const closeThreadPost = () => setThreadDetailPost(null)
 
-  // Thread tab content: either the post list (ThreadPanel) or, when a post is
-  // tapped, its detail (replies + reactions + author actions) reusing the same
-  // PostThread as the Connect Feed (#206). Rendered inline (not a Modal) so it
-  // works reliably on web inside the screen's ScrollView.
-  const renderThreadTab = () =>
-    threadDetailPost ? (
-      <View style={{ paddingTop: 6 }}>
-        <Pressable
-          onPress={closeThreadPost}
-          accessibilityRole="button"
-          accessibilityLabel="Back to board"
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 6,
-            paddingHorizontal: 16,
-            paddingVertical: 10,
-          }}
-        >
-          <ChevronLeft size={20} color={appColors.accent} />
-          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: appColors.accent }}>
-            Back to board
-          </Text>
-        </Pressable>
-        <View style={{ paddingHorizontal: 16 }}>
-          <PostThread
-            post={threadDetailPost}
-            colors={appColors}
-            onPostChanged={refetchBoard}
-            onPostDeleted={() => {
-              closeThreadPost()
-              refetchBoard()
-            }}
-          />
-        </View>
-      </View>
-    ) : (
-      <ThreadPanel
-        messages={eventBoardMessages}
-        colors={colors}
-        emptyTitle="Be the first to post"
-        emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event?.attendees ?? 0} people going.`}
-        composerPlaceholder="Write to the group..."
-        composerState={canPostToThread ? 'open' : 'locked'}
-        onSubmitPost={handleCreateThreadPost}
-        onMessagePress={openThreadPost}
-      />
-    )
-
   // ── Loading state ────────────────────────────────────────────────────
 
   if (loading) {
@@ -723,26 +679,12 @@ export default function EventDetailPage() {
   if (!event) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
-        <View
-          style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 }}
-        >
-          <Text
-            style={{
-              fontSize: 22,
-              fontFamily: 'Inclusive Sans',
-              color: colors.text,
-              marginBottom: 16,
-            }}
-          >
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 }}>
+          <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, marginBottom: 16 }}>
             Event not found
           </Text>
-          <Pressable
-            onPress={() => router.back()}
-            style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}
-          >
-            <Text style={{ fontSize: 16, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>
-              Go Back
-            </Text>
+          <Pressable onPress={() => router.back()} style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}>
+            <Text style={{ fontSize: 16, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>Go Back</Text>
           </Pressable>
         </View>
       </SafeAreaView>
@@ -752,145 +694,52 @@ export default function EventDetailPage() {
   // ── Derived state ────────────────────────────────────────────────────
 
   const isRegistered = !!event?.isRegistered && !isPast
-  const canPostToThread = canAccessEventBoard
 
-  // ── Registered state (with tabs) ─────────────────────────────────────
+  // ── Focused thread view (a board post + its replies) ─────────────────
+  // Reuses the same PostThread (with its bottom-docked composer) as the
+  // Connect feed, so opening a comment feels identical across the app.
 
-  if (isRegistered) {
+  if (threadDetailPost) {
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
-        <HeaderBar
-          title={event.title}
-          isPast={false}
-          isRegistered
-          isAdmin={canEdit}
-          eventId={id as string}
-          onBack={() => router.back()}
-          onEdit={handleEditPress}
-          onDelete={canEdit ? handleDeletePress : undefined}
-          colors={colors}
-        />
-
-        <View style={{ paddingTop: 8 }}>
-          <UnderlineTabBar
-            tabs={['Details', 'Thread', 'People']}
-            activeTab={activeTab}
-            onTabChange={handleTabChange}
-            counts={{ Thread: eventBoardMessages.length }}
+      <SafeAreaView style={{ flex: 1, backgroundColor: appColors.bg }}>
+        <View style={{ paddingTop: 6 }}>
+          <Pressable
+            onPress={closeThreadPost}
+            accessibilityRole="button"
+            accessibilityLabel="Back to board"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 12 }}
+          >
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: appColors.accent }}>
+              Back to board
+            </Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              closeThreadPost()
+              refetchBoard()
+            }}
           />
         </View>
-
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: 100 }}
-          showsVerticalScrollIndicator={false}
-        >
-          {activeTab === 'Details' && (
-            <View style={{ paddingHorizontal: 20, paddingTop: 20, paddingBottom: 24, gap: 20 }}>
-              {/* Date & time */}
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <MetaIcon icon={Clock} color="#E8862A" colors={colors} />
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
-                  {formatRelativeDateTime(event.date, event.time)}
-                </Text>
-              </View>
-
-              <MetaSection event={event} attendees={attendees} colors={colors} />
-              <AboutSection description={event.description} colors={colors} />
-            </View>
-          )}
-
-          {activeTab === 'People' && (
-            <View style={{ paddingTop: 16, paddingHorizontal: 20 }}>
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: colors.textSecondary,
-                  marginBottom: 12,
-                }}
-              >
-                {event.attendees} {event.attendees === 1 ? 'person' : 'people'} on Janata
-              </Text>
-              {attendees.length > 0 ? (
-                attendees.map((attendee, index) => (
-                  <View
-                    key={index}
-                    style={{
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      paddingVertical: 12,
-                      gap: 12,
-                    }}
-                  >
-                    <Avatar
-                      image={attendee.image}
-                      initials={attendee.initials}
-                      name={attendee.name}
-                      size={42}
-                    />
-                    <View style={{ flex: 1, gap: 2 }}>
-                      <Text
-                        style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}
-                      >
-                        {attendee.name}
-                      </Text>
-                      {attendee.subtitle ? (
-                        <Text
-                          style={{
-                            fontFamily: 'Inclusive Sans',
-                            fontSize: 12,
-                            color: colors.textSecondary,
-                          }}
-                        >
-                          {attendee.subtitle}
-                        </Text>
-                      ) : null}
-                    </View>
-                    {index === 0 && <Badge label="HOST" variant="host" />}
-                  </View>
-                ))
-              ) : (
-                <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-                  <Users size={48} color={colors.textMuted} />
-                  <Text
-                    style={{
-                      fontFamily: 'Inclusive Sans',
-                      fontSize: 14,
-                      color: colors.textSecondary,
-                      marginTop: 12,
-                    }}
-                  >
-                    No attendees yet
-                  </Text>
-                </View>
-              )}
-            </View>
-          )}
-
-          {activeTab === 'Thread' && renderThreadTab()}
-
-        </ScrollView>
-
-        <ActionBar
-          isRegistered
-          onToggle={handleToggleRegistration}
-          isToggling={isToggling}
-          signupUrl={event.signupUrl}
-          allowJanataSignup={event.allowJanataSignup}
-          colors={colors}
-        />
       </SafeAreaView>
     )
   }
 
-  // ── Default / past state ─────────────────────────────────────────────
+  // ── Sectioned detail (Details → Attendees → Comments) ────────────────
+
+  const isExternalOnly = !!event.signupUrl && !event.allowJanataSignup
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
       <HeaderBar
         title={event.title}
         isPast={isPast}
+        isRegistered={isRegistered}
         isAdmin={canEdit}
         eventId={id as string}
         onBack={() => router.back()}
@@ -899,134 +748,74 @@ export default function EventDetailPage() {
         colors={colors}
       />
 
-      {/* Hero image — edge-to-edge */}
-      {event.image ? (
-        <View style={{ width: '100%', height: 200, position: 'relative' }}>
-          <Image
-            source={{ uri: event.image }}
-            style={{ width: '100%', height: 200, opacity: isPast ? 0.75 : 1 }}
-            resizeMode="cover"
-          />
-          {isPast && (
-            <View
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                backgroundColor: 'rgba(0,0,0,0.15)',
-              }}
-            />
-          )}
-          <View style={{ position: 'absolute', bottom: 16, left: 16 }}>
-            <Badge
-              label={isPast ? 'Past Event' : 'Upcoming'}
-              variant={isPast ? 'past' : 'upcoming'}
-            />
-          </View>
-        </View>
-      ) : null}
-
-      <View style={{ paddingTop: 8 }}>
-        <UnderlineTabBar
-          tabs={['Details', 'Thread', 'Attendees']}
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
-          counts={{ Thread: eventBoardMessages.length }}
-        />
-      </View>
-
       <ScrollView
         style={{ flex: 1 }}
-        contentContainerStyle={{
-          paddingHorizontal: 20,
-          paddingTop: 20,
-          paddingBottom: isPast ? 40 : 100,
-          gap: 20,
-        }}
+        contentContainerStyle={{ paddingBottom: isPast ? 32 : 24 }}
+        keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {activeTab === 'Details' && (
-          <>
-            {/* Attended banner (past + user was registered) */}
-            {isPast && isRegistered && <AttendedBanner count={event.attendees} colors={colors} />}
-
-            {/* Date & time */}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-              <MetaIcon icon={Clock} color={isPast ? colors.textMuted : '#E8862A'} colors={colors} />
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
-                {formatRelativeDateTime(event.date, event.time)}
-              </Text>
+        {/* Hero image — edge-to-edge */}
+        {event.image ? (
+          <View style={{ width: '100%', height: 200, position: 'relative', marginBottom: 4 }}>
+            <Image
+              source={{ uri: event.image }}
+              style={{ width: '100%', height: 200, opacity: isPast ? 0.75 : 1 }}
+              resizeMode="cover"
+            />
+            {isPast && (
+              <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.15)' }} />
+            )}
+            <View style={{ position: 'absolute', bottom: 16, left: 16 }}>
+              <Badge label={isPast ? 'Past Event' : 'Upcoming'} variant={isPast ? 'past' : 'upcoming'} />
             </View>
+          </View>
+        ) : null}
 
-            {/* Meta rows */}
-            <MetaSection event={event} attendees={attendees} isPast={isPast} colors={colors} />
+        {/* DETAILS */}
+        <DetailSection title="Details" first>
+          {isPast && isRegistered ? <AttendedBanner count={event.attendees} colors={colors} /> : null}
+          <DetailsContent event={event} attendees={attendees} isPast={isPast} colors={colors} />
+        </DetailSection>
 
-            {/* About */}
-            <AboutSection description={event.description} colors={colors} />
-          </>
-        )}
-
-        {activeTab === 'Thread' && renderThreadTab()}
-
-        {activeTab === 'Attendees' && (
-          <View style={{ paddingTop: 8 }}>
+        {/* ATTENDEES — hidden when registration is external-only (no native RSVP) */}
+        {!isExternalOnly && (
+          <DetailSection
+            title="Attendees"
+            count={event.attendees}
+            contentStyle={{ gap: 8 }}
+          >
             {attendees.length > 0 ? (
-              attendees.map((attendee, index) => (
-                <View
-                  key={index}
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    paddingVertical: 12,
-                    gap: 12,
-                  }}
-                >
-                  <Avatar
-                    image={attendee.image}
-                    initials={attendee.initials}
-                    name={attendee.name}
-                    size={42}
-                  />
-                  <View style={{ flex: 1, gap: 2 }}>
-                    <Text
-                      style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}
-                    >
-                      {attendee.name}
-                    </Text>
-                    {attendee.subtitle ? (
-                      <Text
-                        style={{
-                          fontFamily: 'Inclusive Sans',
-                          fontSize: 12,
-                          color: colors.textSecondary,
-                        }}
-                      >
-                        {attendee.subtitle}
-                      </Text>
-                    ) : null}
-                  </View>
-                  {index === 0 && <Badge label="HOST" variant="host" />}
-                </View>
-              ))
-            ) : (
-              <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-                <Users size={48} color={colors.textMuted} />
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 14,
-                    color: colors.textSecondary,
-                    marginTop: 12,
-                  }}
-                >
-                  No attendees yet
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+                <AvatarStack attendees={attendees} colors={colors} />
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}>
+                  {event.attendees} {event.attendees === 1 ? 'person' : 'people'} on Janata
                 </Text>
               </View>
-            )}
-          </View>
+            ) : null}
+            <AttendeesContent attendees={attendees} colors={colors} />
+          </DetailSection>
         )}
+
+        {/* COMMENTS — board posts, feed-style. Composer sits at the top of the
+            section; tapping a post opens the focused thread view above. */}
+        <DetailSection title="Comments" count={canAccessEventBoard ? eventBoardMessages.length : undefined} contentStyle={{ paddingHorizontal: 0 }}>
+          {canAccessEventBoard ? (
+            <ThreadPanel
+              messages={eventBoardMessages}
+              colors={colors}
+              emptyTitle="Be the first to post"
+              emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event.attendees ?? 0} people going.`}
+              composerPlaceholder="Write to the group..."
+              composerState="open"
+              onSubmitPost={handleCreateThreadPost}
+              onMessagePress={openThreadPost}
+            />
+          ) : (
+            <View style={{ paddingHorizontal: 20 }}>
+              <LockedComments colors={colors} />
+            </View>
+          )}
+        </DetailSection>
       </ScrollView>
 
       <ActionBar

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -1,32 +1,24 @@
 import { useEffect, useMemo, useState, useRef } from 'react'
 import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions, Linking } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Share2, MapPin, Users, User, Clock, CheckCircle, Pencil, Trash2 } from 'lucide-react-native'
+import { ChevronLeft, Share2, MapPin, Users, User, Clock, Lock, Pencil, Trash2 } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
 import { useBoard, useEventDetail } from '../../hooks/useApiData'
 import { createBoardPost, removeEvent } from '../../utils/api'
 import { isSuperAdmin } from '../../utils/admin'
 import Avatar from '../../components/ui/Avatar'
 import Badge from '../../components/ui/Badge'
-import UnderlineTabBar from '../../components/ui/UnderlineTabBar'
 import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
 import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import AuthPromptModal from '../../components/ui/AuthPromptModal'
-import { useDetailColors } from '../../hooks/useDetailColors'
+import { DetailSection } from '../../components/ui'
+import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
 import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildEventJsonLd } from '../../components/seo/jsonLd'
-
-function formatEventDateLabel(dateStr: string): string {
-  const d = new Date(`${dateStr}T00:00:00`)
-  if (isNaN(d.getTime())) return dateStr.toUpperCase()
-  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase()
-  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
-  return `${weekday}, ${month} ${d.getDate()}`
-}
 
 export default function EventDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
@@ -58,13 +50,35 @@ export default function EventDetailWeb() {
   return <MobileEventDetail eventId={id || ''} />
 }
 
+function LockedComments({ colors }: { colors: DetailColors }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingVertical: 14,
+        paddingHorizontal: 14,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: colors.border,
+        backgroundColor: colors.iconBoxBg,
+      }}
+    >
+      <Lock size={18} color={colors.textSecondary} />
+      <Text style={{ flex: 1, fontSize: 13, color: colors.textSecondary }}>
+        RSVP to join the conversation — ask about carpooling, what to bring, and more.
+      </Text>
+    </View>
+  )
+}
+
 function MobileEventDetail({ eventId }: { eventId: string }) {
   const router = useRouter()
   const { user } = useUser()
   const { event, loading, toggleRegistration, isToggling, attendees, isCreator } = useEventDetail(eventId, user?.username, user?.id)
   const colors = useDetailColors()
   const appColors = useColors()
-  const [activeTab, setActiveTab] = useState('Details')
   const [showAuthPrompt, setShowAuthPrompt] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
@@ -73,7 +87,6 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const canEdit = !!user && (isSuperAdmin(user) || isCreator)
   const canAccessEventBoard =
     !!user && !!event?.id && (!!event.isRegistered || isCreator || isSuperAdmin(user))
-  const canPostToThread = canAccessEventBoard
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('event', event?.id, canAccessEventBoard)
   const eventBoardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -97,43 +110,6 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   }
 
   const closeThreadPost = () => setThreadDetailPost(null)
-
-  // Thread tab: post list, or the tapped post's detail (replies + reactions +
-  // author actions) reusing the shared PostThread from the Connect Feed (#206).
-  const renderThreadTab = () =>
-    threadDetailPost ? (
-      <View style={{ paddingTop: 4 }}>
-        <Pressable
-          onPress={closeThreadPost}
-          accessibilityRole="button"
-          accessibilityLabel="Back to board"
-          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 10 }}
-        >
-          <ChevronLeft size={20} color={appColors.accent} />
-          <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
-        </Pressable>
-        <PostThread
-          post={threadDetailPost}
-          colors={appColors}
-          onPostChanged={refetchBoard}
-          onPostDeleted={() => {
-            closeThreadPost()
-            refetchBoard()
-          }}
-        />
-      </View>
-    ) : (
-      <ThreadPanel
-        messages={eventBoardMessages}
-        colors={colors}
-        emptyTitle="Be the first to post"
-        emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event?.attendees ?? 0} people going.`}
-        composerPlaceholder="Write to the group..."
-        composerState={canPostToThread ? 'open' : 'locked'}
-        onSubmitPost={handleCreateThreadPost}
-        onMessagePress={openThreadPost}
-      />
-    )
 
   const handleDelete = async () => {
     if (!event) return
@@ -168,6 +144,36 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
     )
   }
 
+  // ── Focused thread view (a board post + its replies) ─────────────────
+  if (threadDetailPost) {
+    return (
+      <View style={{ flex: 1, backgroundColor: appColors.bg }}>
+        <View style={{ paddingTop: 12 }}>
+          <Pressable
+            onPress={closeThreadPost}
+            accessibilityRole="button"
+            accessibilityLabel="Back to board"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
+          >
+            <ChevronLeft size={20} color={appColors.accent} />
+            <Text style={{ fontSize: 14, color: appColors.accent }}>Back to board</Text>
+          </Pressable>
+        </View>
+        <View style={{ flex: 1 }}>
+          <PostThread
+            post={threadDetailPost}
+            colors={appColors}
+            onPostChanged={refetchBoard}
+            onPostDeleted={() => {
+              closeThreadPost()
+              refetchBoard()
+            }}
+          />
+        </View>
+      </View>
+    )
+  }
+
   const seoTitle = event.title || 'Event'
   const seoDesc =
     event.description && event.description.length > 30
@@ -176,6 +182,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         (event.address ? ` at ${event.address}` : '') +
         '. Find details and RSVP on Chinmaya Janata.'
   const eventJsonLd = buildEventJsonLd(event)
+  const isExternalOnly = !!event.signupUrl && !event.allowJanataSignup
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.panelBg }}>
@@ -199,21 +206,12 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         </Pressable>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
           {canEdit && !isPast && (
-            <Pressable
-              onPress={() => router.push(`/events/form?id=${event.id}`)}
-              style={{ padding: 8 }}
-              accessibilityLabel="Edit event"
-            >
+            <Pressable onPress={() => router.push(`/events/form?id=${event.id}`)} style={{ padding: 8 }} accessibilityLabel="Edit event">
               <Pencil size={18} color={colors.textSecondary} />
             </Pressable>
           )}
           {canEdit && (
-            <Pressable
-              onPress={handleDelete}
-              disabled={isDeleting}
-              style={{ padding: 8, opacity: isDeleting ? 0.5 : 1 }}
-              accessibilityLabel="Delete event"
-            >
+            <Pressable onPress={handleDelete} disabled={isDeleting} style={{ padding: 8, opacity: isDeleting ? 0.5 : 1 }} accessibilityLabel="Delete event">
               <Trash2 size={18} color="#DC2626" />
             </Pressable>
           )}
@@ -235,111 +233,102 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
       </View>
 
       {/* Title + Badge */}
-      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingBottom: 8 }}>
-        <Text style={{ fontSize: 22, fontWeight: 'bold', color: colors.text, flex: 1 }}>{event.title}</Text>
-        {event.isRegistered && <Badge label="Going" variant="going" />}
+      <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', paddingHorizontal: 16, paddingBottom: 12, gap: 10 }}>
+        <Text style={{ fontSize: 26, fontWeight: 'bold', color: colors.text, flex: 1 }}>{event.title}</Text>
+        {event.isRegistered && <View style={{ marginTop: 4 }}><Badge label="Going" variant="going" /></View>}
       </View>
 
-      {/* Tabs */}
-      <UnderlineTabBar
-        tabs={['Details', 'Thread', 'People']}
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
-        counts={{ Thread: eventBoardMessages.length }}
-      />
-
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 16, gap: 16 }}>
-        {activeTab === 'Details' ? (
-          <>
-            {/* Date & Time */}
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 24 }} keyboardShouldPersistTaps="handled">
+        {/* DETAILS */}
+        <DetailSection title="Details" first>
+          <View style={{ gap: 16 }}>
             {event.date && (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                <Clock size={18} color={colors.textSecondary} />
+                <Clock size={18} color="#E8862A" />
                 <Text style={{ color: colors.text, fontSize: 15 }}>
-                  {new Date(event.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })}
+                  {new Date(event.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
                   {event.time ? ` · ${event.time}` : ''}
                 </Text>
               </View>
             )}
 
-            {/* Location */}
             {event.address && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                <MapPin size={18} color="#E8862A" />
-                <Text style={{ color: colors.text, fontSize: 15 }}>{event.address}</Text>
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>
+                <MapPin size={18} color="#E8862A" style={{ marginTop: 1 }} />
+                <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{event.address}</Text>
               </View>
             )}
 
-            {/* Attendees count — hidden when signup is external-only
-                (the on-Janata count would always read 0). */}
-            {!(event.signupUrl && !event.allowJanataSignup) && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                <Users size={18} color={colors.textSecondary} />
-                <Text style={{ color: colors.text, fontSize: 15 }}>
-                  {event.attendees} {event.attendees === 1 ? 'person' : 'people'} attending
-                </Text>
-              </View>
-            )}
-
-            {/* Contact */}
             {event.pointOfContact && (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                <User size={18} color={colors.textSecondary} />
+                <User size={18} color="#E8862A" />
                 <Text style={{ color: colors.text, fontSize: 15 }}>Contact: {event.pointOfContact}</Text>
               </View>
             )}
 
-            {/* Description */}
             {event.description && (
-              <View style={{ marginTop: 8 }}>
-                <Text style={{ color: colors.textSecondary, fontSize: 12, fontWeight: '600', marginBottom: 8 }}>ABOUT</Text>
-                <Text style={{ color: colors.text, fontSize: 15, lineHeight: 22 }}>{event.description}</Text>
+              <Text style={{ color: colors.textSecondary, fontSize: 15, lineHeight: 22, marginTop: 2 }}>{event.description}</Text>
+            )}
+          </View>
+        </DetailSection>
+
+        {/* ATTENDEES — hidden when registration is external-only */}
+        {!isExternalOnly && (
+          <DetailSection title="Attendees" count={event.attendees} contentStyle={{ gap: 4 }}>
+            {attendees.length > 0 ? (
+              attendees.map((a) => (
+                <View key={a.name} style={{ flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 }}>
+                  <Avatar name={a.name} size={40} image={a.image} />
+                  <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{a.name}</Text>
+                </View>
+              ))
+            ) : (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 4 }}>
+                <Users size={18} color={colors.textMuted} />
+                <Text style={{ color: colors.textSecondary, fontSize: 14 }}>No attendees yet — be the first to RSVP.</Text>
               </View>
             )}
-          </>
-        ) : activeTab === 'Thread' ? (
-          renderThreadTab()
-        ) : (
-          <>
-            <Text style={{ color: colors.textSecondary, fontSize: 14 }}>
-              {attendees.length} {attendees.length === 1 ? 'person' : 'people'} attending
-            </Text>
-            {attendees.map((a) => (
-              <View key={a.name} style={{ flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 }}>
-                <Avatar name={a.name} size={40} image={a.image} />
-                <Text style={{ color: colors.text, fontSize: 16, flex: 1 }}>
-                  {a.name}
-                </Text>
-              </View>
-            ))}
-          </>
+          </DetailSection>
         )}
+
+        {/* COMMENTS */}
+        <DetailSection title="Comments" count={canAccessEventBoard ? eventBoardMessages.length : undefined} contentStyle={{ paddingHorizontal: 0 }}>
+          {canAccessEventBoard ? (
+            <ThreadPanel
+              messages={eventBoardMessages}
+              colors={colors}
+              emptyTitle="Be the first to post"
+              emptySubtitle={`Ask about carpooling, what to bring, or anything else for the ${event.attendees ?? 0} people going.`}
+              composerPlaceholder="Write to the group..."
+              composerState="open"
+              onSubmitPost={handleCreateThreadPost}
+              onMessagePress={openThreadPost}
+            />
+          ) : (
+            <View style={{ paddingHorizontal: 16 }}>
+              <LockedComments colors={colors} />
+            </View>
+          )}
+        </DetailSection>
       </ScrollView>
 
-      {/* Action button(s) — three modes (matches EventDetailPanel.ActionBar):
+      {/* Action button(s) — three modes:
           1. signupUrl + allowJanataSignup → Janata primary, external alt
           2. signupUrl only → external referrer, no native RSVP
           3. no signupUrl → native Register / Cancel */}
       {!isPast && (
-        <View style={{ padding: 16, gap: 8 }}>
+        <View style={{ padding: 16, gap: 8, borderTopWidth: 1, borderTopColor: colors.border }}>
           {event.signupUrl && event.allowJanataSignup ? (
             <>
               {event.isRegistered ? (
-                <DestructiveButton
-                  onPress={() => user?.username && toggleRegistration(user.username)}
-                  disabled={isToggling}
-                  loading={isToggling}
-                >
+                <DestructiveButton onPress={() => user?.username && toggleRegistration(user.username)} disabled={isToggling} loading={isToggling}>
                   Cancel Registration
                 </DestructiveButton>
               ) : (
                 <PrimaryButton
                   onPress={() => {
-                    if (!user) {
-                      setShowAuthPrompt(true)
-                    } else if (user.username) {
-                      toggleRegistration(user.username)
-                    }
+                    if (!user) setShowAuthPrompt(true)
+                    else if (user.username) toggleRegistration(user.username)
                   }}
                   disabled={isToggling}
                   loading={isToggling}
@@ -362,34 +351,19 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
               <PrimaryButton onPress={() => Linking.openURL(event.signupUrl!)}>
                 Sign up at {hostnameOf(event.signupUrl)}
               </PrimaryButton>
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 12,
-                  color: colors.textSecondary,
-                  textAlign: 'center',
-                  marginTop: 4,
-                }}
-              >
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textSecondary, textAlign: 'center', marginTop: 4 }}>
                 Registration handled on the official site
               </Text>
             </>
           ) : event.isRegistered ? (
-            <DestructiveButton
-              onPress={() => user?.username && toggleRegistration(user.username)}
-              disabled={isToggling}
-              loading={isToggling}
-            >
+            <DestructiveButton onPress={() => user?.username && toggleRegistration(user.username)} disabled={isToggling} loading={isToggling}>
               Cancel Registration
             </DestructiveButton>
           ) : (
             <PrimaryButton
               onPress={() => {
-                if (!user) {
-                  setShowAuthPrompt(true)
-                } else if (user.username) {
-                  toggleRegistration(user.username)
-                }
+                if (!user) setShowAuthPrompt(true)
+                else if (user.username) toggleRegistration(user.username)
               }}
               disabled={isToggling}
               loading={isToggling}

--- a/packages/frontend/components/ui/DetailSection.tsx
+++ b/packages/frontend/components/ui/DetailSection.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { View, Text, Pressable, type ViewStyle } from 'react-native'
+import { useColors } from '../../hooks/useColors'
+
+/**
+ * DetailSection — the editorial "on-surface" section used across the center
+ * and event detail screens. A small-caps muted label, an optional count and
+ * trailing action, and a thin hairline divider above (skipped for the first
+ * section). Content sits directly on the page background — no cards.
+ *
+ * Replaces the old tabbed layout (Details / Thread / People|Events) with one
+ * ordered scroll so the detail screens read like the Connect feed.
+ */
+export function DetailSection({
+  title,
+  count,
+  first = false,
+  action,
+  onAction,
+  children,
+  contentStyle,
+}: {
+  title: string
+  count?: number
+  first?: boolean
+  action?: string
+  onAction?: () => void
+  children: React.ReactNode
+  contentStyle?: ViewStyle
+}) {
+  const c = useColors()
+  return (
+    <View>
+      {!first ? (
+        <View style={{ height: 1, backgroundColor: c.border, marginHorizontal: 20 }} />
+      ) : null}
+      <View style={{ paddingHorizontal: 20, paddingTop: first ? 4 : 22, paddingBottom: 8 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          <Text style={{ flex: 1, fontSize: 11, letterSpacing: 0.9, color: c.textFaint }}>
+            {title.toUpperCase()}
+            {typeof count === 'number' ? `  ${count}` : ''}
+          </Text>
+          {action ? (
+            <Pressable
+              onPress={onAction}
+              accessibilityRole="button"
+              accessibilityLabel={action}
+              hitSlop={8}
+              style={{ minHeight: 28, justifyContent: 'center' }}
+            >
+              <Text style={{ fontSize: 13, color: c.accent }}>{action}</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+      <View style={[{ paddingHorizontal: 20 }, contentStyle]}>{children}</View>
+    </View>
+  )
+}
+
+export default DetailSection

--- a/packages/frontend/components/ui/index.ts
+++ b/packages/frontend/components/ui/index.ts
@@ -26,6 +26,7 @@ import TabHeader from './TabHeader'
 import StackHeader from './StackHeader'
 import { Text } from './Text'
 import { Section } from './Section'
+import { DetailSection } from './DetailSection'
 import { GradientIconBadge } from './GradientIconBadge'
 import { IconBadge } from './IconBadge'
 
@@ -49,6 +50,7 @@ export {
   StackHeader,
   Text,
   Section,
+  DetailSection,
   GradientIconBadge,
   IconBadge,
 }


### PR DESCRIPTION
## What
Redesigns the **center** and **event** detail screens (native + mobile-web) into one ordered scroll that speaks the Connect-feed language, replacing the old 3-tab layout (Details / Thread / People|Events).

New shared `DetailSection` (small-caps label + hairline divider, content on-surface, no cards):
- **Event:** Details → Attendees → Comments. RSVP stays docked at the bottom.
- **Center:** Details → Upcoming Events → Board.
- Board posts render feed-style inline; tapping one opens the shared `PostThread` (with its bottom-docked composer), identical to the feed.

## Why
The detail screens were inconsistent with the feed (composer floated at the top on the Thread tab, tab names diverged, spacing drifted). This collapses the tabs into one scannable scroll and reuses the feed's message/reply/composer pattern for consistency.

## Verified
- iOS simulator: event + center detail, section order, feed-style comments, focused thread view, RSVP docked.
- Web (mobile width): event + center detail, locked-board states.
- `npm run test:frontend` → 187 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)