### PR TITLE
fix(admin): sevak crash — gate admin tabs by level (Moderation-only for sevaks)

### DIFF
--- a/packages/frontend/app/admin.web.tsx
+++ b/packages/frontend/app/admin.web.tsx
@@ -9,13 +9,18 @@ import UsersTab from '../components/admin/UsersTab'
 import InviteCodesTab from '../components/admin/InviteCodesTab'
 import NotificationsTab from '../components/admin/NotificationsTab'
 import ModerationTab from '../components/admin/ModerationTab'
-import { isSuperAdmin as checkSuperAdmin } from '../utils/admin'
+import { isSevakOrAdmin, hasAdminCapability } from '../utils/admin'
 import { useAnalytics } from '../utils/analytics'
 
 export default function AdminPage() {
   const { user, loading } = useUser()
   const { isDark } = useTheme()
   const { track } = useAnalytics()
+  // canEnter: sevak+ may open the app (Moderation). isAdmin: full admin (all
+  // tabs). Admin-only endpoints 403 for a sevak token, so we gate by isAdmin —
+  // not the localhost-masked isSuperAdmin.
+  const canEnter = isSevakOrAdmin(user)
+  const isAdmin = hasAdminCapability(user)
   const [activeTab, setActiveTab] = useState<AdminTab>('Centers')
 
   const handleTabChange = (tab: AdminTab) => {
@@ -23,16 +28,21 @@ export default function AdminPage() {
     track('admin_tab_changed', { tab, source: 'admin' })
   }
 
-  // TODO: backend must enforce admin auth on all admin-specific endpoints
-  const isAdmin = checkSuperAdmin(user)
-
   useEffect(() => {
-    if (!loading && !isAdmin) {
+    if (!loading && !canEnter) {
       router.replace('/(tabs)')
     }
-  }, [loading, isAdmin])
+  }, [loading, canEnter])
 
-  if (!loading && !isAdmin) {
+  // Sevaks only get Moderation — the 'Centers' default hits an admin-only
+  // endpoint that 403s for a sevak. Land them on Moderation once auth resolves.
+  useEffect(() => {
+    if (!loading && canEnter && !isAdmin) {
+      setActiveTab('Moderation')
+    }
+  }, [loading, canEnter, isAdmin])
+
+  if (!loading && !canEnter) {
     return null
   }
 
@@ -48,13 +58,15 @@ export default function AdminPage() {
 
   return (
     <View style={{ flex: 1, flexDirection: 'row', backgroundColor: pageBg }}>
-      <AdminSidebar activeTab={activeTab} onTabChange={handleTabChange} />
-      {activeTab === 'Centers' && <CentersTab />}
-      {activeTab === 'Events' && <EventsTab />}
-      {activeTab === 'Users' && <UsersTab />}
-      {activeTab === 'Invite Codes' && <InviteCodesTab />}
+      <AdminSidebar activeTab={activeTab} onTabChange={handleTabChange} isAdmin={isAdmin} />
+      {/* Admin-only tabs are gated by isAdmin so a sevak never mounts a tab
+          whose endpoint 403s. Moderation is available to sevak+. */}
+      {isAdmin && activeTab === 'Centers' && <CentersTab />}
+      {isAdmin && activeTab === 'Events' && <EventsTab />}
+      {isAdmin && activeTab === 'Users' && <UsersTab />}
+      {isAdmin && activeTab === 'Invite Codes' && <InviteCodesTab />}
       {activeTab === 'Moderation' && <ModerationTab />}
-      {activeTab === 'Notifications' && <NotificationsTab />}
+      {isAdmin && activeTab === 'Notifications' && <NotificationsTab />}
     </View>
   )
 }

--- a/packages/frontend/components/admin/AdminSidebar.tsx
+++ b/packages/frontend/components/admin/AdminSidebar.tsx
@@ -14,6 +14,8 @@ export type AdminTab =
 type AdminSidebarProps = {
   activeTab: AdminTab
   onTabChange: (tab: AdminTab) => void
+  // Full admins see every tab; sevaks (moderation-only) see just Moderation.
+  isAdmin: boolean
 }
 
 const tabs: { key: AdminTab; label: string; Icon: typeof Building2 }[] = [
@@ -25,10 +27,11 @@ const tabs: { key: AdminTab; label: string; Icon: typeof Building2 }[] = [
   { key: 'Notifications', label: 'Notifications', Icon: Bell },
 ]
 
-export default function AdminSidebar({ activeTab, onTabChange }: AdminSidebarProps) {
+export default function AdminSidebar({ activeTab, onTabChange, isAdmin }: AdminSidebarProps) {
   const { isDark } = useTheme()
 
   const inactiveColor = isDark ? '#A8A29E' : '#78716C'
+  const visibleTabs = isAdmin ? tabs : tabs.filter((t) => t.key === 'Moderation')
 
   return (
     <View
@@ -42,7 +45,7 @@ export default function AdminSidebar({ activeTab, onTabChange }: AdminSidebarPro
     >
       <Text style={styles.header}>Admin</Text>
 
-      {tabs.map(({ key, label, Icon }) => {
+      {visibleTabs.map(({ key, label, Icon }) => {
         const isActive = activeTab === key
         const color = isActive ? '#E8862A' : inactiveColor
 

--- a/packages/frontend/utils/admin.ts
+++ b/packages/frontend/utils/admin.ts
@@ -5,11 +5,34 @@ export const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 export const isLocal =
   typeof window !== 'undefined' && window.location?.hostname === 'localhost'
 
+export const ADMIN_LEVEL = 107
+export const SEVAK_LEVEL = 54
+
 export function isSuperAdmin(user: { email?: string | null; verificationLevel?: number } | null): boolean {
   if (!user) return false
   return (
     user.email === ADMIN_EMAIL ||
-    (user.verificationLevel !== undefined && user.verificationLevel >= 107) ||
+    (user.verificationLevel !== undefined && user.verificationLevel >= ADMIN_LEVEL) ||
     isLocal
   )
+}
+
+// Real admin capability — mirrors the backend adminMiddleware (level >= 107 or
+// the admin email) and does NOT include the localhost bypass. Use this to gate
+// admin-only tabs/endpoints so a sevak (or any local session) only sees what
+// their token can actually do, instead of crashing on a 403.
+export function hasAdminCapability(
+  user: { email?: string | null; verificationLevel?: number } | null
+): boolean {
+  if (!user) return false
+  return user.email === ADMIN_EMAIL || (user.verificationLevel ?? 0) >= ADMIN_LEVEL
+}
+
+// Who can open the admin app at all: admins (full), sevaks (Moderation only),
+// or local dev. Matches the backend moderatorMiddleware (level >= 54).
+export function isSevakOrAdmin(
+  user: { email?: string | null; verificationLevel?: number } | null
+): boolean {
+  if (!user) return false
+  return isSuperAdmin(user) || (user.verificationLevel ?? 0) >= SEVAK_LEVEL
 }


### PR DESCRIPTION
## Problem (#335)
Opening the admin app as a **Sevak** crashed: `Failed to load centers: Failed to fetch admin centers` (CentersTab.tsx loadCenters → fetchAdminCenters). The default **Centers** tab hits an admin-only endpoint (backend `adminMiddleware`, level ≥ 107) that **403s** for a sevak token. The frontend entry gate (`isSuperAdmin`) is `true` on localhost and didn't separate moderation-only sevaks from full admins, so a sevak landed on Centers and crashed.

## Fix (frontend; backend already enforces the right levels)
- **utils/admin:** `hasAdminCapability()` — real admin (level ≥ 107 or admin email, **no** localhost bypass) for capability gating; `isSevakOrAdmin()` — who may open the app (≥ 54, matching `moderatorMiddleware`).
- **admin.web:** enter if sevak+; **gate every admin-only tab's render** behind `hasAdminCapability` so a sevak never mounts a 403-ing tab; default sevaks to **Moderation**.
- **AdminSidebar:** non-admins see only the **Moderation** tab.

Net: a sevak gets their allowed Moderation surface; admins get all tabs (Centers loads for level ≥ 107).

## Verification
`npm test`: 187 passed. Live sevak-vs-admin check best done on the redeployed preview / a human dev-mode login (the local auth-boot doesn't pick up an injected token for automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)