### PR TITLE
Explore (mobile web): remove redundant + create from header

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -213,17 +213,11 @@ export default function TabLayout() {
               tabBarShowLabel: false,
               title: 'Explore',
               headerTransparent: !isDesktopWeb,
+              // No header create action — creating an event lives in the Explore
+              // sheet itself, so the mobile header just shows the profile avatar.
               header: isDesktopWeb
                 ? () => <WebHeader />
-                : () => (
-                    <TabHeader
-                      transparent
-                      borderAvatar
-                      {...(Platform.OS === 'web'
-                        ? { action: 'create' as const, onActionPress: () => router.push('/events/form') }
-                        : {})}
-                    />
-                  ),
+                : () => <TabHeader transparent borderAvatar />,
               tabBarIcon: ({ color, size }) => <Compass size={size} color={color} />,
             }}
           />


### PR DESCRIPTION
The Explore mobile header had a **+** create action next to the profile avatar, but creating an event already lives in the Explore sheet, so it was redundant (native explore has no header create action). The header now just shows the profile avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)