### PR TITLE
feat(notifications): wire the bell to a /notifications screen

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -234,6 +234,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
           <Stack.Screen name="landing" options={{ headerShown: false }} />
           <Stack.Screen name="onboarding" options={{ headerShown: false, gestureEnabled: false }} />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
+          <Stack.Screen name="notifications" options={{ headerShown: false }} />
           <Stack.Screen
             name="events/index"
             options={{ headerShown: true, title: 'My Events', headerBackTitle: '' }}

--- a/packages/frontend/app/notifications.tsx
+++ b/packages/frontend/app/notifications.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { View } from 'react-native'
+import { useRouter } from 'expo-router'
+import StackHeader from '../components/ui/StackHeader'
+import { NotificationCenter } from '../components/notifications/NotificationCenter'
+import { useColors } from '../hooks/useColors'
+import type { Notification } from '../utils/notificationService'
+
+export default function NotificationsScreen() {
+  const c = useColors()
+  const router = useRouter()
+
+  const handleNotificationPress = (notification: Notification) => {
+    // Deep-link to the related resource when the notification carries one.
+    if (notification.actionUrl) {
+      router.push(notification.actionUrl as never)
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: c.bg }}>
+      <StackHeader title="Notifications" />
+      <NotificationCenter showHeader={false} onNotificationPress={handleNotificationPress} />
+    </View>
+  )
+}

--- a/packages/frontend/components/notifications/NotificationCenter.tsx
+++ b/packages/frontend/components/notifications/NotificationCenter.tsx
@@ -15,12 +15,23 @@ import {
   deleteNotification,
 } from '../../utils/notificationService'
 import { NotificationItem } from './NotificationItem'
+import { useColors } from '../../hooks/useColors'
 
 interface NotificationCenterProps {
   onNotificationPress?: (notification: Notification) => void
+  /**
+   * Render the built-in "Notifications" title row. Defaults to true.
+   * Pass false when the hosting screen already supplies a header
+   * (e.g. the /notifications route uses StackHeader for the title + back).
+   */
+  showHeader?: boolean
 }
 
-export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotificationPress }) => {
+export const NotificationCenter: React.FC<NotificationCenterProps> = ({
+  onNotificationPress,
+  showHeader = true,
+}) => {
+  const c = useColors()
   const [notifications, setNotifications] = useState<Notification[]>([])
   const [loading, setLoading] = useState(true)
   const [hasMore, setHasMore] = useState(true)
@@ -122,32 +133,40 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotifi
   const unreadCount = notifications.filter((n) => !n.isRead).length
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: c.bg }]}>
       {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Notifications</Text>
-        {unreadCount > 0 && (
-          <View style={styles.badge}>
-            <Text style={styles.badgeText}>{unreadCount}</Text>
-          </View>
-        )}
-      </View>
+      {showHeader && (
+        <View style={[styles.header, { borderBottomColor: c.divider }]}>
+          <Text style={[styles.headerTitle, { color: c.text }]}>Notifications</Text>
+          {unreadCount > 0 && (
+            <View style={[styles.badge, { backgroundColor: c.accent }]}>
+              <Text style={[styles.badgeText, { color: c.textInverse }]}>{unreadCount}</Text>
+            </View>
+          )}
+        </View>
+      )}
 
       {/* Filters */}
-      <View style={styles.filterContainer}>
+      <View style={[styles.filterContainer, { borderBottomColor: c.divider }]}>
         <TouchableOpacity
-          style={[styles.filterButton, filter === 'all' && styles.filterButtonActive]}
+          style={[
+            styles.filterButton,
+            { backgroundColor: filter === 'all' ? c.accent : c.surface },
+          ]}
           onPress={() => setFilter('all')}
         >
-          <Text style={[styles.filterText, filter === 'all' && styles.filterTextActive]}>
+          <Text style={[styles.filterText, { color: filter === 'all' ? c.textInverse : c.textMuted }]}>
             All
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
-          style={[styles.filterButton, filter === 'unread' && styles.filterButtonActive]}
+          style={[
+            styles.filterButton,
+            { backgroundColor: filter === 'unread' ? c.accent : c.surface },
+          ]}
           onPress={() => setFilter('unread')}
         >
-          <Text style={[styles.filterText, filter === 'unread' && styles.filterTextActive]}>
+          <Text style={[styles.filterText, { color: filter === 'unread' ? c.textInverse : c.textMuted }]}>
             Unread ({unreadCount})
           </Text>
         </TouchableOpacity>
@@ -156,7 +175,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotifi
             style={styles.markAllButton}
             onPress={handleMarkAllAsRead}
           >
-            <Text style={styles.markAllText}>Mark all as read</Text>
+            <Text style={[styles.markAllText, { color: c.accent }]}>Mark all as read</Text>
           </TouchableOpacity>
         )}
       </View>
@@ -164,12 +183,12 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotifi
       {/* Content */}
       {loading && notifications.length === 0 ? (
         <View style={styles.centerContent}>
-          <ActivityIndicator size="large" color="#007AFF" />
-          <Text style={styles.loadingText}>Loading notifications...</Text>
+          <ActivityIndicator size="large" color={c.accent} />
+          <Text style={[styles.loadingText, { color: c.textMuted }]}>Loading notifications...</Text>
         </View>
       ) : notifications.length === 0 ? (
         <View style={styles.centerContent}>
-          <Text style={styles.emptyText}>
+          <Text style={[styles.emptyText, { color: c.textMuted }]}>
             {filter === 'unread' ? 'No unread notifications' : 'No notifications yet'}
           </Text>
         </View>
@@ -189,7 +208,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotifi
           onEndReached={loadMore}
           onEndReachedThreshold={0.3}
           ListFooterComponent={
-            hasMore ? <ActivityIndicator size="small" color="#007AFF" style={styles.footer} /> : null
+            hasMore ? <ActivityIndicator size="small" color={c.accent} style={styles.footer} /> : null
           }
         />
       )}
@@ -200,7 +219,6 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ onNotifi
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   header: {
     flexDirection: 'row',
@@ -209,23 +227,20 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     paddingHorizontal: 16,
     borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
   },
   headerTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#000',
   },
   badge: {
-    backgroundColor: '#007AFF',
     borderRadius: 12,
-    width: 24,
+    minWidth: 24,
     height: 24,
+    paddingHorizontal: 6,
     justifyContent: 'center',
     alignItems: 'center',
   },
   badgeText: {
-    color: '#fff',
     fontSize: 12,
     fontWeight: 'bold',
   },
@@ -235,25 +250,16 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     gap: 8,
     borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
     alignItems: 'center',
   },
   filterButton: {
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 16,
-    backgroundColor: '#f0f0f0',
-  },
-  filterButtonActive: {
-    backgroundColor: '#007AFF',
   },
   filterText: {
     fontSize: 12,
-    color: '#666',
     fontWeight: '500',
-  },
-  filterTextActive: {
-    color: '#fff',
   },
   markAllButton: {
     marginLeft: 'auto',
@@ -262,7 +268,6 @@ const styles = StyleSheet.create({
   },
   markAllText: {
     fontSize: 12,
-    color: '#007AFF',
     fontWeight: '500',
   },
   centerContent: {
@@ -273,11 +278,9 @@ const styles = StyleSheet.create({
   loadingText: {
     marginTop: 12,
     fontSize: 14,
-    color: '#666',
   },
   emptyText: {
     fontSize: 16,
-    color: '#999',
   },
   footer: {
     paddingVertical: 16,

--- a/packages/frontend/components/notifications/NotificationItem.tsx
+++ b/packages/frontend/components/notifications/NotificationItem.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import type { Notification } from '../../utils/notificationService'
 import { getNotificationTypeName } from '../../utils/notificationService'
+import { useColors } from '../../hooks/useColors'
 
 interface NotificationItemProps {
   notification: Notification
@@ -24,6 +25,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   onArchive,
   onDelete,
 }) => {
+  const c = useColors()
   const timestamp = new Date(notification.createdAt)
   const timeString = getTimeString(timestamp)
 
@@ -31,7 +33,8 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
     <TouchableOpacity
       style={[
         styles.container,
-        !notification.isRead && styles.unread,
+        { borderBottomColor: c.divider, backgroundColor: c.card },
+        !notification.isRead && { backgroundColor: c.cardActive },
       ]}
       onPress={() => {
         if (!notification.isRead && onMarkAsRead) {
@@ -43,35 +46,43 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
     >
       <View style={styles.content}>
         <View style={styles.header}>
-          <Text style={[styles.title, !notification.isRead && styles.unreadTitle]}>
+          <Text
+            style={[
+              styles.title,
+              { color: c.text },
+              !notification.isRead && styles.unreadTitle,
+            ]}
+          >
             {notification.title}
           </Text>
-          <Text style={styles.time}>{timeString}</Text>
+          <Text style={[styles.time, { color: c.textFaint }]}>{timeString}</Text>
         </View>
-        <Text style={styles.message} numberOfLines={2}>
+        <Text style={[styles.message, { color: c.textSecondary }]} numberOfLines={2}>
           {notification.message}
         </Text>
-        <Text style={styles.type}>
+        <Text style={[styles.type, { color: c.textMuted }]}>
           {getNotificationTypeName(notification.typeId)}
         </Text>
       </View>
 
-      {!notification.isRead && <View style={styles.unreadIndicator} />}
+      {!notification.isRead && (
+        <View style={[styles.unreadIndicator, { backgroundColor: c.accent }]} />
+      )}
 
       <View style={styles.actions}>
         {!notification.isRead && onMarkAsRead && (
-          <TouchableOpacity onPress={onMarkAsRead} style={styles.actionButton}>
-            <Text style={styles.actionText}>✓</Text>
+          <TouchableOpacity onPress={onMarkAsRead} style={[styles.actionButton, { backgroundColor: c.surface }]}>
+            <Text style={[styles.actionText, { color: c.text }]}>✓</Text>
           </TouchableOpacity>
         )}
         {onArchive && (
-          <TouchableOpacity onPress={onArchive} style={styles.actionButton}>
+          <TouchableOpacity onPress={onArchive} style={[styles.actionButton, { backgroundColor: c.surface }]}>
             <Text style={styles.actionText}>📥</Text>
           </TouchableOpacity>
         )}
         {onDelete && (
-          <TouchableOpacity onPress={onDelete} style={styles.actionButton}>
-            <Text style={styles.actionText}>✕</Text>
+          <TouchableOpacity onPress={onDelete} style={[styles.actionButton, { backgroundColor: c.surface }]}>
+            <Text style={[styles.actionText, { color: c.text }]}>✕</Text>
           </TouchableOpacity>
         )}
       </View>
@@ -100,12 +111,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
-    backgroundColor: '#fff',
     alignItems: 'center',
-  },
-  unread: {
-    backgroundColor: '#f9f9f9',
   },
   content: {
     flex: 1,
@@ -120,7 +126,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: '500',
-    color: '#333',
     flex: 1,
   },
   unreadTitle: {
@@ -128,25 +133,21 @@ const styles = StyleSheet.create({
   },
   time: {
     fontSize: 12,
-    color: '#999',
     marginLeft: 8,
   },
   message: {
     fontSize: 14,
-    color: '#666',
     marginBottom: 4,
     lineHeight: 20,
   },
   type: {
     fontSize: 12,
-    color: '#999',
     fontStyle: 'italic',
   },
   unreadIndicator: {
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#007AFF',
     marginRight: 8,
   },
   actions: {
@@ -157,7 +158,6 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 4,
-    backgroundColor: '#f0f0f0',
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
## What

The notification **bell** (`TabHeader` `action="notifications"`) pushes to `/notifications`, but **that route didn't exist** — taps fell through to `+not-found`. This connects the already-built pieces so the bell actually works.

Found during review of #291 (which placed the bell next to the new profile avatar on the home header): notifications was ~80% built — backend API (`packages/backend/src/app.ts:2440+`), D1 schema (`migrations/0005_notifications.sql`), the `NotificationCenter` UI and `notificationService` all exist. Only the frontend route was missing.

## Changes
- **New `app/notifications.tsx`** — `StackHeader` (themed back button + title) + `<NotificationCenter showHeader={false} />`. Notification taps deep-link to `actionUrl` when present.
- **Register the route** in the root Stack (`app/_layout.tsx`, one line).
- **Theme `NotificationCenter` + `NotificationItem`** — they hardcoded light colors (`#fff`, iOS-blue `#007AFF`), so they'd render a **white panel in the dark app**. Now use `useColors()` → match light/dark and use the brand orange.
- **`NotificationCenter` gains a `showHeader` prop** so the route's `StackHeader` supplies the title without a duplicate.

## Scope
- Independent PR off `v2` (sits on top of merged #291). No dependency on other branches.
- **In-app notifications only.** Push (APNs/FCM) is unbuilt (`expo-notifications` not installed; schema's `push_enabled` flagged "future") — left as separate, larger work.
- Unread **badge/dot on the bell itself** is not included (would need an unread-count fetch in `TabHeader`) — noted as a follow-up.

## Verification
- `tsc --noEmit`: **0 errors in the changed files** (6 pre-existing baseline errors elsewhere, unrelated).
- ⚠️ **Not yet simulator-smoke-tested** (sandbox couldn't complete `npm install`). Recommend confirming: bell opens the screen, back works, empty state reads "No notifications yet" in dark mode, All/Unread filters toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)