### PR TITLE
Home (mobile): stack schedule above center/boards

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -341,13 +341,16 @@ export default function HomeScreen() {
       }}
       showsVerticalScrollIndicator={false}
     >
+      {/* Mobile single column: lead with the schedule (the desktop "main"
+          column — Up Next + Coming Up), then wrap the center/boards content
+          (the desktop right rail) below it, so the order matches desktop. */}
       <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center', gap: 22 }}>
         {greeting}
         {welcomeBanner}
-        {firstRunOverview}
         {upNextSection}
-        {boardsSection}
         {weekSection}
+        {firstRunOverview}
+        {boardsSection}
       </View>
     </ScrollView>
   )


### PR DESCRIPTION
On mobile web, the Home single-column order now leads with the schedule (Up Next + Coming Up — the desktop "main" column), then wraps the center/boards content (the desktop right rail) below it. Matches the desktop two-column semantics. Desktop layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)