### PR TITLE
fix(feed): drop "groups" from search placeholder (out of v2 scope)

### DIFF
--- a/packages/frontend/components/feed/FeedHeader.tsx
+++ b/packages/frontend/components/feed/FeedHeader.tsx
@@ -55,7 +55,7 @@ export function FeedHeader({
           <TextInput
             value={query}
             onChangeText={onChangeQuery}
-            placeholder="Search posts, people, groups"
+            placeholder="Search posts and people"
             placeholderTextColor={colors.textFaint}
             style={{
               flex: 1,

--- a/packages/frontend/components/feed/FeedWorkspace.tsx
+++ b/packages/frontend/components/feed/FeedWorkspace.tsx
@@ -265,7 +265,7 @@ function FeedContextRail({
         <TextInput
           value={query}
           onChangeText={onChangeQuery}
-          placeholder="Search posts, people, groups"
+          placeholder="Search posts and people"
           placeholderTextColor={colors.textFaint}
           style={{ flex: 1, fontSize: 14, color: colors.text, paddingVertical: 0, outlineStyle: 'none' } as any}
         />


### PR DESCRIPTION
## What
Feed search placeholder said **"Search posts, people, groups"**, but user-created **groups are out of v2** (boards attach to centers + events only — PRD §3/§7). Changed to **"Search posts and people"** in both feed surfaces:
- `components/feed/FeedHeader.tsx`
- `components/feed/FeedWorkspace.tsx`

## Why
Spotted during the v2 testing walkthrough — testers shouldn't see UI implying a feature that's intentionally not in v2.

Copy-only change. No tests reference the string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)