### PR TITLE
Web detail panels: single-view, no tabs (match iOS)

### DIFF
--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { View, Text, Image, ScrollView, Pressable, Linking } from 'react-native'
 import { MapPin, Globe, Phone, User, ChevronLeft, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import CopyLinkButton from '../ui/CopyLinkButton'
-import UnderlineTabBar from '../ui/UnderlineTabBar'
+import { DetailSection } from '../ui'
 import { useBoard, type CenterDisplay } from '../../hooks/useApiData'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
@@ -39,7 +39,6 @@ export default function CenterDetailPanel({
 }: CenterDetailPanelProps) {
   const colors = useDetailColors()
   const { user } = useUser()
-  const [activeTab, setActiveTab] = useState('About')
 
   const handleAddressPress = () => {
     const query = encodeURIComponent(center.address)
@@ -174,19 +173,8 @@ export default function CenterDetailPanel({
           resizeMode="cover"
         />
 
-        <View style={{ paddingTop: 8 }}>
-          <UnderlineTabBar
-            tabs={['About', 'Thread', 'Events']}
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            counts={{ Thread: boardMessages.length, Events: events.length }}
-          />
-        </View>
-
-        {/* Content area */}
-        <View style={{ paddingHorizontal: 24, paddingTop: 20, paddingBottom: 32 }}>
-          {activeTab === 'About' && (
-            <>
+        {/* ── DETAILS ─────────────────────────────────────────────── */}
+        <DetailSection title="Details" first>
           {/* Point of contact subtitle */}
           {center.pointOfContact ? (
             <Text
@@ -358,24 +346,11 @@ export default function CenterDetailPanel({
               </View>
             ) : null}
           </View>
-            </>
-          )}
+        </DetailSection>
 
-          {activeTab === 'Thread' && (
-            <ThreadPanel
-              messages={boardMessages}
-              colors={colors}
-              emptyTitle="Be the first to post"
-              emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
-              composerPlaceholder="Write to the board..."
-              composerState={canPostToThread ? 'open' : 'locked'}
-              onSubmitPost={handleCreateThreadPost}
-            />
-          )}
-
-          {activeTab === 'Events' && (
-            <>
-              {events.length > 0 ? (
+        {/* ── UPCOMING EVENTS ──────────────────────────────────────── */}
+        <DetailSection title="Upcoming Events" count={events.length} contentStyle={{ gap: 8 }}>
+          {events.length > 0 ? (
                 <View style={{ gap: 8 }}>
                   {events.map((event) => {
                     const { month, day } = formatDateCallout(event.date)
@@ -466,9 +441,20 @@ export default function CenterDetailPanel({
                   </Text>
                 </View>
               )}
-            </>
-          )}
-        </View>
+        </DetailSection>
+
+        {/* ── BOARD ───────────────────────────────────────────────── */}
+        <DetailSection title="Board" count={boardMessages.length} contentStyle={{ paddingHorizontal: 0 }}>
+          <ThreadPanel
+            messages={boardMessages}
+            colors={colors}
+            emptyTitle="Be the first to post"
+            emptySubtitle={`Ask about rides, what to bring, or anything else for ${center.name}.`}
+            composerPlaceholder="Write to the board..."
+            composerState={canPostToThread ? 'open' : 'locked'}
+            onSubmitPost={handleCreateThreadPost}
+          />
+        </DetailSection>
       </ScrollView>
     </View>
   )

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { View, Text, Image, ScrollView, Pressable, ActivityIndicator, Linking } from 'react-native'
 import { MapPin, Users, User, Clock, CheckCircle, ChevronLeft, Pencil, ExternalLink, Trash2 } from 'lucide-react-native'
 import CopyLinkButton from '../ui/CopyLinkButton'
 import Badge from '../ui/Badge'
-import UnderlineTabBar from '../ui/UnderlineTabBar'
+import { DetailSection } from '../ui'
 import Avatar from '../ui/Avatar'
 import PrimaryButton from '../ui/buttons/PrimaryButton'
 import DestructiveButton from '../ui/buttons/DestructiveButton'
@@ -663,54 +663,41 @@ function RegisteredContent({
   boardMessages: BoardMessage[]
   onSubmitPost: (body: string) => Promise<void>
 }) {
-  const [activeTab, setActiveTab] = useState('Details')
-
   return (
     <View style={{ flex: 1 }}>
-      <View style={{ paddingTop: 8 }}>
-        <UnderlineTabBar
-          tabs={['Details', 'Thread', 'People']}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-          counts={{ Thread: boardMessages.length }}
-        />
-      </View>
-
       <ScrollView
         style={{ flex: 1 }}
         showsVerticalScrollIndicator={false}
       >
-        {activeTab === 'Details' && (
-          <View
-            style={{
-              paddingHorizontal: 24,
-              paddingTop: 20,
-              paddingBottom: 24,
-              gap: 20,
-            }}
-          >
-            {/* Date & time */}
-            <View className="flex-row items-center" style={{ gap: 12 }}>
-              <MetaIcon icon={Clock} color="#E8862A" colors={colors} />
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 14,
-                  color: colors.text,
-                }}
-              >
-                {formatRelativeDateTime(event.date, event.time)}
-              </Text>
-            </View>
-
-            <MetaSection event={event} attendees={attendees} colors={colors} />
-            {event.description && (
-              <AboutSection description={event.description} colors={colors} />
-            )}
+        {/* ── DETAILS ───────────────────────────────────────────── */}
+        <DetailSection title="Details" first contentStyle={{ gap: 20 }}>
+          {/* Date & time */}
+          <View className="flex-row items-center" style={{ gap: 12 }}>
+            <MetaIcon icon={Clock} color="#E8862A" colors={colors} />
+            <Text
+              style={{
+                fontFamily: 'Inclusive Sans',
+                fontSize: 14,
+                color: colors.text,
+              }}
+            >
+              {formatRelativeDateTime(event.date, event.time)}
+            </Text>
           </View>
-        )}
 
-        {activeTab === 'Thread' && (
+          <MetaSection event={event} attendees={attendees} colors={colors} />
+          {event.description && (
+            <AboutSection description={event.description} colors={colors} />
+          )}
+        </DetailSection>
+
+        {/* ── PEOPLE ────────────────────────────────────────────── */}
+        <DetailSection title="People" count={attendees.length} contentStyle={{ paddingHorizontal: 0 }}>
+          <PeopleTab attendees={attendees} colors={colors} />
+        </DetailSection>
+
+        {/* ── DISCUSSION ────────────────────────────────────────── */}
+        <DetailSection title="Discussion" count={boardMessages.length} contentStyle={{ paddingHorizontal: 0 }}>
           <ThreadPanel
             messages={boardMessages}
             colors={colors}
@@ -720,10 +707,7 @@ function RegisteredContent({
             composerState={canPostToThread ? 'open' : 'locked'}
             onSubmitPost={onSubmitPost}
           />
-        )}
-
-        {activeTab === 'People' && <PeopleTab attendees={attendees} colors={colors} />}
-
+        </DetailSection>
       </ScrollView>
     </View>
   )


### PR DESCRIPTION
Matches the iOS change where event/center detail dropped tabs and stack everything in one view. The desktop center and event detail panels (rendered on Explore) now stack their sections under `DetailSection` headers in the existing ScrollView instead of `UnderlineTabBar`.

- **Center:** Details → Upcoming Events → Board
- **Event (registered):** Details → People → Discussion
- Removes `UnderlineTabBar` + `activeTab` from both panels; reuses the same `DetailSection` pattern as the mobile center screen.

Verified: center + event (registered and unregistered) render stacked with no tabs and no console errors; 187/187 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)