### PR TITLE
feat(analytics): typed PostHog coverage across every page + feature (iOS + web)

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -7,7 +7,7 @@ import { House, Newspaper, Compass, Plus } from 'lucide-react-native'
 import SettingsPanel from '../../components/settings/SettingsPanel'
 import Logo from '../../components/ui/Logo'
 import TabHeader from '../../components/ui/TabHeader'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 
 export default function TabLayout() {
   const router = useRouter()
@@ -16,7 +16,7 @@ export default function TabLayout() {
   const { isDark } = useTheme()
   const [settingsVisible, setSettingsVisible] = useState(false)
   const canCreate = !!user
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const tabBarShowLabel = Platform.OS === 'web'
   const { width } = useWindowDimensions()
   const isDesktopWeb = Platform.OS === 'web' && width >= 768
@@ -28,7 +28,7 @@ export default function TabLayout() {
   }, [user, loading])
 
   const handleLogout = async () => {
-    posthog?.capture('nav_logout')
+    track('nav_logout')
     await logout()
     router.replace('/auth')
   }
@@ -70,7 +70,7 @@ export default function TabLayout() {
         {/* Left: Logo + Nav */}
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 24 }}>
           <Pressable
-            onPress={() => router.push('/')}
+            onPress={() => { track('nav_logo_pressed', { source: 'web_header' }); router.push('/') }}
             style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}
           >
             <Logo size={28} />
@@ -81,7 +81,7 @@ export default function TabLayout() {
               return (
                 <Pressable
                   key={href}
-                  onPress={() => router.push(href)}
+                  onPress={() => { track('nav_tab_pressed', { label, href, source: 'web_header' }); router.push(href) }}
                   style={{
                     paddingHorizontal: 12,
                     paddingVertical: 10,
@@ -123,7 +123,7 @@ export default function TabLayout() {
                 borderColor: '#E8862A',
               }}
               onPress={() => {
-                posthog?.capture('nav_create_event')
+                track('nav_create_event', { source: 'web_header' })
                 router.push('/explore?action=create')
               }}
             >
@@ -136,7 +136,7 @@ export default function TabLayout() {
           <Pressable
             style={{ width: 36, height: 36, borderRadius: 18, overflow: 'hidden' }}
             onPress={() => {
-              posthog?.capture('nav_menu_opened')
+              track('nav_menu_opened', { source: 'web_header' })
               setSettingsVisible(true)
             }}
           >

--- a/packages/frontend/app/(tabs)/chat.tsx
+++ b/packages/frontend/app/(tabs)/chat.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native'
 import { useNavigation, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import {
@@ -76,7 +76,7 @@ export default function ChatScreen() {
   const colors = useColors()
   const { width } = useWindowDimensions()
   const insets = useSafeAreaInsets()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const detailTranslateX = useRef(new Animated.Value(width)).current
 
   const isDesktop = width >= 980
@@ -156,6 +156,10 @@ export default function ChatScreen() {
   }
 
   const closeDetail = () => {
+    track('connect_conversation_closed', {
+      conversationId: selectedConversationId,
+      source: 'chat',
+    })
     if (Platform.OS !== 'web' && nativeDetailOpen) {
       detailTranslateX.stopAnimation()
       Animated.timing(detailTranslateX, {
@@ -175,7 +179,7 @@ export default function ChatScreen() {
   }
 
   const openConversation = (id: string) => {
-    posthog?.capture('connect_conversation_selected', { conversationId: id })
+    track('connect_conversation_selected', { conversationId: id, source: 'chat' })
     if (Platform.OS === 'web' && isDesktop) {
       primeNativeDetailTransition()
       setSelectedConversationId(id)
@@ -212,7 +216,7 @@ export default function ChatScreen() {
             subtitle="Your group chats, requests, and DMs live here."
             colors={colors}
             onPress={() => {
-              posthog?.capture('connect_signin_pressed')
+              track('connect_signin_pressed', { source: 'chat' })
               router.push('/auth')
             }}
           />

--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -22,7 +22,7 @@ import {
   Plus,
 } from 'lucide-react-native'
 import { useRouter, useFocusEffect, useNavigation } from 'expo-router'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useTheme } from '../../components/contexts'
 import { Badge, UnderlineTabBar, Avatar, FilterChip } from '../../components/ui'
 import FilterPickerModal, { type FilterPickerOption } from '../../components/ui/FilterPickerModal'
@@ -232,7 +232,7 @@ function CenterItem({ center, onPress, isMyCenter }: { center: DiscoverCenter; o
 export default function DiscoverScreen() {
   const router = useRouter()
   const { isDark } = useTheme()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const [activeFilter, setActiveFilter] = useState<DiscoverFilter>('Events')
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
@@ -435,13 +435,13 @@ export default function DiscoverScreen() {
   )
 
   const handleFilterPress = (f: DiscoverFilter) => {
-    posthog?.capture('discover_filter_changed', { filter: f })
+    track('discover_filter_changed', { filter: f, source: 'discover' })
     setActiveFilter(f)
     setSelectedDate(null)
   }
 
   const handlePointPress = (point: { id: string; type: 'center' | 'event' }) => {
-    posthog?.capture('map_point_pressed', { type: point.type, id: point.id })
+    track('map_point_pressed', { type: point.type, id: point.id, source: 'discover' })
     if (point.type === 'center') {
       router.push(`/center/${point.id}`)
     } else {
@@ -506,7 +506,7 @@ export default function DiscoverScreen() {
                 onChangeText={setSearchQuery}
                 onEndEditing={() => {
                   if (searchQuery.trim()) {
-                    posthog?.capture('discover_search', { query: searchQuery.trim() })
+                    track('discover_search', { query: searchQuery.trim(), source: 'discover' })
                   }
                 }}
               />
@@ -533,7 +533,7 @@ export default function DiscoverScreen() {
                     onPress={() => {
                       setSelectedDate((prev) => {
                         const next = prev === todayStr ? null : todayStr
-                        if (next) posthog?.capture('discover_date_selected', { date: next })
+                        if (next) track('discover_date_selected', { date: next, source: 'discover' })
                         return next
                       })
                     }}
@@ -542,14 +542,20 @@ export default function DiscoverScreen() {
                     label={centerChipLabel}
                     variant="outline"
                     active={selectedCenter !== null}
-                    onPress={() => setShowCenterModal(true)}
+                    onPress={() => {
+                      track('discover_center_filter_opened', { source: 'discover' })
+                      setShowCenterModal(true)
+                    }}
                   />
                   {user && (
                     <FilterChip
                       label="Going"
                       variant="outline"
                       active={showGoingOnly}
-                      onPress={() => setShowGoingOnly((prev) => !prev)}
+                      onPress={() => {
+                        track('discover_going_filter_toggled', { enabled: !showGoingOnly, source: 'discover' })
+                        setShowGoingOnly((prev) => !prev)
+                      }}
                     />
                   )}
                 </View>
@@ -559,7 +565,7 @@ export default function DiscoverScreen() {
                     accessibilityLabel="Create event"
                     hitSlop={8}
                     onPress={() => {
-                      posthog?.capture('nav_create_event', { source: 'discover' })
+                      track('nav_create_event', { source: 'discover' })
                       router.push('/events/form')
                     }}
                     className="flex-row items-center active:opacity-70"
@@ -608,7 +614,10 @@ export default function DiscoverScreen() {
                 return (
                   <Pressable
                     key={`section-${idx}`}
-                    onPress={() => toggleSection(label)}
+                    onPress={() => {
+                      track('discover_section_toggled', { label, collapsed: !collapsedSections.has(label), source: 'discover' })
+                      toggleSection(label)
+                    }}
                     className={`bg-white dark:bg-neutral-900 ${idx > 0 ? 'border-t border-stone-200 dark:border-neutral-800' : ''}`}
                   >
                     <View
@@ -635,7 +644,7 @@ export default function DiscoverScreen() {
                     event={item.data as EventDisplay}
                     centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
                     onPress={() => {
-                      posthog?.capture('event_list_item_pressed', { eventId: item.data.id, source: 'discover' })
+                      track('event_list_item_pressed', { eventId: item.data.id, source: 'discover' })
                       router.push(`/events/${item.data.id}`)
                     }}
                   />
@@ -649,7 +658,7 @@ export default function DiscoverScreen() {
                   center={item.data as DiscoverCenter}
                   isMyCenter={!!user?.centerID && item.data.id === user.centerID}
                   onPress={() => {
-                    posthog?.capture('center_list_item_pressed', { centerId: item.data.id, source: 'discover' })
+                    track('center_list_item_pressed', { centerId: item.data.id, source: 'discover' })
                     router.push(`/center/${item.data.id}`)
                   }}
                 />

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react-native'
 import { MapPin, Search, Building2, Users, ChevronUp, ChevronDown } from 'lucide-react-native'
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router'
+import { useAnalytics } from '../../utils/analytics'
 import { useTheme, useUser } from '../../components/contexts'
 import { FilterChip, Badge, UnderlineTabBar, Avatar } from '../../components/ui'
 import FilterPickerModal, { type FilterPickerOption } from '../../components/ui/FilterPickerModal'
@@ -465,6 +466,7 @@ type SheetSnap = 'peek' | 'collapsed' | 'mid' | 'expanded'
 function MobileDiscoverFallback() {
   const router = useRouter()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [activeFilter, setActiveFilter] = useState<DiscoverFilter>('Events')
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
@@ -581,19 +583,21 @@ function MobileDiscoverFallback() {
 
   const handlePointPress = useCallback(
     (point: MapPoint) => {
+      track('map_point_pressed', { type: point.type, id: point.id, source: 'discover' })
       if (point.type === 'center') {
         router.push(`/center/${point.id}`)
       } else {
         router.push(`/events/${point.id}`)
       }
     },
-    [router]
+    [router, track]
   )
 
   const handleFilterPress = useCallback((f: DiscoverFilter) => {
+    track('discover_filter_changed', { filter: f, source: 'discover' })
     setActiveFilter(f)
     setSelectedDate(null)
-  }, [])
+  }, [track])
 
   const eventDates = useMemo(
     () => new Set(allEvents.filter((e) => e.date).map((e) => e.date)),
@@ -697,11 +701,13 @@ function MobileDiscoverFallback() {
   const toggleSection = useCallback((label: string) => {
     setCollapsedSections((prev) => {
       const next = new Set(prev)
-      if (next.has(label)) next.delete(label)
-      else next.add(label)
+      const willCollapse = !next.has(label)
+      if (willCollapse) next.add(label)
+      else next.delete(label)
+      track('discover_section_toggled', { label, collapsed: willCollapse, source: 'discover' })
       return next
     })
-  }, [])
+  }, [track])
 
   return (
     <div
@@ -806,6 +812,11 @@ function MobileDiscoverFallback() {
                 value={searchQuery}
                 onChangeText={setSearchQuery}
                 onFocus={() => setSheetSnap('expanded')}
+                onEndEditing={() => {
+                  if (searchQuery.trim()) {
+                    track('discover_search', { query: searchQuery.trim(), source: 'discover' })
+                  }
+                }}
               />
             </View>
 
@@ -826,20 +837,32 @@ function MobileDiscoverFallback() {
                   label="Today"
                   variant="outline"
                   active={selectedDate === todayStr}
-                  onPress={() => setSelectedDate((prev) => (prev === todayStr ? null : todayStr))}
+                  onPress={() => {
+                    setSelectedDate((prev) => {
+                      const next = prev === todayStr ? null : todayStr
+                      if (next) track('discover_date_selected', { date: next, source: 'discover' })
+                      return next
+                    })
+                  }}
                 />
                 <FilterChip
                   label={centerChipLabel}
                   variant="outline"
                   active={selectedCenter !== null}
-                  onPress={() => setShowCenterModal(true)}
+                  onPress={() => {
+                    track('discover_center_filter_opened', { source: 'discover' })
+                    setShowCenterModal(true)
+                  }}
                 />
                 {user && (
                   <FilterChip
                     label="Going"
                     variant="outline"
                     active={showGoingOnly}
-                    onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
+                    onPress={() => {
+                      track('discover_going_filter_toggled', { enabled: !showGoingOnly, source: 'discover' })
+                      setShowGoingOnly((prev: boolean) => !prev)
+                    }}
                   />
                 )}
               </View>
@@ -919,7 +942,10 @@ function MobileDiscoverFallback() {
                     key={`event-${item.data.id}`}
                     event={item.data as EventDisplay}
                     centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
-                    onPress={() => router.push(`/events/${item.data.id}`)}
+                    onPress={() => {
+                      track('event_list_item_pressed', { eventId: item.data.id, source: 'discover' })
+                      router.push(`/events/${item.data.id}`)
+                    }}
                   />
                 )
               }
@@ -930,7 +956,10 @@ function MobileDiscoverFallback() {
                   key={`center-${item.data.id}`}
                   center={item.data as DiscoverCenter}
                   isMyCenter={!!user?.centerID && item.data.id === user.centerID}
-                  onPress={() => router.push(`/center/${item.data.id}`)}
+                  onPress={() => {
+                    track('center_list_item_pressed', { centerId: item.data.id, source: 'discover' })
+                    router.push(`/center/${item.data.id}`)
+                  }}
                 />
               )
             })}
@@ -962,6 +991,7 @@ export default function DiscoverScreenWeb() {
   const router = useRouter()
   const { isDark } = useTheme()
   const { user } = useUser()
+  const { track } = useAnalytics()
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
   // Beta: any signed-in user can create events. Backend enforces auth-only;
   // post-beta this becomes a coordinator-tier gate (see issue tracker).
@@ -1118,19 +1148,22 @@ export default function DiscoverScreenWeb() {
     : 'Center'
 
   const handleFilterPress = useCallback((f: DiscoverFilter) => {
+    track('discover_filter_changed', { filter: f, source: 'discover' })
     setActiveFilter(f)
     setSelectedDate(null)
-  }, [])
+  }, [track])
 
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
   const toggleSection = useCallback((label: string) => {
     setCollapsedSections((prev) => {
       const next = new Set(prev)
-      if (next.has(label)) next.delete(label)
-      else next.add(label)
+      const willCollapse = !next.has(label)
+      if (willCollapse) next.add(label)
+      else next.delete(label)
+      track('discover_section_toggled', { label, collapsed: willCollapse, source: 'discover' })
       return next
     })
-  }, [])
+  }, [track])
 
   // Map popover state
   const mapPanelRef = useRef<View>(null)
@@ -1180,9 +1213,10 @@ export default function DiscoverScreenWeb() {
   const handlePopoverView = useCallback(() => {
     if (!clickPopover) return
     const { point } = clickPopover
+    track('map_point_pressed', { type: point.type, id: point.id, source: 'discover_map_popover' })
     setSelectedItem({ type: point.type === 'center' ? 'center' : 'event', id: point.id })
     setClickPopover(null)
-  }, [clickPopover])
+  }, [clickPopover, track])
 
   // Look up details for popover from hook data (not sample constants)
   const clickEventDetail = useMemo(() => {
@@ -1196,8 +1230,9 @@ export default function DiscoverScreenWeb() {
   }, [clickPopover, allCenters])
 
   const handlePointPress = useCallback((point: MapPoint) => {
+    track('map_point_pressed', { type: point.type, id: point.id, source: 'discover' })
     setSelectedItem({ type: point.type === 'center' ? 'center' : 'event', id: point.id })
-  }, [])
+  }, [track])
 
   const handleMapMove = useCallback(() => {
     setClickPopover(null)
@@ -1311,6 +1346,11 @@ export default function DiscoverScreenWeb() {
                     value={searchQuery}
                     onChangeText={setSearchQuery}
                     style={{ paddingVertical: 8 }}
+                    onEndEditing={() => {
+                      if (searchQuery.trim()) {
+                        track('discover_search', { query: searchQuery.trim(), source: 'discover' })
+                      }
+                    }}
                   />
                 </View>
               </View>
@@ -1333,22 +1373,32 @@ export default function DiscoverScreenWeb() {
                   label="Today"
                   variant="outline"
                   active={selectedDate === todayStrDesktop}
-                  onPress={() =>
-                    setSelectedDate((prev) => (prev === todayStrDesktop ? null : todayStrDesktop))
-                  }
+                  onPress={() => {
+                    setSelectedDate((prev) => {
+                      const next = prev === todayStrDesktop ? null : todayStrDesktop
+                      if (next) track('discover_date_selected', { date: next, source: 'discover' })
+                      return next
+                    })
+                  }}
                 />
                 <FilterChip
                   label={centerChipLabelDesktop}
                   variant="outline"
                   active={selectedCenterDesktop !== null}
-                  onPress={() => setShowCenterModalDesktop(true)}
+                  onPress={() => {
+                    track('discover_center_filter_opened', { source: 'discover' })
+                    setShowCenterModalDesktop(true)
+                  }}
                 />
                 {user && (
                   <FilterChip
                     label="Going"
                     variant="outline"
                     active={showGoingOnly}
-                    onPress={() => setShowGoingOnly((prev: boolean) => !prev)}
+                    onPress={() => {
+                      track('discover_going_filter_toggled', { enabled: !showGoingOnly, source: 'discover' })
+                      setShowGoingOnly((prev: boolean) => !prev)
+                    }}
                   />
                 )}
               </View>
@@ -1392,7 +1442,10 @@ export default function DiscoverScreenWeb() {
                       key={`event-${item.data.id}`}
                       event={item.data as EventDisplay}
                       centerName={allCenters.find((c) => c.id === (item.data as EventDisplay).centerId)?.name}
-                      onPress={() => setSelectedItem({ type: 'event', id: item.data.id })}
+                      onPress={() => {
+                        track('event_list_item_pressed', { eventId: item.data.id, source: 'discover' })
+                        setSelectedItem({ type: 'event', id: item.data.id })
+                      }}
                     />
                   )
                 }
@@ -1403,7 +1456,10 @@ export default function DiscoverScreenWeb() {
                     key={`center-${item.data.id}`}
                     center={item.data as DiscoverCenter}
                     isMyCenter={!!user?.centerID && item.data.id === user.centerID}
-                    onPress={() => setSelectedItem({ type: 'center', id: item.data.id })}
+                    onPress={() => {
+                      track('center_list_item_pressed', { centerId: item.data.id, source: 'discover' })
+                      setSelectedItem({ type: 'center', id: item.data.id })
+                    }}
                   />
                 )
               })}

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native'
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { toThreadColors } from '../../tokens'
@@ -144,7 +144,7 @@ export default function FeedScreen() {
   const colors = useColors()
   const { width } = useWindowDimensions()
   const insets = useSafeAreaInsets()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const detailTranslateX = useRef(new Animated.Value(width)).current
   const {
     events: myEvents,
@@ -308,17 +308,32 @@ export default function FeedScreen() {
     setSelectedPostId('')
   }
 
+  // Track non-empty search queries with a short debounce so rapid keystrokes
+  // are collapsed into a single event.
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    if (!query.trim()) return
+    searchDebounceRef.current = setTimeout(() => {
+      track('feed_searched', { query: query.trim(), source: 'feed' })
+    }, 600)
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    }
+  }, [query])
+
   const handleBoardAccessCta = () => {
     if (!user) {
-      posthog?.capture('connect_signin_pressed', { source: 'feed_cta' })
+      track('connect_signin_pressed', { source: 'feed_cta' })
       router.push('/auth')
       return
     }
-    posthog?.capture('connect_explore_pressed', { source: 'feed_cta' })
+    track('connect_explore_pressed', { source: 'feed_cta' })
     router.push('/explore' as never)
   }
 
   const closeDetail = () => {
+    track('feed_post_detail_closed', { postId: selectedPostId, source: 'feed' })
     if (Platform.OS !== 'web' && nativeDetailOpen) {
       detailTranslateX.stopAnimation()
       Animated.timing(detailTranslateX, {
@@ -337,14 +352,14 @@ export default function FeedScreen() {
   }
 
   const openPost = (id: string) => {
-    posthog?.capture('connect_feed_post_selected', { postId: id })
+    track('connect_feed_post_selected', { postId: id, source: 'feed' })
     primeNativeDetailTransition()
     setSelectedPostId(id)
   }
 
   const openGroup = (group: GroupBoard) => {
     if (!group.routeHref) return
-    posthog?.capture('connect_empty_board_opened', { groupId: group.id, kind: group.kind })
+    track('connect_empty_board_opened', { groupId: group.id, kind: group.kind, source: 'feed' })
     router.push(group.routeHref as never)
   }
 
@@ -352,8 +367,14 @@ export default function FeedScreen() {
     group: { kind: 'center' | 'event'; parentId: string },
     body: string
   ) => {
-    await createBoardPost(group.kind, group.parentId, body)
-    await loadBoards()
+    try {
+      await createBoardPost(group.kind, group.parentId, body)
+      track('feed_post_created', { kind: group.kind, parentId: group.parentId, source: 'feed' })
+      await loadBoards()
+    } catch (err) {
+      track('feed_post_create_failed', { kind: group.kind, parentId: group.parentId, source: 'feed' })
+      throw err
+    }
   }
 
   return (
@@ -383,7 +404,7 @@ export default function FeedScreen() {
             subtitle="Your member feed, group boards, and announcements live here."
             colors={colors}
             onPress={() => {
-              posthog?.capture('connect_signin_pressed')
+              track('connect_signin_pressed', { source: 'feed_banner' })
               router.push('/auth')
             }}
           />
@@ -537,7 +558,10 @@ export default function FeedScreen() {
         visible={createPostOpen}
         colors={colors}
         groups={groupsWithMessages}
-        onClose={() => setCreatePostOpen(false)}
+        onClose={() => {
+          track('feed_create_post_dismissed', { source: 'feed' })
+          setCreatePostOpen(false)
+        }}
         onSubmit={handleCreatePost}
       />
     </View>

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react'
 import { ActivityIndicator, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
 import { CalendarCheck, ChevronRight, Compass, MapPin, MessageCircle } from 'lucide-react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { useDetailColors } from '../../hooks/useDetailColors'
@@ -56,7 +56,7 @@ function liveEventToWeekItem(event: EventDisplay, onPress: () => void): WeekItem
 export default function HomeScreen() {
   const router = useRouter()
   const { width } = useWindowDimensions()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const { user } = useUser()
   const c = useColors()
   const detailColors = useDetailColors()
@@ -120,11 +120,11 @@ export default function HomeScreen() {
     if (pool.length === 0) return []
     return pool.slice(0, 4).map((event) =>
       liveEventToWeekItem(event, () => {
-        posthog?.capture('home_event_pressed', { eventId: event.id, source: 'this_week' })
+        track('home_event_pressed', { eventId: event.id, source: 'this_week' })
         router.push(`/events/${event.id}`)
       })
     )
-  }, [featured, posthog, router, signedUpEvents, upcomingExploreEvents])
+  }, [featured, track, router, signedUpEvents, upcomingExploreEvents])
 
   const greetingName = user?.firstName || user?.username || 'friend'
   const todayLabel = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
@@ -169,35 +169,38 @@ export default function HomeScreen() {
             center={userCenter}
             peek={boardPeek}
             onExplore={() => {
-              posthog?.capture('home_first_run_explore_pressed')
+              track('home_first_run_explore_pressed')
               router.push('/explore' as never)
             }}
             onFeed={() => {
-              posthog?.capture('home_first_run_feed_pressed')
+              track('home_first_run_feed_pressed')
               router.push('/feed' as never)
             }}
             onChooseCenter={() => {
-              posthog?.capture('home_first_run_center_pressed')
+              track('home_first_run_center_pressed')
               router.push('/center-picker' as never)
             }}
             onOpenCenter={(id) => {
-              posthog?.capture('home_first_run_center_opened', { centerId: id })
+              track('home_first_run_center_opened', { centerId: id })
               router.push(`/center/${id}`)
             }}
             onPeekPress={(id) => {
-              posthog?.capture('home_board_peek_pressed', { postId: id })
+              track('home_board_peek_pressed', { postId: id, source: 'first_run_peek' })
               router.push('/feed' as never)
             }}
           />
         ) : null}
 
         {!isNewUser || featured ? (
-          <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => router.push('/' as never)}>
+          <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => {
+            track('home_see_all_pressed', { section: 'up_next' })
+            router.push('/' as never)
+          }}>
             {featured ? (
               <FeaturedEventCard
                 featured={featured}
                 onPress={() => {
-                  posthog?.capture('home_featured_event_pressed', { eventId: featured.event.id })
+                  track('home_featured_event_pressed', { eventId: featured.event.id })
                   router.push(`/events/${featured.event.id}`)
                 }}
               />
@@ -210,7 +213,10 @@ export default function HomeScreen() {
                   </Text>
                 </View>
                 <Pressable
-                  onPress={() => router.push('/explore' as never)}
+                  onPress={() => {
+                    track('home_explore_fallback_pressed', { source: 'up_next_empty' })
+                    router.push('/explore' as never)
+                  }}
                   style={{ alignSelf: 'flex-start', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: c.accentSoft }}
                 >
                   <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.accent }}>Explore</Text>
@@ -231,7 +237,10 @@ export default function HomeScreen() {
             trailing="Open Feed"
             accentColor={c.accent}
             faintColor={c.textFaint}
-            onTrailingPress={() => router.push('/feed' as never)}
+            onTrailingPress={() => {
+              track('home_open_feed_pressed', { source: 'boards_section_header' })
+              router.push('/feed' as never)
+            }}
           >
             {boardPeek.length > 0 ? (
               <View>
@@ -242,7 +251,7 @@ export default function HomeScreen() {
                     colors={detailColors}
                     showSource
                     onPress={() => {
-                      posthog?.capture('home_board_peek_pressed', { postId: message.id })
+                      track('home_board_peek_pressed', { postId: message.id, source: 'boards_section' })
                       router.push('/feed' as never)
                     }}
                   />
@@ -267,7 +276,10 @@ export default function HomeScreen() {
             trailing="See all"
             accentColor={c.accent}
             faintColor={c.textFaint}
-            onTrailingPress={() => router.push('/' as never)}
+            onTrailingPress={() => {
+              track('home_see_all_pressed', { section: signedUpEvents.length > 0 ? 'this_week' : 'coming_up' })
+              router.push('/' as never)
+            }}
           >
             {weekItems.length > 0 ? (
               <View style={{ gap: 8 }}>

--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -12,11 +12,13 @@ import {
   fetchUserPosts,
   CenterData,
 } from '../../utils/api'
+import { useAnalytics } from '../../utils/analytics'
 
 export default function ProfileNative() {
   const router = useRouter()
   const { user, refreshUser } = useUser()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [allCenters, setAllCenters] = useState<CenterData[]>([])
   const [postCount, setPostCount] = useState(0)
   const [eventCount, setEventCount] = useState(0)
@@ -91,6 +93,7 @@ export default function ProfileNative() {
         message: `Check out ${getDisplayName()} on Janata!`,
         title: getDisplayName(),
       })
+      track('profile_shared', { source: 'profile', username: user?.username })
     } catch {
       // Silently fail
     }
@@ -309,7 +312,10 @@ export default function ProfileNative() {
           }}
         >
           <Pressable
-            onPress={() => router.push('/edit-profile')}
+            onPress={() => {
+              track('profile_edit_opened', { source: 'profile', username: user?.username })
+              router.push('/edit-profile')
+            }}
             accessibilityRole="button"
             accessibilityLabel="Edit profile"
             style={{

--- a/packages/frontend/app/(tabs)/profile.web.tsx
+++ b/packages/frontend/app/(tabs)/profile.web.tsx
@@ -15,6 +15,7 @@ import { Text } from '../../components/ui'
 import BirthdatePicker from '../../components/profile/BirthdatePicker'
 import WebAvatarCropper from '../../components/profile/AvatarCropper.web'
 import { fetchCenters, CenterData } from '../../utils/api'
+import { useAnalytics } from '../../utils/analytics'
 
 type ProfileData = {
   name: string
@@ -55,6 +56,7 @@ const PREFERENCE_OPTIONS = [
 export default function Profile() {
   const { user, updateProfile, setUser } = useUser()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [isEditing, setIsEditing] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
@@ -108,6 +110,7 @@ export default function Profile() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleAvatarPress = () => {
+    track('profile_avatar_edit_opened', { source: 'profile', has_existing_image: !!profileData.profileImage })
     // If user has an existing profile image, use the original (uncropped) if available in session
     if (originalImage || user?.originalImage) {
       setCropperImage(originalImage || user?.originalImage || null)
@@ -125,6 +128,7 @@ export default function Profile() {
       const url = URL.createObjectURL(file)
       setOriginalImage(url)
       setCropperImage(url)
+      track('profile_avatar_file_selected', { source: 'profile', file_type: file.type })
     }
   }
 
@@ -135,10 +139,12 @@ export default function Profile() {
     setProfileData((prev) => ({ ...prev, profileImage: url }))
     setProfileImageChanged(true)
     setCropperImage(null)
+    track('profile_avatar_cropped', { source: 'profile' })
   }
 
   const handleCropCancel = () => {
     setCropperImage(null)
+    track('profile_avatar_crop_cancelled', { source: 'profile' })
   }
 
   const handleReplacePhoto = () => {
@@ -266,6 +272,7 @@ export default function Profile() {
     savedProfileImage.current = profileData.profileImage
     savedCenterID.current = profileData.centerID
     setIsEditing(true)
+    track('profile_edit_started', { source: 'profile', username: user?.username })
   }
 
   const handleCancel = () => {
@@ -284,6 +291,7 @@ export default function Profile() {
     setProfileImageChanged(false)
     setErrors({})
     setIsEditing(false)
+    track('profile_edit_cancelled', { source: 'profile', username: user?.username })
   }
 
   const handleSave = async () => {
@@ -320,6 +328,7 @@ export default function Profile() {
             ...prev,
             profileImage: 'Failed to upload image. Please try again.',
           }))
+          track('profile_update_failed', { source: 'profile', username: user?.username, reason: 'image_upload_error' })
           setIsSaving(false)
           return
         }
@@ -337,6 +346,7 @@ export default function Profile() {
 
       if (!result.success) {
         setErrors((prev) => ({ ...prev, form: result.message || 'Failed to save profile' }))
+        track('profile_update_failed', { source: 'profile', username: user?.username, reason: result.message || 'api_error' })
         setIsSaving(false)
         return
       }
@@ -345,10 +355,12 @@ export default function Profile() {
       if (originalImage && user) {
         setUser({ ...user, originalImage: originalImage })
       }
+      track('profile_updated', { source: 'profile', username: user?.username })
       setIsEditing(false)
       setErrors({})
     } catch (error) {
       if (__DEV__) console.error('Error saving profile:', error)
+      track('profile_update_failed', { source: 'profile', username: user?.username, reason: 'exception' })
       setIsEditing(false)
       setErrors({})
     } finally {
@@ -358,12 +370,14 @@ export default function Profile() {
 
   const handlePreferenceToggle = (preference: string) => {
     if (!isEditing) return
+    const willSelect = !profileData.interests.includes(preference)
     setProfileData((prev) => ({
       ...prev,
       interests: prev.interests.includes(preference)
         ? prev.interests.filter((p) => p !== preference)
         : [...prev.interests, preference],
     }))
+    track('profile_interest_toggled', { source: 'profile', interest: preference, selected: willSelect })
   }
 
   const labelColor = isDark ? '#78716C' : '#A8A29E'
@@ -661,6 +675,7 @@ export default function Profile() {
                           setProfileData((prev) => ({ ...prev, centerID: center.centerID }))
                           setCenterSearch('')
                           setShowCenterPicker(false)
+                          track('profile_center_selected', { source: 'profile', center_id: center.centerID, center_name: center.name })
                         }}
                         style={{
                           paddingHorizontal: 16,
@@ -1191,6 +1206,7 @@ export default function Profile() {
                           setProfileData((prev) => ({ ...prev, centerID: center.centerID }))
                           setCenterSearch('')
                           setShowCenterPicker(false)
+                          track('profile_center_selected', { source: 'profile', center_id: center.centerID, center_name: center.name })
                         }}
                         style={{
                           paddingHorizontal: 16,

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -28,6 +28,7 @@ import {
 } from '../components/contexts'
 import { ErrorBoundary, ErrorBoundaryWithAnalytics } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
+import { AnalyticsScreenTracker } from '../utils/analytics'
 import { getIntroShown } from '../utils/introStorage'
 import '../globals.css'
 
@@ -85,7 +86,21 @@ export default function RootLayout() {
   if (!fontsLoaded) return null
 
   return posthogEnabled ? (
-    <PostHogProvider apiKey={posthogKey!.trim()} options={{ host: posthogHost }}>
+    <PostHogProvider
+      apiKey={posthogKey!.trim()}
+      options={{
+        host: posthogHost,
+        // Capture app opened / backgrounded / became active lifecycle events.
+        captureAppLifecycleEvents: true,
+      }}
+      // Screens are tracked manually via <AnalyticsScreenTracker /> below, and
+      // touch autocapture is too noisy — disable both, keep autocapture off.
+      autocapture={{
+        captureScreens: false,
+        captureTouches: false,
+      }}
+    >
+      <AnalyticsScreenTracker />
       <ErrorBoundaryWithAnalytics>
         <CustomThemeProvider>
           <UserProvider>

--- a/packages/frontend/app/admin.web.tsx
+++ b/packages/frontend/app/admin.web.tsx
@@ -10,11 +10,18 @@ import InviteCodesTab from '../components/admin/InviteCodesTab'
 import NotificationsTab from '../components/admin/NotificationsTab'
 import ModerationTab from '../components/admin/ModerationTab'
 import { isSuperAdmin as checkSuperAdmin } from '../utils/admin'
+import { useAnalytics } from '../utils/analytics'
 
 export default function AdminPage() {
   const { user, loading } = useUser()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [activeTab, setActiveTab] = useState<AdminTab>('Centers')
+
+  const handleTabChange = (tab: AdminTab) => {
+    setActiveTab(tab)
+    track('admin_tab_changed', { tab, source: 'admin' })
+  }
 
   // TODO: backend must enforce admin auth on all admin-specific endpoints
   const isAdmin = checkSuperAdmin(user)
@@ -41,7 +48,7 @@ export default function AdminPage() {
 
   return (
     <View style={{ flex: 1, flexDirection: 'row', backgroundColor: pageBg }}>
-      <AdminSidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <AdminSidebar activeTab={activeTab} onTabChange={handleTabChange} />
       {activeTab === 'Centers' && <CentersTab />}
       {activeTab === 'Events' && <EventsTab />}
       {activeTab === 'Users' && <UsersTab />}

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native'
 import { useRouter, useLocalSearchParams } from 'expo-router'
 import { Code, ArrowLeft } from 'lucide-react-native'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../utils/analytics'
 import { AuthInput, Logo, PrimaryButton } from '../components/ui'
 import { useUser, useTheme } from '../components/contexts'
 import { validateEmail, validatePassword } from '../utils'
@@ -30,7 +30,7 @@ export default function AuthScreen() {
   const router = useRouter()
   const { isDark } = useTheme()
   const { checkUserExists, login, signup, loading } = useUser()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
 
   // Read params for deep-link support (e.g. from AuthPromptModal, or
   // /auth/forgot's "Back to sign in" button).
@@ -65,20 +65,20 @@ export default function AuthScreen() {
       return
     }
     try {
-      posthog?.capture('auth_email_submitted')
+      track('auth_email_submitted', { source: 'auth' })
       const exists = await checkUserExists(username)
       if (exists) {
-        posthog?.capture('auth_user_exists')
+        track('auth_user_exists', { source: 'auth' })
         setAuthStep('login')
       } else {
-        posthog?.capture('auth_user_new')
+        track('auth_user_new', { source: 'auth' })
         setAuthStep('invite-code')
       }
     } catch (e: any) {
-      posthog?.capture('auth_check_failed')
+      track('auth_check_failed', { source: 'auth' })
       setErrors({ form: e.message || 'Failed to connect to server.' })
     }
-  }, [username, checkUserExists, posthog])
+  }, [username, checkUserExists, track])
 
   const handleLogin = useCallback(async () => {
     setErrors({})
@@ -94,14 +94,17 @@ export default function AuthScreen() {
     try {
       const result = await login(username, password)
       if (result.success) {
+        track('login_success', { source: 'auth' })
         router.replace('/(tabs)')
       } else {
+        track('login_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Username or password is incorrect.' })
       }
     } catch (e: any) {
+      track('login_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, login, router])
+  }, [username, password, login, router, track])
 
   const handleInviteCodeContinue = useCallback(async () => {
     setErrors({})
@@ -110,7 +113,7 @@ export default function AuthScreen() {
       return
     }
     try {
-      posthog?.capture('auth_invite_code_submitted')
+      track('auth_invite_code_submitted', { source: 'auth' })
       // Validate the invite code with the backend
       const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
         method: 'POST',
@@ -119,17 +122,17 @@ export default function AuthScreen() {
       })
       const data = await response.json()
       if (data.valid) {
-        posthog?.capture('auth_invite_code_valid')
+        track('auth_invite_code_valid', { source: 'auth' })
         setAuthStep('signup')
       } else {
-        posthog?.capture('auth_invite_code_invalid')
+        track('auth_invite_code_invalid', { source: 'auth' })
         setErrors({ form: data.error || 'Invalid or inactive invite code.' })
       }
     } catch (e: any) {
-      posthog?.capture('auth_invite_code_check_failed')
+      track('auth_invite_code_check_failed', { source: 'auth' })
       setErrors({ form: 'Failed to validate invite code. Please try again.' })
     }
-  }, [inviteCode, posthog])
+  }, [inviteCode, track])
 
   const handleSignup = useCallback(async () => {
     setErrors({})
@@ -152,14 +155,17 @@ export default function AuthScreen() {
     try {
       const result = await signup(username, password, inviteCode)
       if (result.success) {
+        track('signup_success', { source: 'auth' })
         router.replace(params.returnTo ? `/onboarding?returnTo=${encodeURIComponent(params.returnTo)}` : '/onboarding')
       } else {
+        track('signup_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
       }
     } catch (e: any) {
+      track('signup_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, confirmPassword, inviteCode, signup, router])
+  }, [username, password, confirmPassword, inviteCode, signup, router, track])
 
   const handleSubmit = useCallback(
     (e?: any) => {
@@ -182,12 +188,13 @@ export default function AuthScreen() {
   )
 
   const handleBack = useCallback(() => {
+    track('auth_back_pressed', { source: 'auth', from_step: authStep })
     setAuthStep('initial')
     setPassword('')
     setConfirmPassword('')
     setInviteCode('')
     setErrors({})
-  }, [])
+  }, [authStep, track])
 
   const isButtonDisabled =
     loading ||
@@ -262,7 +269,7 @@ export default function AuthScreen() {
             )}
 
             {/* Janata Wordmark */}
-            <Pressable onPress={() => router.push('/landing')}>
+            <Pressable onPress={() => { track('auth_logo_pressed', { source: 'auth' }); router.push('/landing') }}>
               <Logo size={32} style={{ marginBottom: 32 }} />
             </Pressable>
 
@@ -388,7 +395,7 @@ export default function AuthScreen() {
               {authStep === 'login' && (
                 <Pressable
                   className="items-center mt-2"
-                  onPress={() => router.push('/auth/forgot')}
+                  onPress={() => { track('auth_forgot_password_pressed', { source: 'auth' }); router.push('/auth/forgot') }}
                 >
                   <Text className="text-primary font-sans font-medium">Forgot password?</Text>
                 </Pressable>
@@ -400,14 +407,14 @@ export default function AuthScreen() {
               By continuing, you agree to our{' '}
               <Text
                 className="text-primary font-sans"
-                onPress={() => router.push('/terms')}
+                onPress={() => { track('terms_viewed', { source: 'auth' }); router.push('/terms') }}
               >
                 Terms of Service
               </Text>
               {' '}and{' '}
               <Text
                 className="text-primary font-sans"
-                onPress={() => router.push('/privacy')}
+                onPress={() => { track('privacy_policy_viewed', { source: 'auth' }); router.push('/privacy') }}
               >
                 Privacy Policy
               </Text>

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { useRouter } from 'expo-router'
 import { useUser } from '../components/contexts'
+import { useAnalytics } from '../utils/analytics'
 import { validateEmail, validatePassword } from '../utils'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
@@ -49,6 +50,7 @@ const AUTH_CAROUSEL_IMAGES = [
 export default function AuthScreen() {
   const router = useRouter()
   const { checkUserExists, login, signup, loading } = useUser()
+  const { track } = useAnalytics()
 
   // Read mode, returnTo, inviteCode, and email from URL params
   const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null
@@ -103,16 +105,20 @@ export default function AuthScreen() {
       return
     }
     try {
+      track('auth_email_submitted', { source: 'auth' })
       const exists = await checkUserExists(username)
       if (exists) {
+        track('auth_user_exists', { source: 'auth' })
         setAuthStep('login')
       } else {
+        track('auth_user_new', { source: 'auth' })
         setAuthStep('invite-code')
       }
     } catch (e: any) {
+      track('auth_check_failed', { source: 'auth' })
       setErrors({ form: e.message || 'Failed to connect to server.' })
     }
-  }, [username, checkUserExists])
+  }, [username, checkUserExists, track])
 
   const handleLogin = useCallback(async () => {
     setErrors({})
@@ -127,14 +133,17 @@ export default function AuthScreen() {
     try {
       const result = await login(username, password)
       if (result.success) {
+        track('login_success', { source: 'auth' })
         router.replace(returnTo || '/(tabs)')
       } else {
+        track('login_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Username or password is incorrect.' })
       }
     } catch (e: any) {
+      track('login_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, login, router])
+  }, [username, password, login, router, track])
 
   const handleSignup = useCallback(async () => {
     setErrors({})
@@ -157,14 +166,17 @@ export default function AuthScreen() {
     try {
       const result = await signup(username, password, inviteCode)
       if (result.success) {
+        track('signup_success', { source: 'auth' })
         router.replace(returnTo ? `/onboarding?returnTo=${encodeURIComponent(returnTo)}` : '/onboarding')
       } else {
+        track('signup_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
       }
     } catch (e: any) {
+      track('signup_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, confirmPassword, inviteCode, signup, router])
+  }, [username, password, confirmPassword, inviteCode, signup, router, track])
 
   const handleInviteCodeContinue = useCallback(async () => {
     setErrors({})
@@ -173,6 +185,7 @@ export default function AuthScreen() {
       return
     }
     try {
+      track('auth_invite_code_submitted', { source: 'auth' })
       // Validate the invite code with the backend
       const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
         method: 'POST',
@@ -181,14 +194,17 @@ export default function AuthScreen() {
       })
       const data = await response.json()
       if (data.valid) {
+        track('auth_invite_code_valid', { source: 'auth' })
         setAuthStep('signup')
       } else {
+        track('auth_invite_code_invalid', { source: 'auth' })
         setErrors({ form: data.error || 'Invalid or inactive invite code.' })
       }
     } catch (e: any) {
+      track('auth_invite_code_check_failed', { source: 'auth' })
       setErrors({ form: 'Failed to validate invite code. Please try again.' })
     }
-  }, [inviteCode])
+  }, [inviteCode, track])
 
   const handleSubmit = useCallback(
     (e?: any) => {
@@ -210,12 +226,13 @@ export default function AuthScreen() {
   )
 
   const handleBack = useCallback(() => {
+    track('auth_back_pressed', { source: 'auth', from_step: authStep })
     setAuthStep('initial')
     setPassword('')
     setConfirmPassword('')
     setInviteCode('')
     setErrors({})
-  }, [])
+  }, [authStep, track])
 
   const handleUsernameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setUsername(e.target.value)
@@ -349,7 +366,7 @@ export default function AuthScreen() {
           }}
         >
           <button
-            onClick={() => router.push('/landing')}
+            onClick={() => { track('auth_back_to_home_pressed', { source: 'auth' }); router.push('/landing') }}
             style={{
               background: 'none',
               border: 'none',
@@ -367,7 +384,7 @@ export default function AuthScreen() {
             &larr; Back to home
           </button>
           <button
-            onClick={() => router.push('/(tabs)')}
+            onClick={() => { track('auth_discover_pressed', { source: 'auth' }); router.push('/(tabs)') }}
             style={{
               background: 'none',
               border: 'none',
@@ -423,7 +440,7 @@ export default function AuthScreen() {
 
           {/* Janata logo */}
           <div
-            onClick={() => router.push('/landing')}
+            onClick={() => { track('auth_logo_pressed', { source: 'auth' }); router.push('/landing') }}
             role="link"
             style={{ marginBottom: isMobile ? 32 : 48, cursor: 'pointer' }}
           >
@@ -613,6 +630,7 @@ export default function AuthScreen() {
                     setErrors({ username: 'You must enter a valid email address.' })
                     return
                   }
+                  track('auth_create_account_pressed', { source: 'auth' })
                   try {
                     const exists = await checkUserExists(username)
                     if (exists) {
@@ -636,6 +654,7 @@ export default function AuthScreen() {
                       setErrors({ username: 'You must enter a valid email address.' })
                       return
                     }
+                    track('auth_create_account_pressed', { source: 'auth' })
                     try {
                       const exists = await checkUserExists(username)
                       if (exists) {
@@ -675,10 +694,11 @@ export default function AuthScreen() {
               <span
                 role="button"
                 tabIndex={0}
-                onClick={() => router.push('/auth/forgot')}
+                onClick={() => { track('auth_forgot_password_pressed', { source: 'auth' }); router.push('/auth/forgot') }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault()
+                    track('auth_forgot_password_pressed', { source: 'auth' })
                     router.push('/auth/forgot')
                   }
                 }}
@@ -744,8 +764,8 @@ export default function AuthScreen() {
             <span
               role="link"
               tabIndex={0}
-              onClick={() => router.push('/terms')}
-              onKeyDown={(e) => { if (e.key === 'Enter') router.push('/terms') }}
+              onClick={() => { track('terms_viewed', { source: 'auth' }); router.push('/terms') }}
+              onKeyDown={(e) => { if (e.key === 'Enter') { track('terms_viewed', { source: 'auth' }); router.push('/terms') } }}
               style={{ color: '#C2410C', cursor: 'pointer' }}
             >
               Terms of Service
@@ -754,8 +774,8 @@ export default function AuthScreen() {
             <span
               role="link"
               tabIndex={0}
-              onClick={() => router.push('/privacy')}
-              onKeyDown={(e) => { if (e.key === 'Enter') router.push('/privacy') }}
+              onClick={() => { track('privacy_policy_viewed', { source: 'auth' }); router.push('/privacy') }}
+              onKeyDown={(e) => { if (e.key === 'Enter') { track('privacy_policy_viewed', { source: 'auth' }); router.push('/privacy') } }}
               style={{ color: '#C2410C', cursor: 'pointer' }}
             >
               Privacy Policy

--- a/packages/frontend/app/auth/forgot.tsx
+++ b/packages/frontend/app/auth/forgot.tsx
@@ -15,12 +15,14 @@ import { useTheme } from '../../components/contexts'
 import { PasswordStrength } from '../../components'
 import { authClient } from '../../src/auth/authClient'
 import { validateEmail, validatePassword } from '../../utils'
+import { useAnalytics } from '../../utils/analytics'
 
 type Step = 'enter-email' | 'enter-code-and-password' | 'done'
 
 export default function ForgotPasswordScreen() {
   const router = useRouter()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const [step, setStep] = useState<Step>('enter-email')
   const [email, setEmail] = useState('')
@@ -34,6 +36,7 @@ export default function ForgotPasswordScreen() {
 
   const goBack = useCallback(() => {
     if (step === 'enter-code-and-password') {
+      track('forgot_password_back_pressed', { source: 'forgot_password', step })
       setStep('enter-email')
       setCode('')
       setPassword('')
@@ -42,8 +45,9 @@ export default function ForgotPasswordScreen() {
       setResendNotice(null)
       return
     }
+    track('forgot_password_back_pressed', { source: 'forgot_password', step })
     router.back()
-  }, [step, router])
+  }, [step, router, track])
 
   const submitEmail = useCallback(async () => {
     setErrors({})
@@ -62,13 +66,15 @@ export default function ForgotPasswordScreen() {
     setSubmitting(false)
 
     if (!result.success) {
+      track('forgot_password_email_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({ form: result.error.message || 'Could not send a reset code. Please try again.' })
       return
     }
     // Server always returns ok — advance regardless of whether the email
     // exists. Anti-enumeration design.
+    track('forgot_password_email_submitted', { source: 'forgot_password' })
     setStep('enter-code-and-password')
-  }, [email])
+  }, [email, track])
 
   const resend = useCallback(async () => {
     setResendNotice(null)
@@ -77,11 +83,13 @@ export default function ForgotPasswordScreen() {
     const result = await authClient.requestPasswordReset(email.trim())
     setResendBusy(false)
     if (!result.success) {
+      track('forgot_password_resend_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({ form: result.error.message || 'Could not resend the code. Please try again.' })
       return
     }
+    track('forgot_password_code_resent', { source: 'forgot_password' })
     setResendNotice('We sent a new code. Check your inbox.')
-  }, [email])
+  }, [email, track])
 
   const submitReset = useCallback(async () => {
     setErrors({})
@@ -109,15 +117,18 @@ export default function ForgotPasswordScreen() {
     setSubmitting(false)
 
     if (!result.success) {
+      track('forgot_password_reset_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({ form: result.error.message || 'Code invalid or expired.' })
       return
     }
+    track('forgot_password_code_submitted', { source: 'forgot_password' })
     setStep('done')
-  }, [code, password, confirmPassword, email])
+  }, [code, password, confirmPassword, email, track])
 
   const goToLogin = useCallback(() => {
+    track('forgot_password_signin_pressed', { source: 'forgot_password' })
     router.replace('/auth?mode=login')
-  }, [router])
+  }, [router, track])
 
   const errorMessages = Object.values(errors).filter(Boolean)
   const buttonDisabled =
@@ -155,7 +166,7 @@ export default function ForgotPasswordScreen() {
               </Text>
             </TouchableOpacity>
 
-            <Pressable onPress={() => router.push('/landing')}>
+            <Pressable onPress={() => { track('forgot_password_logo_pressed', { source: 'forgot_password' }); router.push('/landing') }}>
               <Logo size={32} style={{ marginBottom: 32 }} />
             </Pressable>
 

--- a/packages/frontend/app/auth/forgot.web.tsx
+++ b/packages/frontend/app/auth/forgot.web.tsx
@@ -4,6 +4,7 @@ import Logo from '../../components/ui/Logo'
 import PasswordStrength from '../../components/auth/PasswordStrength'
 import { authClient } from '../../src/auth/authClient'
 import { validateEmail, validatePassword } from '../../utils'
+import { useAnalytics } from '../../utils/analytics'
 
 // One-time CSS injection for placeholder + hover + iOS zoom prevention.
 if (typeof document !== 'undefined') {
@@ -51,6 +52,7 @@ const focusedInput: React.CSSProperties = {
 
 export default function ForgotPasswordScreen() {
   const router = useRouter()
+  const { track } = useAnalytics()
 
   const [step, setStep] = useState<Step>('enter-email')
   const [email, setEmail] = useState('')
@@ -80,6 +82,7 @@ export default function ForgotPasswordScreen() {
 
   const goBack = useCallback(() => {
     if (step === 'enter-code-and-password') {
+      track('forgot_password_back_pressed', { source: 'forgot_password', step })
       setStep('enter-email')
       setCode('')
       setPassword('')
@@ -88,8 +91,9 @@ export default function ForgotPasswordScreen() {
       setResendNotice(null)
       return
     }
+    track('forgot_password_back_pressed', { source: 'forgot_password', step })
     router.replace('/auth?mode=login')
-  }, [step, router])
+  }, [step, router, track])
 
   const submitEmail = useCallback(async () => {
     setErrors({})
@@ -106,13 +110,15 @@ export default function ForgotPasswordScreen() {
     const result = await authClient.requestPasswordReset(trimmed)
     setSubmitting(false)
     if (!result.success) {
+      track('forgot_password_email_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({
         form: result.error.message || 'Could not send a reset code. Please try again.',
       })
       return
     }
+    track('forgot_password_email_submitted', { source: 'forgot_password' })
     setStep('enter-code-and-password')
-  }, [email])
+  }, [email, track])
 
   const resend = useCallback(async () => {
     setResendNotice(null)
@@ -121,13 +127,15 @@ export default function ForgotPasswordScreen() {
     const result = await authClient.requestPasswordReset(email.trim())
     setResendBusy(false)
     if (!result.success) {
+      track('forgot_password_resend_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({
         form: result.error.message || 'Could not resend the code. Please try again.',
       })
       return
     }
+    track('forgot_password_code_resent', { source: 'forgot_password' })
     setResendNotice('We sent a new code. Check your inbox.')
-  }, [email])
+  }, [email, track])
 
   const submitReset = useCallback(async () => {
     setErrors({})
@@ -153,11 +161,13 @@ export default function ForgotPasswordScreen() {
     const result = await authClient.confirmPasswordReset(email.trim(), trimmedCode, password)
     setSubmitting(false)
     if (!result.success) {
+      track('forgot_password_reset_failed', { source: 'forgot_password', error: result.error.message })
       setErrors({ form: result.error.message || 'Code invalid or expired.' })
       return
     }
+    track('forgot_password_code_submitted', { source: 'forgot_password' })
     setStep('done')
-  }, [code, password, confirmPassword, email])
+  }, [code, password, confirmPassword, email, track])
 
   const onSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -235,7 +245,7 @@ export default function ForgotPasswordScreen() {
       >
         <div style={{ maxWidth: 400, width: '100%' }}>
           <div
-            onClick={() => router.push('/landing')}
+            onClick={() => { track('forgot_password_logo_pressed', { source: 'forgot_password' }); router.push('/landing') }}
             role="link"
             style={{ marginBottom: isMobile ? 32 : 48, cursor: 'pointer' }}
           >
@@ -316,7 +326,7 @@ export default function ForgotPasswordScreen() {
           {step === 'done' ? (
             <button
               className="auth-submit"
-              onClick={() => router.replace('/auth?mode=login')}
+              onClick={() => { track('forgot_password_signin_pressed', { source: 'forgot_password' }); router.replace('/auth?mode=login') }}
               style={{
                 width: '100%',
                 height: 48,

--- a/packages/frontend/app/center-picker.tsx
+++ b/packages/frontend/app/center-picker.tsx
@@ -6,11 +6,13 @@ import { useTheme } from '../components/contexts'
 import { Text, StackHeader } from '../components/ui'
 import { fetchCenters, CenterData } from '../utils/api'
 import { centerPickerStore } from '../utils/centerPickerStore'
+import { useAnalytics } from '../utils/analytics'
 
 export default function CenterPickerScreen() {
   const router = useRouter()
   const { currentCenterID } = useLocalSearchParams<{ currentCenterID?: string }>()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const [allCenters, setAllCenters] = useState<CenterData[]>([])
   const [search, setSearch] = useState('')
@@ -43,7 +45,12 @@ export default function CenterPickerScreen() {
       }}>
         <TextInput
           value={search}
-          onChangeText={setSearch}
+          onChangeText={(text) => {
+            setSearch(text)
+            if (text.length > 0) {
+              track('center_picker_searched', { query: text, source: 'center_picker' })
+            }
+          }}
           placeholder="Search centers..."
           placeholderTextColor={faintColor}
           autoFocus
@@ -66,6 +73,13 @@ export default function CenterPickerScreen() {
         renderItem={({ item }) => (
           <Pressable
             onPress={() => {
+              track('center_picker_selected', {
+                center_id: item.centerID,
+                center_name: item.name,
+                was_current: currentCenterID === item.centerID,
+                search_query: search || null,
+                source: 'center_picker',
+              })
               centerPickerStore.result = item.centerID
               router.back()
             }}

--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -14,7 +14,7 @@ import {
   Users,
   Lock,
 } from 'lucide-react-native'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useBoard, useCenterDetail } from '../../hooks/useApiData'
 import { DetailSection } from '../../components/ui'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
@@ -164,7 +164,7 @@ export default function CenterDetailPage() {
   const { id: rawId } = useLocalSearchParams()
   const id = Array.isArray(rawId) ? rawId[0] : rawId
   const router = useRouter()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const { user } = useUser()
   const { center, events, loading } = useCenterDetail(id as string)
   const colors = useDetailColors()
@@ -177,23 +177,25 @@ export default function CenterDetailPage() {
 
   useEffect(() => {
     if (!loading && center) {
-      posthog?.capture('center_viewed', { centerId: id, name: center.name })
+      track('center_viewed', { centerId: id, name: center.name })
     }
-  }, [loading, center, id, posthog])
+  }, [loading, center, id])
 
   const handleEventPress = (event: EventDisplay) => {
-    posthog?.capture('center_event_pressed', { centerId: id, eventId: event.id })
+    track('center_event_pressed', { centerId: id, eventId: event.id, source: 'center_detail' })
     router.push(`/events/${event.id}`)
   }
 
   const handleCreateThreadPost = async (body: string) => {
     if (!center?.id) return
     await createBoardPost('center', center.id, body)
+    track('center_board_post_created', { centerId: center.id, source: 'center_detail' })
     await refetchBoard()
   }
 
   const openThreadPost = (message: BoardMessage) => {
     if (!center?.id) return
+    track('center_board_post_opened', { centerId: center.id, postId: message.id, source: 'center_detail' })
     setThreadDetailPost(
       buildFeedPostFromMessage(message, {
         groupId: `center-${center.id}`,
@@ -208,7 +210,7 @@ export default function CenterDetailPage() {
   const closeThreadPost = () => setThreadDetailPost(null)
 
   const handleShare = async () => {
-    posthog?.capture('center_shared', { centerId: id })
+    track('center_shared', { centerId: id, source: 'center_detail' })
     try {
       const url = id ? `https://chinmayajanata.org/center/${id}` : 'https://chinmayajanata.org'
       await Share.share({
@@ -224,20 +226,20 @@ export default function CenterDetailPage() {
 
   const handleAddressPress = () => {
     if (!center?.address) return
-    posthog?.capture('center_address_pressed', { centerId: id })
+    track('center_address_pressed', { centerId: id, source: 'center_detail' })
     Linking.openURL(`https://maps.google.com/?q=${encodeURIComponent(center.address)}`)
   }
 
   const handleWebsitePress = () => {
     if (!center?.website) return
-    posthog?.capture('center_website_pressed', { centerId: id })
+    track('center_website_pressed', { centerId: id, source: 'center_detail' })
     const url = center.website.startsWith('http') ? center.website : `https://${center.website}`
     Linking.openURL(url)
   }
 
   const handlePhonePress = () => {
     if (!center?.phone) return
-    posthog?.capture('center_phone_pressed', { centerId: id })
+    track('center_phone_pressed', { centerId: id, source: 'center_detail' })
     Linking.openURL(`tel:${center.phone}`)
   }
 
@@ -256,7 +258,7 @@ export default function CenterDetailPage() {
           <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, marginBottom: 16 }}>
             Center not found
           </Text>
-          <Pressable onPress={() => router.back()} style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}>
+          <Pressable onPress={() => { track('center_not_found_back_pressed', { centerId: id, source: 'center_detail' }); router.back() }} style={{ marginTop: 8, minHeight: 44, justifyContent: 'center' }}>
             <Text style={{ fontSize: 16, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>Go Back</Text>
           </Pressable>
         </View>
@@ -271,7 +273,7 @@ export default function CenterDetailPage() {
       <SafeAreaView style={{ flex: 1, backgroundColor: appColors.bg }} edges={['top']}>
         <View style={{ paddingTop: 6 }}>
           <Pressable
-            onPress={closeThreadPost}
+            onPress={() => { track('center_board_thread_closed', { centerId: center?.id, source: 'center_detail' }); closeThreadPost() }}
             accessibilityRole="button"
             accessibilityLabel="Back to board"
             style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 12 }}
@@ -306,7 +308,7 @@ export default function CenterDetailPage() {
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }} edges={['top']}>
       <HeaderBar
         title={center.name}
-        onBack={() => router.back()}
+        onBack={() => { track('center_back_pressed', { centerId: id, source: 'center_detail' }); router.back() }}
         onShare={handleShare}
         colors={colors}
         memberCount={center.memberCount}

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -13,7 +13,7 @@ import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { useUser } from '../../components/contexts'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildCenterJsonLd } from '../../components/seo/jsonLd'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 
 export default function CenterDetailWeb() {
   const { id: rawId } = useLocalSearchParams()
@@ -77,7 +77,7 @@ function LockedBoard({ colors }: { colors: DetailColors }) {
 function MobileCenterDetail({ centerId }: { centerId: string }) {
   const router = useRouter()
   const { user } = useUser()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const { center, events, loading } = useCenterDetail(centerId)
   const colors = useDetailColors()
   const appColors = useColors()
@@ -87,13 +87,13 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   // event so web traffic isn't missing from PostHog. (#analytics)
   useEffect(() => {
     if (!loading && center?.id) {
-      posthog?.capture('center_viewed', {
+      track('center_viewed', {
         centerId: center.id,
         name: center.name,
         source: 'web_detail',
       })
     }
-  }, [loading, center?.id, center?.name, posthog])
+  }, [loading, center?.id, center?.name])
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
@@ -102,11 +102,13 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   const handleCreateThreadPost = async (body: string) => {
     if (!center?.id) return
     await createBoardPost('center', center.id, body)
+    track('center_board_post_created', { centerId: center.id, source: 'web_detail' })
     await refetchBoard()
   }
 
   const openThreadPost = (message: BoardMessage) => {
     if (!center?.id) return
+    track('center_board_post_opened', { centerId: center.id, postId: message.id, source: 'web_detail' })
     setThreadDetailPost(
       buildFeedPostFromMessage(message, {
         groupId: `center-${center.id}`,
@@ -121,7 +123,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   const closeThreadPost = () => setThreadDetailPost(null)
 
   const handleShare = () => {
-    posthog?.capture('center_shared', { centerId: center?.id ?? '', source: 'web_detail' })
+    track('center_shared', { centerId: center?.id ?? '', source: 'web_detail' })
     if (typeof navigator !== 'undefined' && navigator.share) {
       navigator.share({ title: center?.name || 'Center', text: `Check out ${center?.name} on Chinmaya Janata!` }).catch(() => {})
     } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -131,25 +133,25 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
 
   const handleAddressPress = () => {
     if (!center?.address) return
-    posthog?.capture('center_address_pressed', { centerId: center.id, source: 'web_detail' })
+    track('center_address_pressed', { centerId: center.id, source: 'web_detail' })
     Linking.openURL(`https://maps.google.com/?q=${encodeURIComponent(center.address)}`)
   }
 
   const handleWebsitePress = () => {
     if (!center?.website) return
-    posthog?.capture('center_website_pressed', { centerId: center.id, source: 'web_detail' })
+    track('center_website_pressed', { centerId: center.id, source: 'web_detail' })
     const url = center.website.startsWith('http') ? center.website : `https://${center.website}`
     Linking.openURL(url)
   }
 
   const handlePhonePress = () => {
     if (!center?.phone) return
-    posthog?.capture('center_phone_pressed', { centerId: center.id, source: 'web_detail' })
+    track('center_phone_pressed', { centerId: center.id, source: 'web_detail' })
     Linking.openURL(`tel:${center.phone}`)
   }
 
   const handleEventPress = (event: EventDisplay) => {
-    posthog?.capture('center_event_pressed', { centerId: center?.id ?? '', eventId: event.id, source: 'web_detail' })
+    track('center_event_pressed', { centerId: center?.id ?? '', eventId: event.id, source: 'web_detail' })
     router.push(`/events/${event.id}`)
   }
 
@@ -165,7 +167,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.panelBg }}>
         <Text style={{ color: colors.textSecondary, fontSize: 16 }}>Center not found</Text>
-        <Pressable onPress={() => router.back()} style={{ marginTop: 16 }}>
+        <Pressable onPress={() => { track('center_not_found_back_pressed', { centerId, source: 'web_detail' }); router.back() }} style={{ marginTop: 16 }}>
           <Text style={{ color: '#E8862A', fontSize: 16 }}>Go back</Text>
         </Pressable>
       </View>
@@ -178,7 +180,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
       <View style={{ flex: 1, backgroundColor: appColors.bg }}>
         <View style={{ paddingTop: 12 }}>
           <Pressable
-            onPress={closeThreadPost}
+            onPress={() => { track('center_board_thread_closed', { centerId: center?.id, source: 'web_detail' }); closeThreadPost() }}
             accessibilityRole="button"
             accessibilityLabel="Back to board"
             style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
@@ -223,7 +225,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
       <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 12, gap: 12 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
           <Pressable
-            onPress={() => router.back()}
+            onPress={() => { track('center_back_pressed', { centerId: center?.id, source: 'web_detail' }); router.back() }}
             accessibilityRole="button"
             accessibilityLabel="Back"
             style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}

--- a/packages/frontend/app/chat/[id].tsx
+++ b/packages/frontend/app/chat/[id].tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react-native'
 import { useTheme } from '../../components/contexts'
 import { Avatar } from '../../components/ui'
 import { groupChats, inboxThreads, type PersonSummary } from '../../components/boards'
+import { useAnalytics } from '../../utils/analytics'
 
 type GroupKind = 'center' | 'event'
 
@@ -79,6 +80,7 @@ export default function ChatConversationDetail() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const colors = useMemo(
     () => ({
@@ -108,7 +110,10 @@ export default function ChatConversationDetail() {
             Conversation not found
           </Text>
           <Pressable
-            onPress={() => router.back()}
+            onPress={() => {
+              track('chat_not_found_back_pressed', { conversation_id: id, source: 'chat_detail' })
+              router.back()
+            }}
             style={{ marginTop: 16, paddingVertical: 10, paddingHorizontal: 20, borderRadius: 12, backgroundColor: colors.orange }}
           >
             <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#FFFFFF' }}>Go back</Text>
@@ -132,7 +137,10 @@ export default function ChatConversationDetail() {
         }}
       >
         <Pressable
-          onPress={() => router.back()}
+          onPress={() => {
+            track('chat_back_pressed', { conversation_id: id, conversation_type: conversation.type, source: 'chat_detail' })
+            router.back()
+          }}
           accessibilityRole="button"
           accessibilityLabel="Back"
           hitSlop={10}

--- a/packages/frontend/app/edit-profile.tsx
+++ b/packages/frontend/app/edit-profile.tsx
@@ -23,6 +23,7 @@ try {
 } catch {}
 import { Camera, ChevronRight } from 'lucide-react-native'
 import { useUser, useTheme } from '../components/contexts'
+import { useAnalytics } from '../utils/analytics'
 import { Text, Section, StackHeader } from '../components/ui'
 import BirthdatePicker from '../components/profile/BirthdatePicker'
 import { fetchCenters, CenterData } from '../utils/api'
@@ -50,6 +51,7 @@ export default function EditProfileScreen() {
   const router = useRouter()
   const { user, updateProfile, setUser } = useUser()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
@@ -127,6 +129,8 @@ export default function EditProfileScreen() {
 
     if (result.canceled || !result.assets.length) return
 
+    track('profile_photo_changed', { source: 'edit_profile' })
+
     const uri = result.assets[0].uri
 
     if (ImageManipulator) {
@@ -171,30 +175,37 @@ export default function EditProfileScreen() {
 
       if (!result.success) {
         setErrors({ form: result.message || 'Failed to save profile' })
+        track('profile_update_failed', { source: 'edit_profile', reason: result.message || 'api_error' })
         return
       }
 
+      track('profile_updated', { source: 'edit_profile', image_changed: imageChanged })
       if (user && imageChanged && profileImage) {
         setUser({ ...user, originalImage: profileImage })
       }
       router.back()
     } catch {
       setErrors({ form: 'Failed to save profile. Please try again.' })
+      track('profile_update_failed', { source: 'edit_profile', reason: 'exception' })
     } finally {
       setIsSaving(false)
     }
   }
 
   const toggleLookingFor = (option: string) => {
-    setLookingFor((prev) =>
-      prev.includes(option) ? prev.filter((i) => i !== option) : [...prev, option]
-    )
+    setLookingFor((prev) => {
+      const selected = prev.includes(option)
+      track('profile_looking_for_toggled', { option, selected: !selected, source: 'edit_profile' })
+      return selected ? prev.filter((i) => i !== option) : [...prev, option]
+    })
   }
 
   const toggleInterest = (interest: string) => {
-    setInterests((prev) =>
-      prev.includes(interest) ? prev.filter((i) => i !== interest) : [...prev, interest]
-    )
+    setInterests((prev) => {
+      const selected = prev.includes(interest)
+      track('profile_interest_toggled', { interest, selected: !selected, source: 'edit_profile' })
+      return selected ? prev.filter((i) => i !== interest) : [...prev, interest]
+    })
   }
 
   const getInitials = () => {
@@ -350,7 +361,10 @@ export default function EditProfileScreen() {
               </View>
               <Pressable
                 style={rowStyle}
-                onPress={() => router.push({ pathname: '/center-picker', params: { currentCenterID: centerID || '' } })}
+                onPress={() => {
+                  track('profile_center_picker_opened', { source: 'edit_profile', current_center_id: centerID || null })
+                  router.push({ pathname: '/center-picker', params: { currentCenterID: centerID || '' } })
+                }}
               >
                 <Text style={fieldLabelStyle}>CENTER</Text>
                 <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingTop: 6 }}>

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -15,7 +15,7 @@ import {
   Pencil,
   Trash2,
 } from 'lucide-react-native'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useBoard, useEventDetail } from '../../hooks/useApiData'
 import { useUser } from '../../components/contexts'
 import { Badge, Avatar, PrimaryButton, DestructiveButton, DetailSection } from '../../components/ui'
@@ -166,6 +166,7 @@ function HeaderBar({
   onBack,
   onEdit,
   onDelete,
+  onShare,
   colors,
 }: {
   title: string
@@ -176,6 +177,7 @@ function HeaderBar({
   onBack: () => void
   onEdit?: () => void
   onDelete?: () => void
+  onShare?: () => void
   colors: DetailColors
 }) {
   const router = useRouter()
@@ -235,6 +237,7 @@ function HeaderBar({
           {!isPast && (
             <Pressable
               onPress={() => {
+                onShare?.()
                 const url = eventId ? `https://chinmayajanata.org/events/${eventId}` : 'https://chinmayajanata.org'
                 Share.share({
                   message: `Check out ${title} on Chinmaya Janata! ${url}`,
@@ -441,6 +444,7 @@ function ActionBar({
   isToggling,
   signupUrl,
   allowJanataSignup,
+  onExternalSignup,
   colors,
 }: {
   isRegistered?: boolean
@@ -449,6 +453,7 @@ function ActionBar({
   isToggling: boolean
   signupUrl?: string | null
   allowJanataSignup?: boolean
+  onExternalSignup?: () => void
   colors: DetailColors
 }) {
   if (isPast) return null
@@ -475,7 +480,10 @@ function ActionBar({
           </PrimaryButton>
         )}
         <Pressable
-          onPress={() => Linking.openURL(signupUrl)}
+          onPress={() => {
+            onExternalSignup?.()
+            Linking.openURL(signupUrl)
+          }}
           style={{ paddingVertical: 12, alignItems: 'center', justifyContent: 'center' }}
           accessibilityLabel={`Sign up at ${hostnameOf(signupUrl)}`}
         >
@@ -490,7 +498,7 @@ function ActionBar({
   if (signupUrl) {
     return (
       <View style={wrapperStyle}>
-        <PrimaryButton onPress={() => Linking.openURL(signupUrl)}>
+        <PrimaryButton onPress={() => { onExternalSignup?.(); Linking.openURL(signupUrl) }}>
           Sign up at {hostnameOf(signupUrl)}
         </PrimaryButton>
         <Text
@@ -569,7 +577,7 @@ export default function EventDetailPage() {
   const { id: rawId } = useLocalSearchParams()
   const id = Array.isArray(rawId) ? rawId[0] : rawId
   const router = useRouter()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const userContext = useUser()
   const { user, authStatus } = userContext
   const username = authStatus === 'authenticated' ? user?.username : undefined
@@ -592,12 +600,12 @@ export default function EventDetailPage() {
   useEffect(() => {
     if (!loading && event && !hasTrackedView.current) {
       hasTrackedView.current = true
-      posthog?.capture('event_viewed', { eventId: id, title: event.title, isPast })
+      track('event_viewed', { eventId: id, title: event.title, isPast })
     }
-  }, [loading, event, id, isPast, posthog])
+  }, [loading, event, id, isPast])
 
   const handleEditPress = () => {
-    posthog?.capture('event_edit_opened', { eventId: id })
+    track('event_edit_opened', { eventId: id, source: 'event_detail' })
   }
 
   const handleDeletePress = () => {
@@ -612,7 +620,7 @@ export default function EventDetailPage() {
           style: 'destructive',
           onPress: async () => {
             try {
-              posthog?.capture('event_deleted', { eventId: id })
+              track('event_deleted', { eventId: id, source: 'event_detail' })
               await removeEvent(id as string)
               router.replace('/')
             } catch (err: any) {
@@ -627,11 +635,11 @@ export default function EventDetailPage() {
   const handleToggleRegistration = async () => {
     if (!user?.username) return
     try {
-      posthog?.capture(event?.isRegistered ? 'event_unregistered' : 'event_registered', { eventId: id })
+      track(event?.isRegistered ? 'event_unregistered' : 'event_registered', { eventId: id, source: 'event_detail' })
       await toggleRegistration(user.username)
     } catch (err: any) {
       const message = err?.message || ''
-      posthog?.capture('event_registration_failed', { eventId: id, error: message })
+      track('event_registration_failed', { eventId: id, error: message, source: 'event_detail' })
       if (message.includes('Already registered')) {
         Alert.alert('Already Registered', 'You are already registered for this event.')
       } else if (message.includes('Not registered')) {
@@ -645,12 +653,13 @@ export default function EventDetailPage() {
   const handleCreateThreadPost = async (body: string) => {
     if (!event?.id) return
     await createBoardPost('event', event.id, body)
+    track('event_board_post_created', { eventId: id, source: 'event_detail' })
     await refetchBoard()
   }
 
   const openThreadPost = (message: BoardMessage) => {
     if (!event?.id) return
-    posthog?.capture('event_board_post_opened', { eventId: id, postId: message.id })
+    track('event_board_post_opened', { eventId: id, postId: message.id, source: 'event_detail' })
     setThreadDetailPost(
       buildFeedPostFromMessage(message, {
         groupId: `event-${event.id}`,
@@ -662,7 +671,10 @@ export default function EventDetailPage() {
     )
   }
 
-  const closeThreadPost = () => setThreadDetailPost(null)
+  const closeThreadPost = () => {
+    track('event_board_thread_closed', { eventId: id, source: 'event_detail' })
+    setThreadDetailPost(null)
+  }
 
   // ── Loading state ────────────────────────────────────────────────────
 
@@ -745,6 +757,7 @@ export default function EventDetailPage() {
         onBack={() => router.back()}
         onEdit={handleEditPress}
         onDelete={canEdit ? handleDeletePress : undefined}
+        onShare={() => track('event_shared', { eventId: id, source: 'event_detail' })}
         colors={colors}
       />
 
@@ -825,6 +838,7 @@ export default function EventDetailPage() {
         isToggling={isToggling}
         signupUrl={event.signupUrl}
         allowJanataSignup={event.allowJanataSignup}
+        onExternalSignup={() => track('event_external_signup_pressed', { eventId: id, signupUrl: event.signupUrl, source: 'event_detail' })}
         colors={colors}
       />
     </SafeAreaView>

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, useRef } from 'react'
 import { View, Text, ScrollView, Pressable, ActivityIndicator, useWindowDimensions, Linking } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, Share2, MapPin, Users, User, Clock, Lock, Pencil, Trash2 } from 'lucide-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useBoard, useEventDetail } from '../../hooks/useApiData'
 import { createBoardPost, removeEvent } from '../../utils/api'
@@ -75,6 +76,7 @@ function LockedComments({ colors }: { colors: DetailColors }) {
 
 function MobileEventDetail({ eventId }: { eventId: string }) {
   const router = useRouter()
+  const { track } = useAnalytics()
   const { user } = useUser()
   const { event, loading, toggleRegistration, isToggling, attendees, isCreator } = useEventDetail(eventId, user?.username, user?.id)
   const colors = useDetailColors()
@@ -82,6 +84,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const [showAuthPrompt, setShowAuthPrompt] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
+  const hasTrackedView = useRef(false)
 
   const isPast = event?.date ? new Date(event.date + 'T23:59:59') < new Date() : false
   const canEdit = !!user && (isSuperAdmin(user) || isCreator)
@@ -90,14 +93,24 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('event', event?.id, canAccessEventBoard)
   const eventBoardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
+  useEffect(() => {
+    if (!loading && event && !hasTrackedView.current) {
+      hasTrackedView.current = true
+      const isPast = event.date ? new Date(event.date + 'T23:59:59') < new Date() : false
+      track('event_viewed', { eventId, title: event.title, isPast, source: 'event_detail' })
+    }
+  }, [loading, event, eventId])
+
   const handleCreateThreadPost = async (body: string) => {
     if (!event?.id) return
     await createBoardPost('event', event.id, body)
+    track('event_board_post_created', { eventId, source: 'event_detail' })
     await refetchBoard()
   }
 
   const openThreadPost = (message: BoardMessage) => {
     if (!event?.id) return
+    track('event_board_post_opened', { eventId, postId: message.id, source: 'event_detail' })
     setThreadDetailPost(
       buildFeedPostFromMessage(message, {
         groupId: `event-${event.id}`,
@@ -109,7 +122,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
     )
   }
 
-  const closeThreadPost = () => setThreadDetailPost(null)
+  const closeThreadPost = () => {
+    track('event_board_thread_closed', { eventId, source: 'event_detail' })
+    setThreadDetailPost(null)
+  }
 
   const handleDelete = async () => {
     if (!event) return
@@ -117,6 +133,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
     if (!ok) return
     try {
       setIsDeleting(true)
+      track('event_deleted', { eventId, source: 'event_detail' })
       await removeEvent(event.id)
       router.replace('/')
     } catch (err: any) {
@@ -206,7 +223,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         </Pressable>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
           {canEdit && !isPast && (
-            <Pressable onPress={() => router.push(`/events/form?id=${event.id}`)} style={{ padding: 8 }} accessibilityLabel="Edit event">
+            <Pressable onPress={() => { track('event_edit_opened', { eventId, source: 'event_detail' }); router.push(`/events/form?id=${event.id}`) }} style={{ padding: 8 }} accessibilityLabel="Edit event">
               <Pencil size={18} color={colors.textSecondary} />
             </Pressable>
           )}
@@ -217,6 +234,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
           )}
           <Pressable
             onPress={() => {
+              track('event_shared', { eventId, source: 'event_detail' })
               if (typeof navigator !== 'undefined' && navigator.share) {
                 navigator.share({ title: event.title, text: `Check out ${event.title} on Chinmaya Janata!` }).catch(() => {})
               } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
@@ -321,14 +339,28 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
           {event.signupUrl && event.allowJanataSignup ? (
             <>
               {event.isRegistered ? (
-                <DestructiveButton onPress={() => user?.username && toggleRegistration(user.username)} disabled={isToggling} loading={isToggling}>
+                <DestructiveButton
+                  onPress={() => {
+                    if (user?.username) {
+                      track('event_unregistered', { eventId, source: 'event_detail' })
+                      toggleRegistration(user.username)
+                    }
+                  }}
+                  disabled={isToggling}
+                  loading={isToggling}
+                >
                   Cancel Registration
                 </DestructiveButton>
               ) : (
                 <PrimaryButton
                   onPress={() => {
-                    if (!user) setShowAuthPrompt(true)
-                    else if (user.username) toggleRegistration(user.username)
+                    if (!user) {
+                      track('event_auth_prompt_shown', { eventId, source: 'event_detail' })
+                      setShowAuthPrompt(true)
+                    } else if (user.username) {
+                      track('event_registered', { eventId, source: 'event_detail' })
+                      toggleRegistration(user.username)
+                    }
                   }}
                   disabled={isToggling}
                   loading={isToggling}
@@ -337,7 +369,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
                 </PrimaryButton>
               )}
               <Pressable
-                onPress={() => Linking.openURL(event.signupUrl!)}
+                onPress={() => {
+                  track('event_external_signup_pressed', { eventId, signupUrl: event.signupUrl, source: 'event_detail' })
+                  Linking.openURL(event.signupUrl!)
+                }}
                 style={{ paddingVertical: 12, alignItems: 'center' }}
                 accessibilityLabel={`Sign up at ${hostnameOf(event.signupUrl)}`}
               >
@@ -348,7 +383,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
             </>
           ) : event.signupUrl ? (
             <>
-              <PrimaryButton onPress={() => Linking.openURL(event.signupUrl!)}>
+              <PrimaryButton onPress={() => {
+                track('event_external_signup_pressed', { eventId, signupUrl: event.signupUrl, source: 'event_detail' })
+                Linking.openURL(event.signupUrl!)
+              }}>
                 Sign up at {hostnameOf(event.signupUrl)}
               </PrimaryButton>
               <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textSecondary, textAlign: 'center', marginTop: 4 }}>
@@ -356,14 +394,28 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
               </Text>
             </>
           ) : event.isRegistered ? (
-            <DestructiveButton onPress={() => user?.username && toggleRegistration(user.username)} disabled={isToggling} loading={isToggling}>
+            <DestructiveButton
+              onPress={() => {
+                if (user?.username) {
+                  track('event_unregistered', { eventId, source: 'event_detail' })
+                  toggleRegistration(user.username)
+                }
+              }}
+              disabled={isToggling}
+              loading={isToggling}
+            >
               Cancel Registration
             </DestructiveButton>
           ) : (
             <PrimaryButton
               onPress={() => {
-                if (!user) setShowAuthPrompt(true)
-                else if (user.username) toggleRegistration(user.username)
+                if (!user) {
+                  track('event_auth_prompt_shown', { eventId, source: 'event_detail' })
+                  setShowAuthPrompt(true)
+                } else if (user.username) {
+                  track('event_registered', { eventId, source: 'event_detail' })
+                  toggleRegistration(user.username)
+                }
               }}
               disabled={isToggling}
               loading={isToggling}

--- a/packages/frontend/app/events/form.tsx
+++ b/packages/frontend/app/events/form.tsx
@@ -13,7 +13,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, ChevronDown } from 'lucide-react-native'
 import DateTimePicker from '@react-native-community/datetimepicker'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { PrimaryButton } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import {
@@ -162,7 +162,7 @@ export default function EventFormPage() {
   const isEdit = !!eventId
   const router = useRouter()
   const colors = useDetailColors()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const today = todayLocalISODate()
 
   const [loading, setLoading] = useState(isEdit)
@@ -309,16 +309,16 @@ export default function EventFormPage() {
       let savedId = eventId
       if (isEdit && eventId) {
         await updateEvent({ id: eventId, ...sharedFields })
-        posthog?.capture('event_updated', { eventId, title: title.trim() })
+        track('event_updated', { eventId, title: title.trim(), source: 'event_form' })
       } else {
         const created = await createEvent(sharedFields)
         savedId = created.id
-        posthog?.capture('event_created', { title: title.trim(), centerID })
+        track('event_created', { title: title.trim(), centerID, source: 'event_form' })
       }
       if (savedId) router.replace(`/events/${savedId}`)
     } catch (err: any) {
       const msg = err?.message || 'Something went wrong. Please try again.'
-      posthog?.capture('event_create_failed', { error: msg, isEdit })
+      track('event_create_failed', { error: msg, isEdit, source: 'event_form' })
       setErrors({ submit: msg })
     } finally {
       setSaving(false)
@@ -332,6 +332,7 @@ export default function EventFormPage() {
     if (!longitude && center.longitude) setLongitude(String(center.longitude))
     if (!address && center.address) setAddress(center.address)
     setShowCenterPicker(false)
+    track('event_form_center_selected', { centerID: center.centerID, centerName: center.name, source: 'event_form' })
   }
 
   // ── Input styling helper ────────────────────────────────────────────
@@ -373,7 +374,10 @@ export default function EventFormPage() {
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.panelBg }}>
       <HeaderBar
         title={isEdit ? 'Edit Event' : 'Create Event'}
-        onBack={() => router.back()}
+        onBack={() => {
+          track('event_form_back_pressed', { isEdit, source: 'event_form' })
+          router.back()
+        }}
         colors={colors}
       />
 
@@ -429,7 +433,7 @@ export default function EventFormPage() {
         {/* Date */}
         <FieldRow label="Date" colors={colors} error={errors.date} required>
           <Pressable
-            onPress={() => setShowDatePicker(true)}
+            onPress={() => { setShowDatePicker(true); track('event_form_date_picker_opened', { source: 'event_form' }) }}
             style={pickerFieldStyle(!!errors.date)}
             accessibilityLabel="Pick a date"
           >
@@ -478,7 +482,7 @@ export default function EventFormPage() {
         {/* Time */}
         <FieldRow label="Time" colors={colors} error={errors.time}>
           <Pressable
-            onPress={() => setShowTimePicker(true)}
+            onPress={() => { setShowTimePicker(true); track('event_form_time_picker_opened', { source: 'event_form' }) }}
             style={pickerFieldStyle(!!errors.time)}
             accessibilityLabel="Pick a time"
           >
@@ -525,7 +529,7 @@ export default function EventFormPage() {
         {/* Center selection */}
         <FieldRow label="Center" colors={colors} error={errors.center} required hint="Picking a center auto-fills address & coordinates.">
           <Pressable
-            onPress={() => setShowCenterPicker(!showCenterPicker)}
+            onPress={() => { const next = !showCenterPicker; setShowCenterPicker(next); if (next) track('event_form_center_picker_opened', { source: 'event_form' }) }}
             style={pickerFieldStyle(!!errors.center)}
           >
             <Text
@@ -701,7 +705,7 @@ export default function EventFormPage() {
               </View>
               <Switch
                 value={allowJanataSignup}
-                onValueChange={setAllowJanataSignup}
+                onValueChange={(v) => { setAllowJanataSignup(v); track('event_form_janata_signup_toggled', { enabled: v, source: 'event_form' }) }}
                 trackColor={{ true: '#E8862A', false: colors.border }}
                 thumbColor="#FFFFFF"
                 ios_backgroundColor={colors.border}
@@ -713,7 +717,7 @@ export default function EventFormPage() {
         {/* Advanced: coordinates (auto-filled from center) */}
         <View style={{ gap: 10 }}>
           <Pressable
-            onPress={() => setShowAdvanced((v) => !v)}
+            onPress={() => setShowAdvanced((v) => { const next = !v; track('event_form_advanced_toggled', { expanded: next, source: 'event_form' }); return next })}
             style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
             accessibilityLabel="Toggle advanced location options"
           >
@@ -776,7 +780,7 @@ export default function EventFormPage() {
               return (
                 <Pressable
                   key={opt.label}
-                  onPress={() => setCategory(opt.value)}
+                  onPress={() => { setCategory(opt.value); track('event_form_category_selected', { category: opt.label, value: opt.value ?? null, source: 'event_form' }) }}
                   style={{
                     paddingHorizontal: 16,
                     paddingVertical: 10,

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, ChevronDown } from 'lucide-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import { useTheme } from '../../components/contexts'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { PrimaryButton, SecondaryButton } from '../../components/ui'
@@ -131,6 +132,7 @@ export default function EventFormPage() {
   const isEdit = !!eventId
   const router = useRouter()
   const colors = useDetailColors()
+  const { track } = useAnalytics()
   const { isDark } = useTheme()
   const today = todayLocalISODate()
   const { width: viewportWidth } = useWindowDimensions()
@@ -278,13 +280,17 @@ export default function EventFormPage() {
       }
       if (isEdit && eventId) {
         await updateEvent({ id: eventId, ...sharedFields })
+        track('event_updated', { eventId, title: title.trim(), source: 'event_form' })
         router.replace(`/events/${eventId}`)
       } else {
         const created = await createEvent(sharedFields)
+        track('event_created', { title: title.trim(), centerID, source: 'event_form' })
         router.replace(`/events/${created.id}`)
       }
     } catch (err: any) {
-      setErrors({ submit: err?.message || 'Something went wrong. Please try again.' })
+      const msg = err?.message || 'Something went wrong. Please try again.'
+      track('event_create_failed', { error: msg, isEdit, source: 'event_form' })
+      setErrors({ submit: msg })
     } finally {
       setSaving(false)
     }
@@ -297,6 +303,7 @@ export default function EventFormPage() {
     if (!longitude && center.longitude) setLongitude(String(center.longitude))
     if (!address && center.address) setAddress(center.address)
     setShowCenterPicker(false)
+    track('event_form_center_selected', { centerID: center.centerID, centerName: center.name, source: 'event_form' })
   }
 
   const inputStyle = (hasError?: boolean) => ({
@@ -343,7 +350,7 @@ export default function EventFormPage() {
       >
         <View style={{ gap: 4 }}>
           <Pressable
-            onPress={() => router.back()}
+            onPress={() => { track('event_form_back_pressed', { isEdit, source: 'event_form' }); router.back() }}
             style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 8 }}
           >
             <ChevronLeft size={18} color={colors.iconHeader} />
@@ -449,7 +456,7 @@ export default function EventFormPage() {
         {/* Center selection */}
         <FieldRow label="Center" colors={colors} error={errors.center} required hint="Picking a center auto-fills address & coordinates.">
           <Pressable
-            onPress={() => setShowCenterPicker(!showCenterPicker)}
+            onPress={() => { const next = !showCenterPicker; setShowCenterPicker(next); if (next) track('event_form_center_picker_opened', { source: 'event_form' }) }}
             style={{
               ...inputStyle(!!errors.center),
               flexDirection: 'row',
@@ -628,7 +635,7 @@ export default function EventFormPage() {
               </View>
               <Switch
                 value={allowJanataSignup}
-                onValueChange={setAllowJanataSignup}
+                onValueChange={(v) => { setAllowJanataSignup(v); track('event_form_janata_signup_toggled', { enabled: v, source: 'event_form' }) }}
                 trackColor={{ true: '#E8862A', false: colors.border }}
                 thumbColor="#FFFFFF"
                 ios_backgroundColor={colors.border}
@@ -645,7 +652,7 @@ export default function EventFormPage() {
               return (
                 <Pressable
                   key={opt.label}
-                  onPress={() => setCategory(opt.value)}
+                  onPress={() => { setCategory(opt.value); track('event_form_category_selected', { category: opt.label, value: opt.value ?? null, source: 'event_form' }) }}
                   style={{
                     paddingHorizontal: 18,
                     paddingVertical: 10,
@@ -673,7 +680,7 @@ export default function EventFormPage() {
         {/* Advanced: coordinates (collapsed by default — auto-filled from center) */}
         <View style={{ gap: 12, marginTop: 4 }}>
           <Pressable
-            onPress={() => setShowAdvanced((v) => !v)}
+            onPress={() => setShowAdvanced((v) => { const next = !v; track('event_form_advanced_toggled', { expanded: next, source: 'event_form' }); return next })}
             style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}
             accessibilityLabel="Toggle advanced location options"
           >
@@ -747,7 +754,7 @@ export default function EventFormPage() {
         }}
       >
         <SecondaryButton
-          onPress={() => router.back()}
+          onPress={() => { track('event_form_back_pressed', { isEdit, source: 'event_form' }); router.back() }}
           style={{ paddingHorizontal: 24, paddingVertical: 12 }}
         >
           Cancel

--- a/packages/frontend/app/events/index.tsx
+++ b/packages/frontend/app/events/index.tsx
@@ -1,31 +1,28 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { View, Text, ScrollView, ActivityIndicator, RefreshControl, Pressable } from 'react-native'
 import { useRouter } from 'expo-router'
 import { Calendar, MapPin, ThumbsUp, MessageCircle } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
 import { useMyEvents, EventDisplay } from '../../hooks/useApiData'
 import { Card } from '../../components/ui'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 
 export default function EventsListPage() {
   const router = useRouter()
   const { user } = useUser()
   const { events, loading, refetch } = useMyEvents(user?.username)
   const [refreshing, setRefreshing] = React.useState(false)
-  const posthog = usePostHog()
-
-  useEffect(() => {
-    posthog?.capture('event_list_viewed')
-  }, [])
+  const { track } = useAnalytics()
 
   const handleRefresh = async () => {
     setRefreshing(true)
     await refetch()
     setRefreshing(false)
+    track('event_list_refreshed', { source: 'events_list' })
   }
 
   const handleEventPress = (event: EventDisplay) => {
-    posthog?.capture('event_list_item_pressed', { eventId: event.id })
+    track('event_list_item_pressed', { eventId: event.id, source: 'events_list' })
     router.push(`/events/${event.id}`)
   }
 

--- a/packages/frontend/app/feed/[id].tsx
+++ b/packages/frontend/app/feed/[id].tsx
@@ -15,6 +15,7 @@ import {
   type BoardMessage,
   type PersonSummary,
 } from '../../components/boards'
+import { useAnalytics } from '../../utils/analytics'
 
 type GroupKind = 'center' | 'event'
 
@@ -99,6 +100,7 @@ export default function FeedPostDetail() {
   const router = useRouter()
   const { user } = useUser()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const { centers: allCenters } = useCenterList()
   const { events: myEvents } = useMyEvents(user?.username)
 
@@ -130,7 +132,10 @@ export default function FeedPostDetail() {
             Post not found
           </Text>
           <Pressable
-            onPress={() => router.back()}
+            onPress={() => {
+              track('feed_post_back_pressed', { post_id: id, source: 'feed_post_detail', reason: 'not_found' })
+              router.back()
+            }}
             style={{
               marginTop: 16,
               paddingVertical: 10,
@@ -165,7 +170,10 @@ export default function FeedPostDetail() {
         }}
       >
         <Pressable
-          onPress={() => router.back()}
+          onPress={() => {
+            track('feed_post_back_pressed', { post_id: id, source: 'feed_post_detail', group_id: post?.groupId, group_kind: post?.groupKind })
+            router.back()
+          }}
           accessibilityRole="button"
           accessibilityLabel="Back"
           hitSlop={10}

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -13,7 +13,7 @@ import {
 import { useUser, useTheme } from '../../components/contexts'
 import { Avatar, Text, Section, StackHeader } from '../../components/ui'
 import ThemeSelector from '../../components/settings/ThemeSelector'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import Constants from 'expo-constants'
 
 const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
@@ -23,7 +23,7 @@ export default function PreferencesNative() {
   const { user, logout } = useUser()
   const { isDark } = useTheme()
   const { deleteAccount } = useUser()
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const currentYear = new Date().getFullYear()
@@ -36,7 +36,7 @@ export default function PreferencesNative() {
   const pageBg = isDark ? '#1A1A1A' : '#F5F5F4'
 
   const handleLogout = async () => {
-    posthog?.capture('nav_logout')
+    track('nav_logout')
     await logout()
     router.replace('/auth')
   }
@@ -46,12 +46,15 @@ export default function PreferencesNative() {
     try {
       const result = await deleteAccount()
       if (result.success) {
+        track('account_deleted', { source: 'settings' })
         setShowDeleteModal(false)
         router.replace('/auth')
       } else {
+        track('delete_account_failed', { source: 'settings', reason: result.message })
         Alert.alert('Error', result.message || 'Failed to delete account')
       }
     } catch (error) {
+      track('delete_account_failed', { source: 'settings', reason: 'exception' })
       Alert.alert('Error', 'Failed to delete account. Please try again.')
     } finally {
       setIsDeleting(false)
@@ -175,7 +178,10 @@ export default function PreferencesNative() {
               marginHorizontal: -16,
             }}
           >
-            <MenuRow onPress={() => router.push('/settings/invite')}>
+            <MenuRow onPress={() => {
+              track('settings_invite_pressed', { source: 'settings' })
+              router.push('/settings/invite')
+            }}>
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
                 <UserPlus size={20} color={textColor} />
                 <Text style={{ fontSize: 15, color: textColor }}>Invite Friends</Text>
@@ -195,7 +201,7 @@ export default function PreferencesNative() {
           >
             <MenuRow
               onPress={() => {
-                posthog?.capture('privacy_policy_viewed')
+                track('privacy_policy_viewed')
                 router.push('/privacy')
               }}
             >
@@ -206,7 +212,7 @@ export default function PreferencesNative() {
             </MenuRow>
             <MenuRow
               onPress={() => {
-                posthog?.capture('terms_viewed')
+                track('terms_viewed')
                 router.push('/terms')
               }}
             >
@@ -217,7 +223,7 @@ export default function PreferencesNative() {
             </MenuRow>
             <MenuRow
               onPress={() => {
-                posthog?.capture('cookie_policy_viewed')
+                track('cookie_policy_viewed')
                 router.push('/cookies')
               }}
             >
@@ -267,7 +273,7 @@ export default function PreferencesNative() {
             </MenuRow>
             <MenuRow
               onPress={() => {
-                posthog?.capture('delete_account_started')
+                track('delete_account_started', { source: 'settings' })
                 setShowDeleteModal(true)
               }}
               showArrow={false}
@@ -345,7 +351,10 @@ export default function PreferencesNative() {
             </View>
             <View style={{ flexDirection: 'row', gap: 12, marginTop: 8 }}>
               <Pressable
-                onPress={() => setShowDeleteModal(false)}
+                onPress={() => {
+                  track('delete_account_cancelled', { source: 'settings' })
+                  setShowDeleteModal(false)
+                }}
                 disabled={isDeleting}
                 style={{
                   flex: 1,

--- a/packages/frontend/app/settings/index.web.tsx
+++ b/packages/frontend/app/settings/index.web.tsx
@@ -15,7 +15,7 @@ import { useUser, useTheme } from '../../components/contexts'
 import { useRouter } from 'expo-router'
 import { DestructiveButton, SecondaryButton, Text } from '../../components/ui'
 import ThemeSelector from '../../components/settings/ThemeSelector'
-import { usePostHog } from 'posthog-react-native'
+import { useAnalytics } from '../../utils/analytics'
 import Constants from 'expo-constants'
 
 const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
@@ -26,7 +26,7 @@ export default function Preferences() {
   const router = useRouter()
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
-  const posthog = usePostHog()
+  const { track } = useAnalytics()
   const currentYear = new Date().getFullYear()
 
   const textColor = isDark ? '#FAFAFA' : '#1C1917'
@@ -45,12 +45,15 @@ export default function Preferences() {
     try {
       const result = await deleteAccount()
       if (result.success) {
+        track('account_deleted', { source: 'settings' })
         setShowDeleteModal(false)
         router.replace('/auth')
       } else {
+        track('delete_account_failed', { source: 'settings', reason: result.message })
         Alert.alert('Error', result.message || 'Failed to delete account')
       }
     } catch (error) {
+      track('delete_account_failed', { source: 'settings', reason: 'exception' })
       Alert.alert('Error', 'Failed to delete account. Please try again.')
     } finally {
       setIsDeleting(false)
@@ -129,7 +132,7 @@ export default function Preferences() {
                 borderBottomColor: borderColor,
               }}
               onPress={() => {
-                posthog?.capture('privacy_policy_viewed')
+                track('privacy_policy_viewed')
                 router.push('/privacy')
               }}
             >
@@ -146,7 +149,7 @@ export default function Preferences() {
                 borderBottomColor: borderColor,
               }}
               onPress={() => {
-                posthog?.capture('terms_viewed')
+                track('terms_viewed')
                 router.push('/terms')
               }}
             >
@@ -161,7 +164,7 @@ export default function Preferences() {
                 padding: isNarrowWeb ? 20 : 28,
               }}
               onPress={() => {
-                posthog?.capture('cookie_policy_viewed')
+                track('cookie_policy_viewed')
                 router.push('/cookies')
               }}
             >
@@ -241,7 +244,7 @@ export default function Preferences() {
             </View>
             <DestructiveButton
               onPress={() => {
-                posthog?.capture('delete_account_started')
+                track('delete_account_started', { source: 'settings' })
                 setShowDeleteModal(true)
               }}
             >
@@ -315,7 +318,10 @@ export default function Preferences() {
             </View>
             <View style={{ flexDirection: 'row', gap: 12, marginTop: 8 }}>
               <View style={{ flex: 1 }}>
-                <SecondaryButton onPress={() => setShowDeleteModal(false)} disabled={isDeleting}>
+                <SecondaryButton onPress={() => {
+                  track('delete_account_cancelled', { source: 'settings' })
+                  setShowDeleteModal(false)
+                }} disabled={isDeleting}>
                   Cancel
                 </SecondaryButton>
               </View>

--- a/packages/frontend/app/settings/invite.tsx
+++ b/packages/frontend/app/settings/invite.tsx
@@ -14,6 +14,7 @@ import { useUser } from '../../components/contexts'
 import { StackHeader, GradientIconBadge, Card, IconBadge } from '../../components/ui'
 import { fetchCenters } from '../../utils/api'
 import { useColors } from '../../hooks/useColors'
+import { useAnalytics } from '../../utils/analytics'
 
 const MONO_FONT = Platform.select({
   ios: 'JetBrains Mono',
@@ -24,6 +25,7 @@ const MONO_FONT = Platform.select({
 export default function InviteScreen() {
   const { user } = useUser()
   const c = useColors()
+  const { track } = useAnalytics()
   const [centerName, setCenterName] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   const [pressing, setPressing] = useState(false)
@@ -44,6 +46,7 @@ export default function InviteScreen() {
   const handleCopy = () => {
     if (!inviteUrl) return
     Share.share({ message: inviteUrl })
+    track('invite_link_shared', { source: 'invite_screen', method: 'share_button', invite_code: inviteCode })
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
@@ -167,7 +170,10 @@ export default function InviteScreen() {
           </View>
           <Pressable
             style={{ gap: 8, alignItems: 'center' }}
-            onPress={() => Share.share({ message: inviteUrl ?? '' })}
+            onPress={() => {
+              Share.share({ message: inviteUrl ?? '' })
+              track('invite_link_shared', { source: 'invite_screen', method: 'other', invite_code: inviteCode })
+            }}
           >
             <IconBadge size={56} color="#6c757d">
               <EllipsisIcon size={32} color="#fff" strokeWidth={2} />

--- a/packages/frontend/components/boards/CreatePostSheet.tsx
+++ b/packages/frontend/components/boards/CreatePostSheet.tsx
@@ -3,6 +3,7 @@ import { KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, Tex
 import { Building2, CalendarDays, ChevronDown, X } from 'lucide-react-native'
 import { Avatar } from '../ui'
 import type { AppColors } from '../../tokens'
+import { useAnalytics } from '../../utils/analytics'
 
 type GroupOption = {
   id: string
@@ -24,6 +25,7 @@ export function CreatePostSheet({
   onClose: () => void
   onSubmit?: (group: GroupOption, body: string) => Promise<void> | void
 }) {
+  const { track } = useAnalytics()
   const [body, setBody] = useState('')
   const [groupId, setGroupId] = useState<string | undefined>()
   const [groupPickerOpen, setGroupPickerOpen] = useState(false)
@@ -47,8 +49,22 @@ export function CreatePostSheet({
     try {
       setSubmitting(true)
       await onSubmit?.(selectedGroup, body.trim())
+      track('board_post_created', {
+        source: 'create_post_sheet',
+        group_id: selectedGroup.id,
+        group_kind: selectedGroup.kind,
+        group_title: selectedGroup.title,
+        body_length: body.trim().length,
+      })
       setBody('')
       onClose()
+    } catch (err) {
+      track('board_post_create_failed', {
+        source: 'create_post_sheet',
+        group_id: selectedGroup.id,
+        group_kind: selectedGroup.kind,
+      })
+      throw err
     } finally {
       setSubmitting(false)
     }
@@ -68,7 +84,7 @@ export function CreatePostSheet({
       >
         {/* Header */}
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: Platform.OS === 'ios' ? 20 : 16, paddingTop: Platform.OS === 'ios' ? 14 : 18, paddingBottom: 12, borderBottomWidth: 1, borderBottomColor: colors.border }}>
-          <Pressable onPress={onClose} hitSlop={8} style={{ minWidth: 64 }}>
+          <Pressable onPress={() => { track('board_post_dismissed', { source: 'create_post_sheet', body_length: body.trim().length }); onClose() }} hitSlop={8} style={{ minWidth: 64 }}>
             <X size={22} color={colors.textMuted} />
           </Pressable>
           <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: colors.text }}>New post</Text>
@@ -86,7 +102,7 @@ export function CreatePostSheet({
               POST TO
             </Text>
             <Pressable
-              onPress={() => setGroupPickerOpen((o) => !o)}
+              onPress={() => setGroupPickerOpen((o) => { const next = !o; if (next) track('board_group_picker_opened', { source: 'create_post_sheet', current_group_id: selectedGroup?.id, current_group_kind: selectedGroup?.kind }); return next })}
               style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 12, paddingVertical: 11, borderRadius: 12, borderWidth: 1, borderColor: colors.border, backgroundColor: colors.card }}
             >
               <View style={{ width: 28, height: 28, borderRadius: 9, backgroundColor: colors.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
@@ -114,7 +130,7 @@ export function CreatePostSheet({
                   return (
                     <Pressable
                       key={group.id}
-                      onPress={() => { setGroupId(group.id); setGroupPickerOpen(false) }}
+                      onPress={() => { track('board_group_selected', { source: 'create_post_sheet', group_id: group.id, group_kind: group.kind, group_title: group.title }); setGroupId(group.id); setGroupPickerOpen(false) }}
                       style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 12, paddingVertical: 11, backgroundColor: active ? colors.accentSoft : colors.card, borderBottomWidth: index < sortedGroups.length - 1 ? 1 : 0, borderBottomColor: colors.border }}
                     >
                       <View style={{ width: 24, height: 24, borderRadius: 7, backgroundColor: colors.panel, alignItems: 'center', justifyContent: 'center' }}>

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -31,6 +31,7 @@ import {
   optimisticReply,
 } from './feedData'
 import type { FeedPost } from './types'
+import { useAnalytics } from '../../utils/analytics'
 
 const REACTION_CHOICES = ['🙏', '❤️', '👍', '🎉']
 
@@ -52,6 +53,7 @@ export function PostThread({
   onPostDeleted?: () => void
 }) {
   const { user } = useUser()
+  const { track } = useAnalytics()
   const author = authorFromUser(user)
   const [replies, setReplies] = useState<BoardMessage[]>([])
   const [loadingReplies, setLoadingReplies] = useState(true)
@@ -84,6 +86,7 @@ export function PostThread({
     setMenuOpen(false)
     setActionBusy(true)
     setActionError(null)
+    track('feed_post_pin_toggled', { post_id: post.postId, pinned: !prev, source: 'post_thread' })
     try {
       await setBoardPostPinned(post.postId, !prev)
       onPostChanged?.()
@@ -103,9 +106,11 @@ export function PostThread({
       await deleteBoardPost(post.postId)
       setDeleted(true)
       setMenuOpen(false)
+      track('feed_post_deleted', { post_id: post.postId, source: 'post_thread' })
       // onPostDeleted already refreshes the feed; no separate change notice needed.
       onPostDeleted?.()
     } catch (err: any) {
+      track('feed_post_delete_failed', { post_id: post.postId, error: err?.message, source: 'post_thread' })
       setActionError(err?.message || 'Could not delete the post.')
     } finally {
       setActionBusy(false)
@@ -123,9 +128,11 @@ export function PostThread({
     try {
       const updated = await editBoardPost(post.postId, body)
       setPostBody(updated.body)
+      track('feed_post_edited', { post_id: post.postId, source: 'post_thread' })
       onPostChanged?.()
     } catch (err: any) {
       setPostBody(prev)
+      track('feed_post_edit_failed', { post_id: post.postId, error: err?.message, source: 'post_thread' })
       setActionError(err?.message || 'Could not save your edit.')
     } finally {
       setActionBusy(false)
@@ -135,6 +142,7 @@ export function PostThread({
   const handleReact = async (emoji: string) => {
     const prev = reactions
     setReactions(applyOptimisticReaction(prev, emoji))
+    track('feed_post_reacted', { post_id: post.postId, emoji, source: 'post_thread' })
     try {
       const res = await toggleBoardPostReaction(post.postId, emoji)
       setReactions(res.reactions)
@@ -195,11 +203,13 @@ export function PostThread({
       const created = await createBoardPostReply(post.postId, body)
       setReplies((prev) => prev.map((r) => (r.id === tempId ? boardPostToMessage(created) : r)))
       setRepliesLoaded(true)
+      track('feed_reply_sent', { post_id: post.postId, source: 'post_thread' })
     } catch (err: any) {
       // Roll back the optimistic reply and give the user their text back.
       setReplies((prev) => prev.filter((r) => r.id !== tempId))
       setDraft(body)
       setSendError(err?.message || 'Reply failed to send. Try again.')
+      track('feed_reply_failed', { post_id: post.postId, error: err?.message, source: 'post_thread' })
     } finally {
       setSending(false)
     }
@@ -230,7 +240,7 @@ export function PostThread({
           reactions={reactions}
           colors={colors}
           hasMenu={hasMenu}
-          onOpenMenu={() => setMenuOpen(true)}
+          onOpenMenu={() => { setMenuOpen(true); track('feed_post_menu_opened', { post_id: post.postId, source: 'post_thread' }) }}
           onReact={handleReact}
         />
       )}
@@ -379,12 +389,14 @@ export function PostThread({
         isAuthor={isAuthor}
         pinned={pinned}
         busy={actionBusy}
+        postId={post.postId}
         onClose={() => setMenuOpen(false)}
         onTogglePin={handleTogglePin}
         onEdit={() => {
           setMenuOpen(false)
           setEditDraft(postBody)
           setEditOpen(true)
+          track('feed_post_edit_opened', { post_id: post.postId, source: 'post_thread' })
         }}
         onDelete={handleDelete}
       />
@@ -395,7 +407,7 @@ export function PostThread({
         value={editDraft}
         busy={actionBusy}
         onChangeText={setEditDraft}
-        onCancel={() => setEditOpen(false)}
+        onCancel={() => { setEditOpen(false); track('feed_post_edit_cancelled', { post_id: post.postId, source: 'post_thread' }) }}
         onSave={handleSaveEdit}
       />
     </View>
@@ -573,6 +585,7 @@ function OriginalPost({
   onOpenMenu: () => void
   onReact: (emoji: string) => void
 }) {
+  const { track } = useAnalytics()
   const [pickerOpen, setPickerOpen] = useState(false)
   return (
     <View style={{ flexDirection: 'row', gap: 12 }}>
@@ -649,7 +662,7 @@ function OriginalPost({
             />
           ))}
           <Pressable
-            onPress={() => setPickerOpen((open) => !open)}
+            onPress={() => { const next = !pickerOpen; setPickerOpen(next); if (next) track('feed_post_reaction_picker_opened', { post_id: post.postId, source: 'post_thread' }) }}
             accessibilityRole="button"
             accessibilityLabel="Add reaction"
             style={{
@@ -706,6 +719,7 @@ function ActionMenuSheet({
   isAuthor,
   pinned,
   busy,
+  postId,
   onClose,
   onTogglePin,
   onEdit,
@@ -717,11 +731,13 @@ function ActionMenuSheet({
   isAuthor: boolean
   pinned: boolean
   busy: boolean
+  postId: string
   onClose: () => void
   onTogglePin: () => void
   onEdit: () => void
   onDelete: () => void
 }) {
+  const { track } = useAnalytics()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   useEffect(() => {
     if (!visible) setConfirmingDelete(false)
@@ -781,7 +797,7 @@ function ActionMenuSheet({
                 </Text>
                 <View style={{ flexDirection: 'row', gap: 10 }}>
                   <Pressable
-                    onPress={() => setConfirmingDelete(false)}
+                    onPress={() => { setConfirmingDelete(false); track('feed_post_delete_cancelled', { post_id: postId, source: 'post_thread' }) }}
                     disabled={busy}
                     accessibilityRole="button"
                     accessibilityLabel="Cancel delete"
@@ -825,7 +841,7 @@ function ActionMenuSheet({
                 colors={colors}
                 destructive
                 disabled={busy}
-                onPress={() => setConfirmingDelete(true)}
+                onPress={() => { setConfirmingDelete(true); track('feed_post_delete_confirm_shown', { post_id: postId, source: 'post_thread' }) }}
               />
             )
           ) : null}

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -6,12 +6,14 @@ import { router, usePathname } from 'expo-router'
 import ThemeSelector from './ThemeSelector'
 import { Avatar } from '../ui'
 import { isSuperAdmin } from '../../utils/admin'
+import { useAnalytics } from '../../utils/analytics'
 
 function SettingsPanel({ visible, onClose, onLogout }) {
   const opacityAnim = useRef(new Animated.Value(0)).current
   const translateYAnim = useRef(new Animated.Value(-20)).current
   const { user } = useUser()
   const { preference: themePreference, setPreference: setThemePreference, isDark } = useTheme()
+  const { track } = useAnalytics()
   const pathname = usePathname()
   const themeOptions = ['light', 'dark', 'system']
   const optionWidth = 70
@@ -120,7 +122,10 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           bottom: 0,
           zIndex: 99,
         }}
-        onPress={onClose}
+        onPress={() => {
+          track('settings_panel_dismissed', { source: 'backdrop' })
+          onClose()
+        }}
       />
 
       {/* Settings Panel */}
@@ -177,6 +182,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
               : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
           }`}
           onPress={() => {
+            track('nav_profile_opened', { source: 'settings_panel' })
             onClose()
             router.push('/profile')
           }}
@@ -203,6 +209,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
               : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
           }`}
           onPress={() => {
+            track('nav_settings_opened', { source: 'settings_panel', destination: 'preferences' })
             onClose()
             router.push('/settings/preferences')
           }}
@@ -226,6 +233,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           <Pressable
             className="flex-row items-center mb-2 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-800"
             onPress={() => {
+              track('settings_admin_dashboard_opened', { source: 'settings_panel' })
               onClose()
               router.push('/admin' as any)
             }}
@@ -254,7 +262,10 @@ function SettingsPanel({ visible, onClose, onLogout }) {
 
         {/* Log Out Button */}
         <Pressable
-          onPress={onLogout}
+          onPress={() => {
+            track('logout', { source: 'settings_panel' })
+            onLogout()
+          }}
           className="flex-row items-center p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20"
         >
           <LogOut size={16} color={isDark ? '#ef4444' : '#dc2626'} className="mr-3" />

--- a/packages/frontend/utils/analytics.ts
+++ b/packages/frontend/utils/analytics.ts
@@ -1,8 +1,252 @@
 /**
- * PostHog analytics — centralised event names and re-export of the hook.
+ * analytics.ts
+ *
+ * Typed PostHog analytics foundation. Wraps posthog-react-native so the app
+ * captures events through a single tiny, dependency-free helper that works
+ * identically on native and web.
+ *
+ * - `useAnalytics()` -> `{ track }` is the import surface for instrumenting
+ *   components. `track(event, props)` is a null-safe no-op when PostHog is not
+ *   configured (e.g. EXPO_PUBLIC_POSTHOG_KEY unset), so callers never need to
+ *   guard themselves.
+ * - `AnalyticsScreenTracker` fires one screen view per distinct pathname and is
+ *   rendered once inside the PostHogProvider in app/_layout.tsx.
  */
-export { usePostHog } from 'posthog-react-native'
 
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'expo-router'
+import { usePostHog } from 'posthog-react-native'
+
+export { usePostHog }
+
+/**
+ * Known, already-used event names. Seeded from the events captured across the
+ * app/ and components/ trees. Kept here purely for autocomplete — see
+ * AnalyticsEvent below, which still accepts any string so parallel work can
+ * introduce new event names without editing this file.
+ */
+export type KnownAnalyticsEvent =
+  | '$exception'
+  | 'account_deleted'
+  | 'admin_tab_changed'
+  | 'auth_back_pressed'
+  | 'auth_back_to_home_pressed'
+  | 'auth_check_failed'
+  | 'auth_create_account_pressed'
+  | 'auth_discover_pressed'
+  | 'auth_email_submitted'
+  | 'auth_forgot_password_pressed'
+  | 'auth_invite_code_check_failed'
+  | 'auth_invite_code_invalid'
+  | 'auth_invite_code_submitted'
+  | 'auth_invite_code_valid'
+  | 'auth_logo_pressed'
+  | 'auth_user_exists'
+  | 'auth_user_new'
+  | 'board_group_picker_opened'
+  | 'board_group_selected'
+  | 'board_post_create_failed'
+  | 'board_post_created'
+  | 'board_post_dismissed'
+  | 'center_address_pressed'
+  | 'center_back_pressed'
+  | 'center_board_post_created'
+  | 'center_board_post_opened'
+  | 'center_board_thread_closed'
+  | 'center_event_pressed'
+  | 'center_list_item_pressed'
+  | 'center_not_found_back_pressed'
+  | 'center_phone_pressed'
+  | 'center_picker_searched'
+  | 'center_picker_selected'
+  | 'center_shared'
+  | 'center_viewed'
+  | 'center_website_pressed'
+  | 'chat_back_pressed'
+  | 'chat_not_found_back_pressed'
+  | 'connect_conversation_closed'
+  | 'connect_conversation_selected'
+  | 'connect_empty_board_opened'
+  | 'connect_explore_pressed'
+  | 'connect_feed_post_selected'
+  | 'connect_signin_pressed'
+  | 'cookie_policy_viewed'
+  | 'delete_account_cancelled'
+  | 'delete_account_failed'
+  | 'delete_account_started'
+  | 'discover_center_filter_opened'
+  | 'discover_date_selected'
+  | 'discover_filter_changed'
+  | 'discover_going_filter_toggled'
+  | 'discover_search'
+  | 'discover_section_toggled'
+  | 'event_auth_prompt_shown'
+  | 'event_board_post_created'
+  | 'event_board_post_opened'
+  | 'event_board_thread_closed'
+  | 'event_create_failed'
+  | 'event_created'
+  | 'event_deleted'
+  | 'event_edit_opened'
+  | 'event_external_signup_pressed'
+  | 'event_form_advanced_toggled'
+  | 'event_form_back_pressed'
+  | 'event_form_category_selected'
+  | 'event_form_center_picker_opened'
+  | 'event_form_center_selected'
+  | 'event_form_date_picker_opened'
+  | 'event_form_janata_signup_toggled'
+  | 'event_form_time_picker_opened'
+  | 'event_list_item_pressed'
+  | 'event_list_refreshed'
+  | 'event_registered'
+  | 'event_registration_failed'
+  | 'event_shared'
+  | 'event_unregistered'
+  | 'event_updated'
+  | 'event_viewed'
+  | 'feed_create_post_dismissed'
+  | 'feed_post_back_pressed'
+  | 'feed_post_create_failed'
+  | 'feed_post_created'
+  | 'feed_post_delete_cancelled'
+  | 'feed_post_delete_confirm_shown'
+  | 'feed_post_delete_failed'
+  | 'feed_post_deleted'
+  | 'feed_post_detail_closed'
+  | 'feed_post_edit_cancelled'
+  | 'feed_post_edit_failed'
+  | 'feed_post_edit_opened'
+  | 'feed_post_edited'
+  | 'feed_post_menu_opened'
+  | 'feed_post_pin_toggled'
+  | 'feed_post_reacted'
+  | 'feed_post_reaction_picker_opened'
+  | 'feed_reply_failed'
+  | 'feed_reply_sent'
+  | 'feed_searched'
+  | 'forgot_password_back_pressed'
+  | 'forgot_password_code_resent'
+  | 'forgot_password_code_submitted'
+  | 'forgot_password_email_failed'
+  | 'forgot_password_email_submitted'
+  | 'forgot_password_logo_pressed'
+  | 'forgot_password_resend_failed'
+  | 'forgot_password_reset_failed'
+  | 'forgot_password_signin_pressed'
+  | 'home_board_peek_pressed'
+  | 'home_event_pressed'
+  | 'home_explore_fallback_pressed'
+  | 'home_featured_event_pressed'
+  | 'home_first_run_center_opened'
+  | 'home_first_run_center_pressed'
+  | 'home_first_run_explore_pressed'
+  | 'home_first_run_feed_pressed'
+  | 'home_open_feed_pressed'
+  | 'home_see_all_pressed'
+  | 'invite_link_shared'
+  | 'landing_ask_pressed'
+  | 'landing_cta_pressed'
+  | 'landing_signin_pressed'
+  | 'login_failed'
+  | 'login_success'
+  | 'logout'
+  | 'map_point_pressed'
+  | 'nav_create_event'
+  | 'nav_create_pressed'
+  | 'nav_logo_pressed'
+  | 'nav_logout'
+  | 'nav_menu_opened'
+  | 'nav_profile_opened'
+  | 'nav_settings_opened'
+  | 'nav_tab_pressed'
+  | 'onboarding_completed'
+  | 'onboarding_failed'
+  | 'onboarding_skipped'
+  | 'onboarding_step_completed'
+  | 'privacy_policy_viewed'
+  | 'profile_avatar_crop_cancelled'
+  | 'profile_avatar_cropped'
+  | 'profile_avatar_edit_opened'
+  | 'profile_avatar_file_selected'
+  | 'profile_center_picker_opened'
+  | 'profile_center_selected'
+  | 'profile_edit_cancelled'
+  | 'profile_edit_opened'
+  | 'profile_edit_started'
+  | 'profile_interest_toggled'
+  | 'profile_looking_for_toggled'
+  | 'profile_photo_changed'
+  | 'profile_shared'
+  | 'profile_update_failed'
+  | 'profile_updated'
+  | 'settings_admin_dashboard_opened'
+  | 'settings_invite_pressed'
+  | 'settings_panel_dismissed'
+  | 'signup_failed'
+  | 'signup_success'
+  | 'terms_viewed'
+
+/**
+ * LiteralUnion: known event names autocomplete, but ANY string is still a valid
+ * event. `string & {}` defeats TypeScript's union-collapsing so the literals
+ * survive in editor suggestions while the type stays open.
+ */
+export type AnalyticsEvent = KnownAnalyticsEvent | (string & {})
+
+/**
+ * Returns a tiny `{ track }` API backed by the active PostHog client.
+ *
+ * `track` is null-safe: when PostHog is not configured (`usePostHog()` returns
+ * undefined) it is a silent no-op, so callers never have to check.
+ */
+export function useAnalytics(): {
+  track: (event: AnalyticsEvent, props?: Record<string, unknown>) => void
+} {
+  const posthog = usePostHog()
+  const track = (event: AnalyticsEvent, props?: Record<string, unknown>) => {
+    // The public `props` type is intentionally loose (Record<string, unknown>)
+    // so callers don't fight the SDK's JsonType; PostHog serialises values to
+    // JSON at send time, so a cast here is safe.
+    posthog?.capture(event, props as Record<string, unknown> as never)
+  }
+  return { track }
+}
+
+/**
+ * Central screen-view tracker. Renders nothing; on each distinct pathname it
+ * fires a single screen view. Works on native and web because it reads
+ * expo-router's `usePathname()` rather than any platform-specific navigation
+ * container. Render once inside the PostHogProvider.
+ *
+ * Prefers the SDK's `screen(name, props)` method; falls back to a manual
+ * `$screen` capture if that method is unavailable.
+ */
+export function AnalyticsScreenTracker(): null {
+  const posthog = usePostHog()
+  const pathname = usePathname()
+  const lastPathname = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!posthog) return
+    if (!pathname) return
+    if (lastPathname.current === pathname) return
+    lastPathname.current = pathname
+
+    if (typeof posthog.screen === 'function') {
+      posthog.screen(pathname, { $screen_name: pathname })
+    } else {
+      posthog.capture('$screen', { $screen_name: pathname })
+    }
+  }, [posthog, pathname])
+
+  return null
+}
+
+/**
+ * Pre-existing centralised event-name constants. Retained so existing callers
+ * that import `AnalyticsEvents` keep working alongside the typed `track` API.
+ */
 export const AnalyticsEvents = {
   // Auth
   AUTH_EMAIL_SUBMITTED: 'auth_email_submitted',


### PR DESCRIPTION
## What

Comprehensive, typed PostHog instrumentation across the whole app on **iOS and web**, built via a multi-agent workflow and validated live against PostHog.

### Foundation (`utils/analytics.ts` + `app/_layout.tsx`)
- **`useAnalytics()` → `track(event, props?)`** — null-safe (no-op when PostHog disabled), one tiny dependency-free helper used everywhere.
- **Typed event registry** — `AnalyticsEvent = KnownAnalyticsEvent | (string & {})`: 160 known names autocomplete, any string still accepted.
- **`AnalyticsScreenTracker`** — fires one `$screen` per route change via `usePathname()`; works on native **and** web. Rendered once inside the provider.
- **Explicit provider config** — `captureAppLifecycleEvents: true`; autocapture screens/touches **off** (screens handled by the tracker, touch autocapture is noise).

### Coverage
- **31 page/feature files** instrumented (each with its `.web` sibling), **187 events added/migrated**. Existing `posthog?.capture(...)` calls migrated to the typed `track()`.
- Static/presentational surfaces (legal pages, intro, landing, onboarding, feed-workspace) intentionally rely on the central screen tracker only — no fabricated interaction events.

## Verification
- **Typecheck:** `tsc` clean — 0 new errors (6 pre-existing baseline, unrelated files).
- **Live, end-to-end (sim + web → server):** ran the build against a PostHog project I can read and confirmed events arrive with props:
  - **iOS:** `$screen` (`/`, `/auth`, `/intro`), `Application Opened`/`Backgrounded`, and `track()` interaction events (`login_failed`, `logout`) — `$os=iOS`.
  - **Web:** `$screen` across `/`, `/intro`, `/landing`, `/explore`, `/auth`, `/terms`, plus lifecycle — `$os=Mac OS`.
  - Props confirmed flowing (e.g. `$screen_name`).
- Not traversed live: authenticated-only screens (home/feed/event-detail) — the validation build wasn't logged in. They use the identical, now-proven `track()`/`$screen` path and are typecheck-clean.

## Notes
- Built in an isolated git worktree off `origin/v2`; the uncommitted WIP on the main `v2` checkout was left untouched.
- The app's real prod PostHog key was never touched — live validation used a separate, git-ignored local `.env` pointed at a sandbox project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)