### PR TITLE
fix(home): make first-run feed peek reachable

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -129,11 +129,12 @@ export default function HomeScreen() {
   const greetingName = user?.firstName || user?.username || 'friend'
   const todayLabel = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
 
-  // First run: a member who hasn't joined an event or posted yet. Rather than a
-  // sparse, hard-to-read home, give them a short tour of what Janata does, a
-  // card for their center, and a peek at the feed — so they grasp the whole app
-  // at a glance and have clear next steps. Real events still render below.
-  const isNewUser = !!user && signedUpEvents.length === 0 && boardPeek.length === 0
+  // First run: a member still in discovery mode — hasn't joined an event yet.
+  // Rather than a sparse, hard-to-read home, give them a short tour of what
+  // Janata does, a card for their center, and a peek at their board feed when
+  // there's activity — so they grasp the whole app at a glance and have clear
+  // next steps. Real events still render below. Self-resolves once they RSVP.
+  const isNewUser = !!user && signedUpEvents.length === 0
 
   if (discoverLoading || (user ? myEventsLoading : false)) {
     return (


### PR DESCRIPTION
Follow-up to #294.

The first-run overview gated `isNewUser` on `boardPeek.length === 0`, but the overview's "Latest on your board" peek only renders when posts exist. Net result: the peek was dead code — the instant a post existed, `isNewUser` went false and the whole overview disappeared (showing the normal home's boards section instead).

Fix: define "new user" by discovery state — **hasn't joined an event yet** (`signedUpEvents.length === 0`), independent of posts. Now a member with no joined events sees the tour + their center + a live peek of their board, and it self-resolves once they RSVP. Members with joined events keep the normal home (which has its own #293 boards peek).

**Verification:** seeded a post on the local center board (local D1, `--local` — no prod/preview writes) and confirmed the peek renders inside the overview. `npm run test:frontend` → 187 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)