### PR TITLE
fix(feed): empty state explains the feed + routes to Explore

### DIFF
--- a/packages/frontend/components/feed/FeedList.tsx
+++ b/packages/frontend/components/feed/FeedList.tsx
@@ -63,12 +63,14 @@ export function FeedList({
 
   if (posts.length === 0) {
     return (
-      <View style={{ paddingVertical: 40, alignItems: 'center', gap: 8 }}>
-        <Text style={{ fontSize: 16, color: colors.text }}>No posts yet</Text>
-        <Text style={{ fontSize: 13, color: colors.textMuted, textAlign: 'center' }}>
+      <View style={{ paddingVertical: 40, paddingHorizontal: 16, alignItems: 'center', gap: 8 }}>
+        <Text style={{ fontSize: 16, color: colors.text }}>
+          {hasQuery ? 'No posts found' : 'Your community feed'}
+        </Text>
+        <Text style={{ fontSize: 13, lineHeight: 19, color: colors.textMuted, textAlign: 'center' }}>
           {hasQuery
             ? 'No board posts match that search.'
-            : 'No posts yet. Be the first to share something on your boards.'}
+            : 'Posts from your center and the events you RSVP to show up here. Use the Explore tab to find your center or an event and join the conversation.'}
         </Text>
       </View>
     )

--- a/packages/frontend/components/feed/FeedWorkspace.tsx
+++ b/packages/frontend/components/feed/FeedWorkspace.tsx
@@ -87,15 +87,15 @@ export function FeedWorkspace({
         <EmptyPanel title="No posts found" subtitle="Try a different search." colors={colors} />
       ) : (
         <EmptyPanel
-          title="Start the conversation"
+          title={groups.length > 0 ? 'Start the conversation' : 'Your community feed'}
           subtitle={
             groups.length > 0
-              ? 'Share the first post with your community.'
-              : 'Join a center or register for an event to start posting with your community.'
+              ? "You're in. Share the first post with your center and event boards."
+              : 'Posts from your center and the events you RSVP to show up here. Find your center or an event in Explore to join the conversation.'
           }
           colors={colors}
-          actionLabel={groups.length > 0 ? 'Write a post' : undefined}
-          onAction={groups.length > 0 ? onCompose : undefined}
+          actionLabel={groups.length > 0 ? 'Write a post' : 'Go to Explore'}
+          onAction={groups.length > 0 ? onCompose : onRequestAccess}
         />
       )
     ) : (


### PR DESCRIPTION
## What
The Feed empty state (members with no boards yet) just said *"Join a center or register for an event to start posting"* with no explanation or path forward (see testing screenshot). Reworked both surfaces:

- **Desktop** (`FeedWorkspace`): **"Your community feed"** + one line on what lands here (your center + RSVP'd events), with a **"Go to Explore"** button (reuses the existing `onRequestAccess` → `/explore`).
- **Mobile** (`FeedList`): same explanation, pointing to the Explore tab.

Kept "Start the conversation / Write a post" for members who *do* have boards but no posts yet.

## Why
From v2 testing (issue #319). Parity with the Home welcome empty state; human, no redundancy; no "groups" wording (out of v2 scope).

## Verification
`npm test` (frontend): **187 passed**. (Live verify after the preview redeploy — #317.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)