### PR TITLE
feat(home): first-run overview — feature tour + your center + feed peek

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useMemo } from 'react'
 import { ActivityIndicator, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
+import { CalendarCheck, ChevronRight, Compass, MapPin, MessageCircle } from 'lucide-react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { usePostHog } from 'posthog-react-native'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useDiscoverData, useMyEvents, useBoard } from '../../hooks/useApiData'
-import type { EventDisplay } from '../../utils/api'
+import type { DiscoverCenter, EventDisplay } from '../../utils/api'
+import { extractCityState } from '../../utils/addressParsing'
 import { FeaturedEventCard, type FeaturedSource } from '../../components/home/FeaturedEventCard'
 import { MiniEventRow, type WeekItem } from '../../components/home/MiniEventRow'
-import { BoardPostCard, boardPostToMessage } from '../../components/boards'
+import { BoardPostCard, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import type { AppColors } from '../../tokens'
 
 function formatDatePill(dateStr: string): { month: string; day: string } {
   const parsed = new Date(`${dateStr}T00:00:00`)
@@ -65,10 +68,11 @@ export default function HomeScreen() {
   // Boards peek (#199): surface the 1-2 latest posts from the user's center
   // board so Home reflects real activity instead of a permanent empty state.
   const { posts: centerBoardPosts } = useBoard('center', user?.centerID ?? undefined, !!user?.centerID)
-  const centerName = useMemo(
-    () => allCenters.find((item) => item.id === user?.centerID)?.name,
+  const userCenter = useMemo(
+    () => allCenters.find((item) => item.id === user?.centerID),
     [allCenters, user?.centerID]
   )
+  const centerName = userCenter?.name
   const boardPeek = useMemo(
     () =>
       centerBoardPosts.slice(0, 2).map((post) => ({
@@ -125,6 +129,12 @@ export default function HomeScreen() {
   const greetingName = user?.firstName || user?.username || 'friend'
   const todayLabel = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
 
+  // First run: a member who hasn't joined an event or posted yet. Rather than a
+  // sparse, hard-to-read home, give them a short tour of what Janata does, a
+  // card for their center, and a peek at the feed — so they grasp the whole app
+  // at a glance and have clear next steps. Real events still render below.
+  const isNewUser = !!user && signedUpEvents.length === 0 && boardPeek.length === 0
+
   if (discoverLoading || (user ? myEventsLoading : false)) {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: c.bg }}>
@@ -151,95 +161,293 @@ export default function HomeScreen() {
           </Text>
         </View>
 
-        <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => router.push('/' as never)}>
-          {featured ? (
-            <FeaturedEventCard
-              featured={featured}
-              onPress={() => {
-                posthog?.capture('home_featured_event_pressed', { eventId: featured.event.id })
-                router.push(`/events/${featured.event.id}`)
-              }}
-            />
-          ) : (
-            <View style={{ borderRadius: 18, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 10 }}>
-              <View style={{ gap: 4 }}>
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: c.text }}>No upcoming events at your center yet</Text>
-                <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                  Explore other CHYK events while your center's calendar fills in.
-                </Text>
+        {isNewUser ? (
+          <FirstRunOverview
+            c={c}
+            detailColors={detailColors}
+            center={userCenter}
+            peek={boardPeek}
+            onExplore={() => {
+              posthog?.capture('home_first_run_explore_pressed')
+              router.push('/explore' as never)
+            }}
+            onFeed={() => {
+              posthog?.capture('home_first_run_feed_pressed')
+              router.push('/feed' as never)
+            }}
+            onChooseCenter={() => {
+              posthog?.capture('home_first_run_center_pressed')
+              router.push('/center-picker' as never)
+            }}
+            onOpenCenter={(id) => {
+              posthog?.capture('home_first_run_center_opened', { centerId: id })
+              router.push(`/center/${id}`)
+            }}
+            onPeekPress={(id) => {
+              posthog?.capture('home_board_peek_pressed', { postId: id })
+              router.push('/feed' as never)
+            }}
+          />
+        ) : null}
+
+        {!isNewUser || featured ? (
+          <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => router.push('/' as never)}>
+            {featured ? (
+              <FeaturedEventCard
+                featured={featured}
+                onPress={() => {
+                  posthog?.capture('home_featured_event_pressed', { eventId: featured.event.id })
+                  router.push(`/events/${featured.event.id}`)
+                }}
+              />
+            ) : (
+              <View style={{ borderRadius: 18, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 10 }}>
+                <View style={{ gap: 4 }}>
+                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: c.text }}>No upcoming events at your center yet</Text>
+                  <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+                    Explore other CHYK events while your center's calendar fills in.
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={() => router.push('/explore' as never)}
+                  style={{ alignSelf: 'flex-start', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: c.accentSoft }}
+                >
+                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.accent }}>Explore</Text>
+                </Pressable>
               </View>
-              <Pressable
-                onPress={() => router.push('/explore' as never)}
-                style={{ alignSelf: 'flex-start', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: c.accentSoft }}
-              >
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.accent }}>Explore</Text>
-              </Pressable>
-            </View>
-          )}
-        </SectionHeader>
+            )}
+          </SectionHeader>
+        ) : null}
 
         {/*
           Boards peek (#199): the 1-2 latest posts from the user's center
-          board (wired to useBoard now that the boards backend #205 landed).
-          Falls back to a visible empty state so members know where
-          conversations land once posts arrive.
+          board. New users get their center + a feed peek inside the first-run
+          overview above, so this section is for returning members only.
         */}
-        <SectionHeader
-          eyebrow="LATEST ON YOUR BOARDS"
-          trailing="Open Feed"
-          accentColor={c.accent}
-          faintColor={c.textFaint}
-          onTrailingPress={() => router.push('/feed' as never)}
-        >
-          {boardPeek.length > 0 ? (
-            <View>
-              {boardPeek.map((message) => (
-                <BoardPostCard
-                  key={message.id}
-                  message={message}
-                  colors={detailColors}
-                  showSource
-                  onPress={() => {
-                    posthog?.capture('home_board_peek_pressed', { postId: message.id })
-                    router.push('/feed' as never)
-                  }}
-                />
-              ))}
-            </View>
-          ) : (
-            <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 6 }}>
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>
-                No posts yet on your boards
-              </Text>
-              <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                Conversations from your center and events you've joined will appear here. Head to the Feed to see what's new across the network.
-              </Text>
-            </View>
-          )}
-        </SectionHeader>
+        {!isNewUser ? (
+          <SectionHeader
+            eyebrow="LATEST ON YOUR BOARDS"
+            trailing="Open Feed"
+            accentColor={c.accent}
+            faintColor={c.textFaint}
+            onTrailingPress={() => router.push('/feed' as never)}
+          >
+            {boardPeek.length > 0 ? (
+              <View>
+                {boardPeek.map((message) => (
+                  <BoardPostCard
+                    key={message.id}
+                    message={message}
+                    colors={detailColors}
+                    showSource
+                    onPress={() => {
+                      posthog?.capture('home_board_peek_pressed', { postId: message.id })
+                      router.push('/feed' as never)
+                    }}
+                  />
+                ))}
+              </View>
+            ) : (
+              <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 6 }}>
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>
+                  No posts yet on your boards
+                </Text>
+                <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+                  Conversations from your center and events you've joined will appear here. Head to the Feed to see what's new across the network.
+                </Text>
+              </View>
+            )}
+          </SectionHeader>
+        ) : null}
 
-        <SectionHeader
-          eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
-          trailing="See all"
-          accentColor={c.accent}
-          faintColor={c.textFaint}
-          onTrailingPress={() => router.push('/' as never)}
-        >
-          {weekItems.length > 0 ? (
-            <View style={{ gap: 8 }}>
-              {weekItems.map((item) => <MiniEventRow key={item.id} item={item} />)}
-            </View>
-          ) : (
-            <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 4 }}>
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>No events yet</Text>
-              <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                Upcoming events from Explore will appear here as they are added.
-              </Text>
-            </View>
-          )}
-        </SectionHeader>
+        {!isNewUser || weekItems.length > 0 ? (
+          <SectionHeader
+            eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
+            trailing="See all"
+            accentColor={c.accent}
+            faintColor={c.textFaint}
+            onTrailingPress={() => router.push('/' as never)}
+          >
+            {weekItems.length > 0 ? (
+              <View style={{ gap: 8 }}>
+                {weekItems.map((item) => <MiniEventRow key={item.id} item={item} />)}
+              </View>
+            ) : (
+              <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 4 }}>
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>No events yet</Text>
+                <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+                  Upcoming events from Explore will appear here as they are added.
+                </Text>
+              </View>
+            )}
+          </SectionHeader>
+        ) : null}
       </View>
     </ScrollView>
+  )
+}
+
+// One row of the first-run feature tour: icon tile, title + one-liner, chevron.
+// Tapping routes to the matching tab so the tour doubles as navigation.
+function FeatureRow({
+  c,
+  icon: Icon,
+  title,
+  subtitle,
+  onPress,
+  first = false,
+}: {
+  c: AppColors
+  icon: typeof Compass
+  title: string
+  subtitle: string
+  onPress: () => void
+  first?: boolean
+}) {
+  return (
+    <View>
+      {!first ? <View style={{ height: 1, backgroundColor: c.border, marginLeft: 68 }} /> : null}
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={title}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: 14, paddingVertical: 14, paddingHorizontal: 14 }}
+      >
+        <View style={{ width: 40, height: 40, borderRadius: 12, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
+          <Icon size={20} color={c.accent} />
+        </View>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15.5, color: c.text }}>{title}</Text>
+          <Text style={{ fontSize: 13, lineHeight: 18, color: c.textMuted }}>{subtitle}</Text>
+        </View>
+        <ChevronRight size={18} color={c.textFaint} />
+      </Pressable>
+    </View>
+  )
+}
+
+// First-run overview shown to members who haven't engaged yet. Three parts:
+// a short feature tour, a card for their center (or a prompt to pick one), and
+// a peek at their board feed when there's activity. Gives new users the whole
+// app at a glance plus real, personal content.
+function FirstRunOverview({
+  c,
+  detailColors,
+  center,
+  peek,
+  onExplore,
+  onFeed,
+  onChooseCenter,
+  onOpenCenter,
+  onPeekPress,
+}: {
+  c: AppColors
+  detailColors: ReturnType<typeof useDetailColors>
+  center?: DiscoverCenter
+  peek: BoardMessage[]
+  onExplore: () => void
+  onFeed: () => void
+  onChooseCenter: () => void
+  onOpenCenter: (id: string) => void
+  onPeekPress: (id: string) => void
+}) {
+  const eyebrow = { fontSize: 11, letterSpacing: 0.9, color: c.textFaint, paddingHorizontal: 4 } as const
+  const cardBase = { borderRadius: 18, borderWidth: 1, borderColor: c.border, backgroundColor: c.card } as const
+  const cityState = center?.address ? extractCityState(center.address) : undefined
+  const centerMeta = [cityState, center?.memberCount ? `${center.memberCount} members` : null].filter(Boolean).join(' · ')
+
+  return (
+    <View style={{ gap: 22 }}>
+      <View style={{ gap: 10 }}>
+        <Text style={eyebrow}>WELCOME TO JANATA</Text>
+        <View style={[cardBase, { overflow: 'hidden' }]}>
+          <FeatureRow
+            first
+            c={c}
+            icon={Compass}
+            title="Discover events & centers"
+            subtitle="Satsangs, camps, and classes near you"
+            onPress={onExplore}
+          />
+          <FeatureRow
+            c={c}
+            icon={CalendarCheck}
+            title="RSVP in a tap"
+            subtitle="Save your spot and never miss a gathering"
+            onPress={onExplore}
+          />
+          <FeatureRow
+            c={c}
+            icon={MessageCircle}
+            title="Join the conversation"
+            subtitle="Center and event boards keep CHYKs connected"
+            onPress={onFeed}
+          />
+        </View>
+      </View>
+
+      <View style={{ gap: 10 }}>
+        <Text style={eyebrow}>{center ? 'YOUR CENTER' : 'GET CONNECTED'}</Text>
+        {center ? (
+          <Pressable
+            onPress={() => onOpenCenter(center.id)}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${center.name}`}
+            style={[cardBase, { flexDirection: 'row', alignItems: 'center', gap: 14, padding: 16 }]}
+          >
+            <View style={{ width: 44, height: 44, borderRadius: 13, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
+              <MapPin size={21} color={c.accent} />
+            </View>
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }} numberOfLines={1}>
+                {center.name}
+              </Text>
+              {centerMeta ? (
+                <Text style={{ fontSize: 13, color: c.textMuted }} numberOfLines={1}>
+                  {centerMeta}
+                </Text>
+              ) : null}
+            </View>
+            <ChevronRight size={18} color={c.textFaint} />
+          </Pressable>
+        ) : (
+          <Pressable
+            onPress={onChooseCenter}
+            accessibilityRole="button"
+            accessibilityLabel="Choose your center"
+            style={[cardBase, { padding: 16, gap: 8 }]}
+          >
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>Choose your home center</Text>
+            <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+              Pick your center to follow its board and see its upcoming events.
+            </Text>
+            <Text style={{ fontSize: 13.5, color: c.accent }}>Choose your center →</Text>
+          </Pressable>
+        )}
+      </View>
+
+      {peek.length > 0 ? (
+        <View style={{ gap: 10 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 4 }}>
+            <Text style={{ fontSize: 11, letterSpacing: 0.9, color: c.textFaint }}>LATEST ON YOUR BOARD</Text>
+            <Pressable onPress={onFeed} hitSlop={8}>
+              <Text style={{ fontWeight: '500', fontSize: 13, color: c.accent }}>Open Feed</Text>
+            </Pressable>
+          </View>
+          <View>
+            {peek.map((message) => (
+              <BoardPostCard
+                key={message.id}
+                message={message}
+                colors={detailColors}
+                showSource
+                onPress={() => onPeekPress(message.id)}
+              />
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </View>
   )
 }
 


### PR DESCRIPTION
## What
Replaces the sparse first-run Home (which read as "dead" for a brand-new member) with a guided overview that teaches the whole app at a glance and surfaces real, personal content.

When a member hasn't engaged yet (no joined events **and** no board posts), Home shows:

1. **WELCOME TO JANATA — feature tour.** Three tappable rows that double as navigation:
   - 🧭 Discover events & centers → Explore
   - 🗓️ RSVP in a tap → Explore
   - 💬 Join the conversation → Feed
2. **YOUR CENTER** — real center name + city + member count, routing to the center board. Falls back to a **"Choose your home center"** prompt when no center is set.
3. **LATEST ON YOUR BOARD** — a feed peek (reuses `BoardPostCard`) when the center board has posts.

Real events still render below (Up next / Coming up).

## Why
Per the MSC-launch feedback, the demo home looked empty/confusing to a first-time viewer. This gives new users an immediate mental model of what Janata does, plus clear next steps and their own center.

## Trigger (easy to tune)
Shown only while `signedUpEvents.length === 0 && boardPeek.length === 0`. It self-resolves the moment the member joins an event or a post appears — an engagement nudge that gets out of the way. Returning members with activity keep the existing layout. If we later want it strictly first-N-visits, a localStorage dismissal is the natural next step.

## Verification
- Web (mobile width) as a no-center fresh signup → tour + "Choose your home center".
- Web as a member with a center → tour + "Chinmaya Mission Boston · Boston, MA · 245 members" card.
- `npm run test:frontend` → **187 pass**. No new tsc errors in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)