### PR TITLE
style(design): desktop layouts for Home + Profile web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ docs/plans/2026-02-27-auth-page-redesign.md
 
 # R2 CORS config (local only)
 packages/backend/cors.json
+.gstack/

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -90,6 +90,9 @@ export default function HomeScreen() {
     }, [refetchMyEvents, refreshDiscover])
   )
 
+  // Desktop two-column composition is web-only and gated on a wide breakpoint.
+  // Mobile web and native always render the original single centered column.
+  const isWideDesktop = Platform.OS === 'web' && width >= 1024
   const isDesktop = width >= 860
 
   const signedUpEvents = useMemo(() => {
@@ -144,6 +147,180 @@ export default function HomeScreen() {
     )
   }
 
+  const greeting = (
+    <View style={{ gap: 4 }}>
+      <Text style={{ fontSize: 12.5, color: c.textFaint, letterSpacing: 0.2 }}>{todayLabel}</Text>
+      <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 30, lineHeight: 34, letterSpacing: -0.5, color: c.text }} numberOfLines={1}>
+        {user ? `Namaste, ${greetingName}` : 'Namaste'}
+      </Text>
+    </View>
+  )
+
+  const firstRunOverview = isNewUser ? (
+    <FirstRunOverview
+      c={c}
+      detailColors={detailColors}
+      center={userCenter}
+      peek={boardPeek}
+      onExplore={() => {
+        track('home_first_run_explore_pressed')
+        router.push('/explore' as never)
+      }}
+      onFeed={() => {
+        track('home_first_run_feed_pressed')
+        router.push('/feed' as never)
+      }}
+      onChooseCenter={() => {
+        track('home_first_run_center_pressed')
+        router.push('/center-picker' as never)
+      }}
+      onOpenCenter={(id) => {
+        track('home_first_run_center_opened', { centerId: id })
+        router.push(`/center/${id}`)
+      }}
+      onPeekPress={(id) => {
+        track('home_board_peek_pressed', { postId: id, source: 'first_run_peek' })
+        router.push('/feed' as never)
+      }}
+    />
+  ) : null
+
+  const upNextSection = !isNewUser || featured ? (
+    <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => {
+      track('home_see_all_pressed', { section: 'up_next' })
+      router.push('/' as never)
+    }}>
+      {featured ? (
+        <FeaturedEventCard
+          featured={featured}
+          onPress={() => {
+            track('home_featured_event_pressed', { eventId: featured.event.id })
+            router.push(`/events/${featured.event.id}`)
+          }}
+        />
+      ) : (
+        <View style={{ borderRadius: 18, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 10 }}>
+          <View style={{ gap: 4 }}>
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: c.text }}>No upcoming events at your center yet</Text>
+            <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+              Explore other CHYK events while your center's calendar fills in.
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => {
+              track('home_explore_fallback_pressed', { source: 'up_next_empty' })
+              router.push('/explore' as never)
+            }}
+            style={{ alignSelf: 'flex-start', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: c.accentSoft }}
+          >
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.accent }}>Explore</Text>
+          </Pressable>
+        </View>
+      )}
+    </SectionHeader>
+  ) : null
+
+  // Boards peek (#199): the 1-2 latest posts from the user's center board.
+  // New users get their center + a feed peek inside the first-run overview,
+  // so this section is for returning members only.
+  const boardsSection = !isNewUser ? (
+    <SectionHeader
+      eyebrow="LATEST ON YOUR BOARDS"
+      trailing="Open Feed"
+      accentColor={c.accent}
+      faintColor={c.textFaint}
+      onTrailingPress={() => {
+        track('home_open_feed_pressed', { source: 'boards_section_header' })
+        router.push('/feed' as never)
+      }}
+    >
+      {boardPeek.length > 0 ? (
+        <View>
+          {boardPeek.map((message) => (
+            <BoardPostCard
+              key={message.id}
+              message={message}
+              colors={detailColors}
+              showSource
+              onPress={() => {
+                track('home_board_peek_pressed', { postId: message.id, source: 'boards_section' })
+                router.push('/feed' as never)
+              }}
+            />
+          ))}
+        </View>
+      ) : (
+        <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 6 }}>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>
+            No posts yet on your boards
+          </Text>
+          <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+            Conversations from your center and events you've joined will appear here. Head to the Feed to see what's new across the network.
+          </Text>
+        </View>
+      )}
+    </SectionHeader>
+  ) : null
+
+  const weekSection = !isNewUser || weekItems.length > 0 ? (
+    <SectionHeader
+      eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
+      trailing="See all"
+      accentColor={c.accent}
+      faintColor={c.textFaint}
+      onTrailingPress={() => {
+        track('home_see_all_pressed', { section: signedUpEvents.length > 0 ? 'this_week' : 'coming_up' })
+        router.push('/' as never)
+      }}
+    >
+      {weekItems.length > 0 ? (
+        <View style={{ gap: 8 }}>
+          {weekItems.map((item) => <MiniEventRow key={item.id} item={item} />)}
+        </View>
+      ) : (
+        <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 4 }}>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>No events yet</Text>
+          <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
+            Upcoming events from Explore will appear here as they are added.
+          </Text>
+        </View>
+      )}
+    </SectionHeader>
+  ) : null
+
+  // ── Wide desktop: a real two-column composition ─────────────────────────
+  // A centered ~1040px container with the schedule (Up Next + This Week) as
+  // the primary column and a ~320px right rail for the member's center, the
+  // welcome tour, and board activity — so the page uses the width instead of
+  // stranding a narrow column in empty gray. Reuses the exact same section
+  // blocks as mobile; only their arrangement differs.
+  if (isWideDesktop) {
+    const rail = isNewUser ? firstRunOverview : (
+      <View style={{ gap: 22 }}>{boardsSection}</View>
+    )
+    return (
+      <ScrollView
+        style={{ flex: 1, backgroundColor: c.bg }}
+        contentContainerStyle={{ paddingHorizontal: 40, paddingTop: 28, paddingBottom: 56 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={{ width: '100%', maxWidth: 1040, alignSelf: 'center', gap: 28 }}>
+          {greeting}
+          <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 32 }}>
+            <View style={{ flex: 1, minWidth: 0, gap: 28 }}>
+              {upNextSection}
+              {weekSection}
+            </View>
+            <View style={{ width: 320, gap: 22 }}>
+              {rail}
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    )
+  }
+
+  // ── Mobile web + native + narrow web: original single centered column ────
   return (
     <ScrollView
       style={{ flex: 1, backgroundColor: c.bg }}
@@ -155,146 +332,11 @@ export default function HomeScreen() {
       showsVerticalScrollIndicator={false}
     >
       <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center', gap: 22 }}>
-        <View style={{ gap: 4 }}>
-          <Text style={{ fontSize: 12.5, color: c.textFaint, letterSpacing: 0.2 }}>{todayLabel}</Text>
-          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 30, lineHeight: 34, letterSpacing: -0.5, color: c.text }} numberOfLines={1}>
-            {user ? `Namaste, ${greetingName}` : 'Namaste'}
-          </Text>
-        </View>
-
-        {isNewUser ? (
-          <FirstRunOverview
-            c={c}
-            detailColors={detailColors}
-            center={userCenter}
-            peek={boardPeek}
-            onExplore={() => {
-              track('home_first_run_explore_pressed')
-              router.push('/explore' as never)
-            }}
-            onFeed={() => {
-              track('home_first_run_feed_pressed')
-              router.push('/feed' as never)
-            }}
-            onChooseCenter={() => {
-              track('home_first_run_center_pressed')
-              router.push('/center-picker' as never)
-            }}
-            onOpenCenter={(id) => {
-              track('home_first_run_center_opened', { centerId: id })
-              router.push(`/center/${id}`)
-            }}
-            onPeekPress={(id) => {
-              track('home_board_peek_pressed', { postId: id, source: 'first_run_peek' })
-              router.push('/feed' as never)
-            }}
-          />
-        ) : null}
-
-        {!isNewUser || featured ? (
-          <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => {
-            track('home_see_all_pressed', { section: 'up_next' })
-            router.push('/' as never)
-          }}>
-            {featured ? (
-              <FeaturedEventCard
-                featured={featured}
-                onPress={() => {
-                  track('home_featured_event_pressed', { eventId: featured.event.id })
-                  router.push(`/events/${featured.event.id}`)
-                }}
-              />
-            ) : (
-              <View style={{ borderRadius: 18, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 10 }}>
-                <View style={{ gap: 4 }}>
-                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: c.text }}>No upcoming events at your center yet</Text>
-                  <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                    Explore other CHYK events while your center's calendar fills in.
-                  </Text>
-                </View>
-                <Pressable
-                  onPress={() => {
-                    track('home_explore_fallback_pressed', { source: 'up_next_empty' })
-                    router.push('/explore' as never)
-                  }}
-                  style={{ alignSelf: 'flex-start', paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: c.accentSoft }}
-                >
-                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.accent }}>Explore</Text>
-                </Pressable>
-              </View>
-            )}
-          </SectionHeader>
-        ) : null}
-
-        {/*
-          Boards peek (#199): the 1-2 latest posts from the user's center
-          board. New users get their center + a feed peek inside the first-run
-          overview above, so this section is for returning members only.
-        */}
-        {!isNewUser ? (
-          <SectionHeader
-            eyebrow="LATEST ON YOUR BOARDS"
-            trailing="Open Feed"
-            accentColor={c.accent}
-            faintColor={c.textFaint}
-            onTrailingPress={() => {
-              track('home_open_feed_pressed', { source: 'boards_section_header' })
-              router.push('/feed' as never)
-            }}
-          >
-            {boardPeek.length > 0 ? (
-              <View>
-                {boardPeek.map((message) => (
-                  <BoardPostCard
-                    key={message.id}
-                    message={message}
-                    colors={detailColors}
-                    showSource
-                    onPress={() => {
-                      track('home_board_peek_pressed', { postId: message.id, source: 'boards_section' })
-                      router.push('/feed' as never)
-                    }}
-                  />
-                ))}
-              </View>
-            ) : (
-              <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 6 }}>
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>
-                  No posts yet on your boards
-                </Text>
-                <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                  Conversations from your center and events you've joined will appear here. Head to the Feed to see what's new across the network.
-                </Text>
-              </View>
-            )}
-          </SectionHeader>
-        ) : null}
-
-        {!isNewUser || weekItems.length > 0 ? (
-          <SectionHeader
-            eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
-            trailing="See all"
-            accentColor={c.accent}
-            faintColor={c.textFaint}
-            onTrailingPress={() => {
-              track('home_see_all_pressed', { section: signedUpEvents.length > 0 ? 'this_week' : 'coming_up' })
-              router.push('/' as never)
-            }}
-          >
-            {weekItems.length > 0 ? (
-              <View style={{ gap: 8 }}>
-                {weekItems.map((item) => <MiniEventRow key={item.id} item={item} />)}
-              </View>
-            ) : (
-              <View style={{ borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 16, gap: 4 }}>
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: c.text }}>No events yet</Text>
-                <Text style={{ fontSize: 14, lineHeight: 20, color: c.textMuted }}>
-                  Upcoming events from Explore will appear here as they are added.
-                </Text>
-              </View>
-            )}
-          </SectionHeader>
-        ) : null}
+        {greeting}
+        {firstRunOverview}
+        {upNextSection}
+        {boardsSection}
+        {weekSection}
       </View>
     </ScrollView>
   )

--- a/packages/frontend/app/(tabs)/profile.web.tsx
+++ b/packages/frontend/app/(tabs)/profile.web.tsx
@@ -866,13 +866,25 @@ export default function Profile() {
   // WEB LAYOUT
   const { width: viewportWidth } = useWindowDimensions()
   const isNarrowWeb = viewportWidth < 768
+  // Wide desktop gets a two-column field grid; mobile web keeps the stacked
+  // single column. Native iOS uses the entirely separate layout above.
+  const isWideWeb = viewportWidth >= 1024
   const webPaddingH = isNarrowWeb ? 16 : viewportWidth < 1024 ? 32 : 60
+  const faintColor = isDark ? '#525252' : '#C4BEB4'
+
+  // Quiet placeholder for an empty read-only field — reads as "not set yet"
+  // instead of a bare em-dash. Only shown when viewing (not editing).
+  const EmptyValue = ({ label }: { label: string }) => (
+    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: faintColor, fontStyle: 'italic' }}>
+      {label}
+    </Text>
+  )
 
   return (
     <ScrollView style={{ flex: 1, backgroundColor: isDark ? '#171717' : '#FAFAF7' }}>
       <View
         style={{
-          maxWidth: 900,
+          maxWidth: isWideWeb ? 1080 : 900,
           width: '100%',
           alignSelf: 'center',
           padding: isNarrowWeb ? 20 : 40,
@@ -1047,8 +1059,10 @@ export default function Profile() {
           </View>
         </View>
 
-        {/* Birthday only */}
-        <View style={{ flexDirection: isNarrowWeb ? 'column' : 'row', gap: isNarrowWeb ? 20 : 28 }}>
+        {/* Birthday + Center — side by side on wide desktop, stacked otherwise.
+            Both are compact fields, so pairing them tightens the page and uses
+            the extra width instead of leaving a tall, sparse single column. */}
+        <View style={{ flexDirection: isWideWeb ? 'row' : 'column', gap: isWideWeb ? 28 : (isNarrowWeb ? 20 : 28) }}>
           <View style={{ flex: 1, gap: 8 }}>
             <Text style={labelStyle}>Birthday</Text>
             {isEditing ? (
@@ -1071,9 +1085,13 @@ export default function Profile() {
                   borderColor,
                 }}
               >
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: textColor }}>
-                  {formatBirthday(profileData.birthday) || '—'}
-                </Text>
+                {profileData.birthday ? (
+                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: textColor }}>
+                    {formatBirthday(profileData.birthday)}
+                  </Text>
+                ) : (
+                  <EmptyValue label="Not added yet" />
+                )}
               </View>
             )}
             {errors.birthday && (
@@ -1089,59 +1107,11 @@ export default function Profile() {
               </Text>
             )}
           </View>
-        </View>
 
-        {/* Bio */}
-        <View style={{ gap: 8 }}>
-          <Text style={labelStyle}>Bio</Text>
-          <TextInput
-            ref={bioRef}
-            defaultValue={profileData.bio}
-            onChangeText={(v) => {
-              draftBio.current = v
-            }}
-            multiline
-            textAlignVertical="top"
-            placeholderTextColor="#9ca3af"
-            style={[multilineInputStyle, !isEditing && hiddenStyle]}
-          />
-          {!isEditing && (
-            <View
-              style={{
-                paddingHorizontal: 16,
-                paddingVertical: 14,
-                backgroundColor: cardBg,
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor,
-                minHeight: 80,
-              }}
-            >
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 15,
-                  color: mutedTextColor,
-                  lineHeight: 24,
-                }}
-              >
-                {profileData.bio || '—'}
-              </Text>
-            </View>
-          )}
-          {errors.bio && (
-            <Text
-              style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 6 }}
-            >
-              {errors.bio}
-            </Text>
-          )}
-        </View>
-
-        {/* Center */}
-        <View style={{ gap: 8 }}>
-          <Text style={labelStyle}>Center</Text>
-          {isEditing ? (
+          {/* Center */}
+          <View style={{ flex: 1, gap: 8 }}>
+            <Text style={labelStyle}>Center</Text>
+            {isEditing ? (
             <View
               style={{
                 position: 'relative',
@@ -1249,21 +1219,86 @@ export default function Profile() {
                 borderColor,
               }}
             >
-              <MapPin size={18} color={mutedTextColor} style={{ marginTop: 2 }} />
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 15,
-                  color: mutedTextColor,
-                  flex: 1,
-                  lineHeight: 22,
-                }}
-              >
-                {profileData.centerID
-                  ? allCenters.find((c) => c.centerID === profileData.centerID)?.name || '—'
-                  : '—'}
-              </Text>
+              {(() => {
+                const centerName = profileData.centerID
+                  ? allCenters.find((c) => c.centerID === profileData.centerID)?.name
+                  : undefined
+                return (
+                  <>
+                    <MapPin size={18} color={centerName ? mutedTextColor : faintColor} style={{ marginTop: 2 }} />
+                    {centerName ? (
+                      <Text
+                        style={{
+                          fontFamily: 'Inclusive Sans',
+                          fontSize: 15,
+                          color: mutedTextColor,
+                          flex: 1,
+                          lineHeight: 22,
+                        }}
+                      >
+                        {centerName}
+                      </Text>
+                    ) : (
+                      <View style={{ flex: 1 }}>
+                        <EmptyValue label="No center selected" />
+                      </View>
+                    )}
+                  </>
+                )
+              })()}
             </View>
+          )}
+          </View>
+        </View>
+
+        {/* Bio — full width below the Birthday + Center row */}
+        <View style={{ gap: 8 }}>
+          <Text style={labelStyle}>Bio</Text>
+          <TextInput
+            ref={bioRef}
+            defaultValue={profileData.bio}
+            onChangeText={(v) => {
+              draftBio.current = v
+            }}
+            multiline
+            textAlignVertical="top"
+            placeholderTextColor="#9ca3af"
+            style={[multilineInputStyle, !isEditing && hiddenStyle]}
+          />
+          {!isEditing && (
+            <View
+              style={{
+                paddingHorizontal: 16,
+                paddingVertical: 14,
+                backgroundColor: cardBg,
+                borderRadius: 12,
+                borderWidth: 1,
+                borderColor,
+                minHeight: 80,
+              }}
+            >
+              {profileData.bio ? (
+                <Text
+                  style={{
+                    fontFamily: 'Inclusive Sans',
+                    fontSize: 15,
+                    color: mutedTextColor,
+                    lineHeight: 24,
+                  }}
+                >
+                  {profileData.bio}
+                </Text>
+              ) : (
+                <EmptyValue label="No bio yet — tap Edit Profile to add one" />
+              )}
+            </View>
+          )}
+          {errors.bio && (
+            <Text
+              style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 6 }}
+            >
+              {errors.bio}
+            </Text>
           )}
         </View>
 


### PR DESCRIPTION
Desktop web design pass. Home (≥1024px web) → centered two-column (schedule + right rail) instead of a stranded mobile column; Profile (≥1024px) → wider two-column field grid + quiet empty-state placeholders. Mobile/native unchanged (gated on web+width). Explore/Feed already had desktop layouts (untouched). 187 FE tests green; visual-QA before/after at 1440px, 0 console errors.