### PR TITLE
Mobile web: profile avatar top-right, drop from bottom nav (match iOS)

### DIFF
--- a/packages/frontend/components/ui/TabHeader.tsx
+++ b/packages/frontend/components/ui/TabHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Text, Pressable, Platform } from 'react-native'
+import { View, Text, Pressable } from 'react-native'
 import { useRouter } from 'expo-router'
 import { Plus, Settings, Bell } from 'lucide-react-native'
 import { usePostHog } from 'posthog-react-native'
@@ -21,8 +21,8 @@ interface TabHeaderProps {
   rightContent?: React.ReactNode
   /**
    * Show the profile avatar as a top-right entry point to `/profile`.
-   * Native only — on web the profile entry lives in WebHeader / WebBottomNav.
-   * Defaults to true; pass false on the profile screen itself.
+   * Shown on native and on mobile web (matching iOS); desktop web uses its
+   * own WebHeader avatar. Defaults to true; pass false on the profile screen.
    */
   showProfile?: boolean
 }
@@ -144,7 +144,7 @@ export default function TabHeader({
             <ActionIcon />
           </Pressable>
         )}
-        {showProfile && Platform.OS !== 'web' && user && (
+        {showProfile && user && (
           <Pressable
             onPress={() => {
               posthog?.capture('nav_profile_opened')

--- a/packages/frontend/components/ui/WebBottomNav.tsx
+++ b/packages/frontend/components/ui/WebBottomNav.tsx
@@ -2,20 +2,19 @@ import { View, Text, Pressable } from 'react-native'
 import { usePathname, useRouter } from 'expo-router'
 import { House, Compass, Newspaper } from 'lucide-react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useUser, useTheme } from '../contexts'
-import Avatar from './Avatar'
+import { useTheme } from '../contexts'
 
+// Profile is no longer a bottom-bar tab — it's reached via the avatar in the
+// top-right of TabHeader (matching iOS). Bottom nav is just the primary tabs.
 const NAV_ITEMS = [
   { label: 'Home', href: '/', icon: House },
   { label: 'Explore', href: '/explore', icon: Compass },
   { label: 'Feed', href: '/feed', icon: Newspaper },
-  { label: 'Profile', href: '/profile', icon: null },
 ] as const
 
 export default function WebBottomNav() {
   const pathname = usePathname()
   const router = useRouter()
-  const { user } = useUser()
   const { isDark } = useTheme()
   const insets = useSafeAreaInsets()
 
@@ -49,20 +48,7 @@ export default function WebBottomNav() {
             accessibilityLabel={label}
             style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 2 }}
           >
-            {href === '/profile' ? (
-              <Avatar
-                image={user?.profileImage ?? undefined}
-                name={
-                  user?.firstName
-                    ? `${user.firstName} ${user.lastName ?? ''}`.trim()
-                    : user?.username
-                }
-                size={24}
-                style={{ borderWidth: on ? 2 : 0, borderColor: ACTIVE }}
-              />
-            ) : Icon ? (
-              <Icon size={24} color={color} />
-            ) : null}
+            <Icon size={24} color={color} />
             <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 10, color }}>{label}</Text>
           </Pressable>
         )

--- a/packages/frontend/src/__tests__/app/WebBottomNav.test.tsx
+++ b/packages/frontend/src/__tests__/app/WebBottomNav.test.tsx
@@ -27,13 +27,12 @@ describe('WebBottomNav', () => {
     ;(useUser as jest.Mock).mockReturnValue({ user: { username: 'kish' } })
   })
 
-  it('renders all five tabs', () => {
+  it('renders the primary tabs (Profile lives in the header, not the bottom bar)', () => {
     render(<WebBottomNav />)
     expect(screen.getByText('Home')).toBeTruthy()
     expect(screen.getByText('Explore')).toBeTruthy()
     expect(screen.getByText('Feed')).toBeTruthy()
-    expect(screen.getByText('Messages')).toBeTruthy()
-    expect(screen.getByText('Profile')).toBeTruthy()
+    expect(screen.queryByText('Profile')).toBeNull()
   })
 
   it('navigates to the tab route when pressed', () => {


### PR DESCRIPTION
Matches the iOS change: on **mobile web** the profile entry is now the **avatar in the top-right** of the header, and **Profile is removed from the bottom nav** (Home / Explore / Feed only). Desktop web keeps its existing WebHeader avatar.

- `TabHeader`: show the profile avatar on web too (drops the `Platform !== 'web'` gate).
- `WebBottomNav`: primary tabs only; removed the profile item + unused imports.
- Verified on mobile web (390px): avatar top-right next to the bell; no Profile tab in the bottom bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)