### PR TITLE
fix(auth): say "invite link" + accept a pasted link or a raw code

### DIFF
--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -42,7 +42,11 @@ const SELECT_COLUMNS = `code, label, verification_level, is_active, created_at,
   created_by_user_id, expires_at, max_uses, uses_count`
 
 function normalizeCode(code: string): string {
-  return code.trim().toUpperCase()
+  // Tolerate a pasted invite LINK (janata.app/i/<code>) as well as a raw code,
+  // so the client can show "invite link" and either form validates server-side.
+  const trimmed = (code ?? '').trim()
+  const fromLink = trimmed.match(/janata\.app\/i\/([^/?#\s]+)/i)
+  return (fromLink ? fromLink[1] : trimmed).trim().toUpperCase()
 }
 
 function isCodeUsable(row: InviteCodeRow, now: Date = new Date()): boolean {

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -14,6 +14,7 @@ import { useAnalytics } from '../utils/analytics'
 import { AuthInput, Logo, PrimaryButton } from '../components/ui'
 import { useUser, useTheme } from '../components/contexts'
 import { validateEmail, validatePassword } from '../utils'
+import { extractInviteCode } from '../utils/validation'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
 import { API_BASE_URL } from '../src/config/api'
@@ -118,7 +119,7 @@ export default function AuthScreen() {
       const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: inviteCode }),
+        body: JSON.stringify({ code: extractInviteCode(inviteCode) }),
       })
       const data = await response.json()
       if (data.valid) {
@@ -153,7 +154,7 @@ export default function AuthScreen() {
       return
     }
     try {
-      const result = await signup(username, password, inviteCode)
+      const result = await signup(username, password, extractInviteCode(inviteCode))
       if (result.success) {
         track('signup_success', { source: 'auth' })
         router.replace(params.returnTo ? `/onboarding?returnTo=${encodeURIComponent(params.returnTo)}` : '/onboarding')
@@ -282,7 +283,7 @@ export default function AuthScreen() {
                 {authStep === 'login'
                   ? 'Welcome back.'
                   : authStep === 'invite-code'
-                  ? 'Enter invite code.'
+                  ? 'Enter your invite link.'
                   : authStep === 'signup'
                   ? 'Join the community.'
                   : 'Welcome.'}
@@ -295,7 +296,7 @@ export default function AuthScreen() {
                 {authStep === 'login'
                   ? 'Enter your password to continue'
                   : authStep === 'invite-code'
-                  ? 'Enter your beta invite code to proceed'
+                  ? 'Paste your invite link or code to continue'
                   : authStep === 'signup'
                   ? 'Create your account to get started'
                   : 'Enter your email to get started'}
@@ -339,7 +340,7 @@ export default function AuthScreen() {
               {authStep === 'invite-code' && (
                 <View>
                   <AuthInput
-                    placeholder="Invite Code"
+                    placeholder="Invite link or code"
                     onChangeText={handleInviteCodeChange}
                     value={inviteCode}
                     secureTextEntry={false}
@@ -385,7 +386,7 @@ export default function AuthScreen() {
                {authStep === 'login'
                    ? 'Log In'
                    : authStep === 'invite-code'
-                   ? 'Verify Code'
+                   ? 'Continue'
                    : authStep === 'signup'
                    ? 'Sign Up'
                   : 'Continue'}

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'expo-router'
 import { useUser } from '../components/contexts'
 import { useAnalytics } from '../utils/analytics'
 import { validateEmail, validatePassword } from '../utils'
+import { extractInviteCode } from '../utils/validation'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -164,7 +165,7 @@ export default function AuthScreen() {
       return
     }
     try {
-      const result = await signup(username, password, inviteCode)
+      const result = await signup(username, password, extractInviteCode(inviteCode))
       if (result.success) {
         track('signup_success', { source: 'auth' })
         router.replace(returnTo ? `/onboarding?returnTo=${encodeURIComponent(returnTo)}` : '/onboarding')
@@ -190,7 +191,7 @@ export default function AuthScreen() {
       const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: inviteCode }),
+        body: JSON.stringify({ code: extractInviteCode(inviteCode) }),
       })
       const data = await response.json()
       if (data.valid) {
@@ -300,7 +301,7 @@ export default function AuthScreen() {
     authStep === 'login'
       ? 'Welcome back.'
       : authStep === 'invite-code'
-        ? 'Enter invite code.'
+        ? 'Enter your invite link.'
         : authStep === 'signup'
           ? 'Join the community.'
           : 'Welcome.'
@@ -309,7 +310,7 @@ export default function AuthScreen() {
     authStep === 'login'
       ? 'Enter your password to continue'
       : authStep === 'invite-code'
-        ? 'Enter your beta invite code to proceed'
+        ? 'Paste your invite link or code to continue'
         : authStep === 'signup'
           ? 'Create your account to get started'
           : 'Enter your email to get started'
@@ -319,7 +320,7 @@ export default function AuthScreen() {
     : authStep === 'login'
       ? 'Sign In'
       : authStep === 'invite-code'
-        ? 'Verify Code'
+        ? 'Continue'
         : authStep === 'signup'
           ? 'Create Account'
           : 'Continue'
@@ -538,7 +539,7 @@ export default function AuthScreen() {
               <input
                 className="auth-input"
                 type="text"
-                placeholder="Invite Code"
+                placeholder="Invite link or code"
                 value={inviteCode}
                 onChange={handleInviteCodeChange}
                 autoComplete="off"

--- a/packages/frontend/utils/validation.ts
+++ b/packages/frontend/utils/validation.ts
@@ -40,3 +40,12 @@ export const validatePhoneNumber = (phoneNumber: string): boolean => {
   const phoneNumberRegex = /^\d{10}$/; // Exactly 10 digits
   return phoneNumberRegex.test(phoneNumber);
 };
+
+// Accept either a full invite LINK (e.g. https://janata.app/i/ABC123) or a raw
+// code. Returns the bare code so the UI can say "invite link" while the backend
+// keeps receiving a code. No-op for an already-bare code.
+export const extractInviteCode = (input: string): string => {
+  const trimmed = (input ?? "").trim();
+  const match = trimmed.match(/janata\.app\/i\/([^/?#\s]+)/i);
+  return (match ? match[1] : trimmed).trim();
+};


### PR DESCRIPTION
## What (#328)
The signup/verify screen said **"Enter invite code"** but we moved to invite **links**. Now:
- **Copy** (web + native `auth.tsx`/`auth.web.tsx`): "Enter your invite link." / "Paste your invite link or code to continue" / placeholder "Invite link or code" / button "Continue".
- **Accept both formats:** new `extractInviteCode()` (utils/validation) strips a `janata.app/i/<code>` link to its code (no-op for a bare code), applied at both submit paths (`/auth/validate-invite-code` + `signup`).
- **Backend defense-in-depth:** `normalizeCode()` (inviteCodes.ts) also tolerates a pasted link, so either form validates server-side regardless of client.

## Coordination
Keeps the canonical `janata.app/i/<code>` URL in sync with **#314** (Abhiram's member-side minting/deep-link). This PR only touches the signup/verify **entry** + parsing — not the minting or the `/i/` route.

## Verification
Frontend `npm test`: **187 passed**. Backend invite tests: **23 passed**. Backend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)