### PR TITLE
Explore map (web): consolidate controls, top-left on mobile

### DIFF
--- a/packages/frontend/components/map/Map.web.tsx
+++ b/packages/frontend/components/map/Map.web.tsx
@@ -104,56 +104,37 @@ const CustomControls = memo<CustomControlsProps>(({ mapRef, isDark }) => {
     )
   }, [mapRef])
 
+  // One cohesive control stack (zoom in / zoom out / locate) instead of two
+  // detached floating groups. On mobile the transparent header (create + profile
+  // avatar) owns the top-right, so the controls sit top-LEFT to avoid overlap;
+  // on desktop the header is a solid bar above the map, so they go bottom-right.
+  const btnClass = `w-9 h-9 border-none cursor-pointer flex items-center justify-center transition-all duration-150 outline-none
+    ${isDark ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700'}
+    active:bg-orange-500/15`
+  const divider = <div className={`h-px ${isDark ? 'bg-white/10' : 'bg-black/[0.08]'}`} />
   return (
-    <>
-      {/* Zoom controls */}
-      <div className="absolute top-2.5 md:top-auto md:bottom-[52px] right-4 z-[1000] pointer-events-auto">
-        <div className="flex flex-col rounded-lg overflow-hidden shadow-[0_2px_6px_rgba(0,0,0,0.2)]">
-          <button
-            className={`w-9 h-9 border-none cursor-pointer flex items-center justify-center transition-all duration-150 outline-none
-              ${isDark ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700'}
-              active:bg-orange-500/15`}
-            onClick={handleZoomIn}
-            title="Zoom in"
-            aria-label="Zoom in"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-          </button>
-          <div className={`h-px ${isDark ? 'bg-white/10' : 'bg-black/[0.08]'}`} />
-          <button
-            className={`w-9 h-9 border-none cursor-pointer flex items-center justify-center transition-all duration-150 outline-none
-              ${isDark ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700'}
-              active:bg-orange-500/15`}
-            onClick={handleZoomOut}
-            title="Zoom out"
-            aria-label="Zoom out"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {/* Location button */}
-      <div className="absolute top-[92px] md:top-auto md:bottom-2.5 right-4 z-[1000] pointer-events-auto">
-        <button
-          className={`w-9 h-9 border-none rounded-lg cursor-pointer flex items-center justify-center shadow-[0_2px_6px_rgba(0,0,0,0.2)] transition-all duration-150 outline-none
-            ${isDark ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700'}
-            active:bg-orange-500/15`}
-          onClick={handleLocate}
-          title="Show my location"
-          aria-label="Show my location"
-        >
+    <div className="absolute top-2.5 left-4 md:top-auto md:left-auto md:bottom-2.5 md:right-4 z-[1000] pointer-events-auto">
+      <div className="flex flex-col rounded-lg overflow-hidden shadow-[0_2px_6px_rgba(0,0,0,0.2)]">
+        <button className={btnClass} onClick={handleZoomIn} title="Zoom in" aria-label="Zoom in">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+        {divider}
+        <button className={btnClass} onClick={handleZoomOut} title="Zoom out" aria-label="Zoom out">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+        {divider}
+        <button className={btnClass} onClick={handleLocate} title="Show my location" aria-label="Show my location">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <polygon points="3 11 22 2 13 21 11 13 3 11" />
           </svg>
         </button>
       </div>
-    </>
+    </div>
   )
 })
 


### PR DESCRIPTION
The Explore map's zoom +/- group and locate button were two separate floating blobs at the top-right; on mobile the transparent header (Create + the new profile avatar) also sits top-right, so they overlapped.

Now they're **one cohesive control stack** (zoom in / zoom out / locate), positioned **top-left on mobile** (clear of the header actions) and **bottom-right on desktop** (solid header above, no conflict).

Verified on mobile (390px) and desktop (1440px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)