### PR TITLE
Fix web center detail crash (board -> boardMessages)

### DIFF
--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -179,7 +179,7 @@ export default function CenterDetailPanel({
             tabs={['About', 'Thread', 'Events']}
             activeTab={activeTab}
             onTabChange={setActiveTab}
-            counts={{ Thread: board.messages.length, Events: events.length }}
+            counts={{ Thread: boardMessages.length, Events: events.length }}
           />
         </View>
 


### PR DESCRIPTION
`CenterDetailPanel.web` referenced an undefined `board` in the `UnderlineTabBar` count props (`board.messages.length`), so the desktop center detail panel (opened from Explore) threw `ReferenceError: board is not defined` on every render. Fixed to use the in-scope `boardMessages` array.

- Root cause of "error when navigating to center pages" on web desktop.
- Typecheck clean for the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)