### PR TITLE
fix(web): open event/center detail on desktop (route to Explore panel)

### DIFF
--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -385,7 +385,7 @@ function EventPanelInner({
       <AuthPromptModal
         visible={showAuthPrompt}
         onClose={() => setShowAuthPrompt(false)}
-        returnTo={`/?detail=event&id=${eventId}`}
+        returnTo={`/explore?detail=event&id=${eventId}`}
         eventTitle={event.title}
       />
     </>

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -26,7 +26,10 @@ export default function CenterDetailWeb() {
 
   useEffect(() => {
     if (!initiallyMobile.current && id) {
-      router.replace(`/?detail=center&id=${id}`)
+      // Desktop detail is rendered by the Explore screen's panel (it consumes
+      // ?detail=&id= and shows the CenterDetailPanel column). Route there, not
+      // to "/" — Home has no detail consumer, so the panel never opened.
+      router.replace(`/explore?detail=center&id=${id}`)
     } else if (!id) {
       router.replace('/')
     }

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -32,7 +32,11 @@ export default function EventDetailWeb() {
 
   useEffect(() => {
     if (!initiallyMobile.current && id) {
-      router.replace(`/?detail=event&id=${id}`)
+      // Desktop detail is rendered by the Explore screen's panel (it consumes
+      // ?detail=&id=, shows the EventDetailPanel column, and pans the map).
+      // Route there, not to "/" (Home has no detail consumer, so the panel
+      // never opened — the desktop detail bug).
+      router.replace(`/explore?detail=event&id=${id}`)
     } else if (!id) {
       router.replace('/')
     }


### PR DESCRIPTION
## Problem (P0, blocks desktop-web testing)
On **desktop web**, tapping an event or center card set the URL to `/?detail=…&id=…` and showed a spinner, but the detail panel never rendered. Mobile web is fine (it uses the full `/events/[id]` route).

## Root cause
The `?detail=` consumer exists **only** on the Explore screen (`explore.web.tsx`): it reads `detail` + `id`, sets `selectedItem`, and renders `EventDetailPanel.web` / `CenterDetailPanel.web` in the 440px column while panning the map. The `/` (Home) route has **no** consumer, so redirecting detail deep-links to `/?detail=…` left them on Home with nothing rendered.

## Fix
Point the desktop redirects (and the Explore auth `returnTo`) at `/explore?detail=…` so they land where the panel is actually rendered:
- `app/events/[id].web.tsx`
- `app/center/[id].web.tsx`
- `app/(tabs)/explore.web.tsx` (returnTo)

No logic change — routes into the existing, working Explore detail path.

## Verification
- `npm test` (frontend): **187 passed**.
- Needs an end-to-end check on the preview **after redeploy** (see note below).

## Notes for review
- This shows desktop detail **inside the Explore tab** (with the map), matching how the panel was built. If we'd prefer it to overlay the current tab, that's a larger follow-up (a global detail overlay) — flagging since web nav is being redesigned in parallel.
- Scope: event + center only (what Explore consumes). `feed`/`chat` detail deep-links are separate and out of scope here.
- Related: the `v2preview` deploy is **stale** (behind #308–#313), which is why several already-fixed issues still appear in testing. A redeploy is needed to validate this too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)