### PR TITLE
Preview DB: seed the real center list, not 10 placeholders

### DIFF
--- a/migrations/seed_preview_data.sql
+++ b/migrations/seed_preview_data.sql
@@ -1,35 +1,29 @@
--- seed_preview_data.sql — dummy data for the v2 PREVIEW database only.
+-- seed_preview_data.sql — demo EVENTS for the v2 PREVIEW database only.
 --
--- Runs LAST in setup-preview-db.sh, after all migrations, so it's the
--- authoritative final state. Clears centers + events and inserts a known
--- set that exercises the v2 features:
+-- Runs LAST in deploy-v2preview.sh, AFTER the real center list
+-- (packages/backend/src/seed/centers.sql) has been loaded. It no longer
+-- touches the centers table, so the preview shows the full real center
+-- list (all 93, including Chinmaya Vrindavan and the India centers).
+--
+-- It clears events and inserts a small known set that exercises v2 features,
+-- each anchored to a REAL center id so everything lines up:
 --   - #192 official-event badge (is_official)
 --   - #191 per-event verified gate (requires_verified)
 --   - #199 home v3 featured + this-week list
---   - #107 pagination (10 centers)
 --
 -- NEVER run against prod. This file is preview-only.
 
 DELETE FROM events;
-DELETE FROM centers;
 
-INSERT OR REPLACE INTO centers (id, name, latitude, longitude, address, member_count, is_verified, created_at, updated_at) VALUES
-  ('c1000001-0000-0000-0000-000000000001', 'Chinmaya Mission Boston', 42.3601, -71.0589, '90 Lincoln St, Boston, MA 02111', 245, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000002', 'Chinmaya Mission New Jersey', 40.7357, -74.1724, '125 C Charlotte Ave, South River, NJ 08882', 312, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000003', 'Chinmaya Mission San Francisco', 37.7749, -122.4194, '675 Templeton Dr, Grover Beach, CA 93433', 189, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000004', 'Chinmaya Mission Los Angeles', 34.0522, -118.2437, '722 Jefferson Ave, Glendale, CA 91203', 428, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000005', 'Chinmaya Mission Chicago', 41.8781, -87.6298, '1921 E Oakton St, Arlington Heights, IL 60004', 156, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000006', 'Chinmaya Mission Houston', 29.7604, -95.3698, '10370 Bissonnet St, Houston, TX 77099', 267, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000007', 'Chinmaya Mission Dallas', 32.7767, -96.7970, '1000 E Plano Pkwy, Plano, TX 75074', 198, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000008', 'Chinmaya Mission Seattle', 47.6062, -122.3321, '11422 Eldorado Pkwy, Frisco, TX 75035', 134, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000009', 'Chinmaya Mission Washington DC', 38.9072, -77.0369, '12100 Eldorado Pkwy, Frisco, TX 75035', 223, 1, datetime('now'), datetime('now')),
-  ('c1000001-0000-0000-0000-000000000010', 'Chinmaya Mission Tampa', 27.9506, -82.4572, '5490 Crane Ridge Dr, Jacksonville, FL 32216', 145, 1, datetime('now'), datetime('now'));
-
+-- Real center anchors used below:
+--   c0000001-...-0002  Chinmaya Maruti        (Andover, MA)
+--   c0000001-...-0008  Chinmaya Sandeepany    (San Jose, CA)
+--   c0000001-...-0081  Chinmaya Vrindavan     (Cranbury, NJ)
 INSERT OR REPLACE INTO events (id, title, description, date, latitude, longitude, address, center_id, tier, people_attending, point_of_contact, image, category, is_official, requires_verified, created_at, updated_at) VALUES
-  ('e0000001-0000-0000-0000-000000000001', 'Bhagavad Gita Study', 'Weekly chapter-by-chapter discussion. All levels welcome.', '2026-08-15', 42.3601, -71.0589, '90 Lincoln St, Boston, MA', 'c1000001-0000-0000-0000-000000000001', 0, 14, 'Ramesh Ji', NULL, 91, 1, 0, datetime('now'), datetime('now')),
-  ('e0000001-0000-0000-0000-000000000002', 'Bala Vihar Children''s Class', 'Sundays for kids ages 5-12. Stories, songs, satsang.', '2026-08-17', 40.7357, -74.1724, '125 C Charlotte Ave, South River, NJ', 'c1000001-0000-0000-0000-000000000002', 0, 32, 'Anita Akka', NULL, 1, 1, 0, datetime('now'), datetime('now')),
-  ('e0000001-0000-0000-0000-000000000003', 'Members Only — Leadership Retreat', 'Annual leadership planning retreat. Requires verified center membership.', '2026-09-10', 37.7749, -122.4194, '675 Templeton Dr, Grover Beach, CA', 'c1000001-0000-0000-0000-000000000003', 0, 8, 'Suresh Ji', NULL, 50, 1, 1, datetime('now'), datetime('now')),
-  ('e0000001-0000-0000-0000-000000000004', '33rd Mahasamadhi Aradhana Camp', 'Mahasamadhi camp at MSC. Talks, satsangs, seva.', '2026-08-01', 40.8567, -74.4296, '1 Krishnalaya Way, Parsippany, NJ', 'c1000001-0000-0000-0000-000000000002', 1, 487, 'MSC Coordination Team', NULL, 91, 1, 0, datetime('now'), datetime('now'));
+  ('e0000001-0000-0000-0000-000000000001', 'Bhagavad Gita Study', 'Weekly chapter-by-chapter discussion. All levels welcome.', '2026-08-15', 42.6765858, -71.1508859, '1 Union St, Andover, MA - 01810, US', 'c0000001-0000-0000-0000-000000000002', 0, 14, 'Ramesh Ji', NULL, 91, 1, 0, datetime('now'), datetime('now')),
+  ('e0000001-0000-0000-0000-000000000002', 'Bala Vihar Children''s Class', 'Sundays for kids ages 5-12. Stories, songs, satsang.', '2026-08-17', 40.3089353, -74.5605169, '95 Cranbury Neck Rd, Cranbury, NJ - 08512, US', 'c0000001-0000-0000-0000-000000000081', 0, 32, 'Anita Akka', NULL, 1, 1, 0, datetime('now'), datetime('now')),
+  ('e0000001-0000-0000-0000-000000000003', 'Members Only - Leadership Retreat', 'Annual leadership planning retreat. Requires verified center membership.', '2026-09-10', 37.3593226, -121.8095066, '10160 Clayton Rd, San Jose, CA - 95127, US', 'c0000001-0000-0000-0000-000000000008', 0, 8, 'Suresh Ji', NULL, 50, 1, 1, datetime('now'), datetime('now')),
+  ('e0000001-0000-0000-0000-000000000004', '33rd Mahasamadhi Aradhana Camp', 'Mahasamadhi camp at MSC. Talks, satsangs, seva.', '2026-08-01', 40.8567, -74.4296, '1 Krishnalaya Way, Parsippany, NJ', 'c0000001-0000-0000-0000-000000000081', 1, 487, 'MSC Coordination Team', NULL, 91, 1, 0, datetime('now'), datetime('now'));
 
 -- Test user is created via the signup flow on the preview URL (real PBKDF2 hash),
--- or via curl against the preview API — see docs/v2-preview-runbook.md step 6.
+-- or via curl against the preview API - see docs/v2-preview-runbook.md step 6.

--- a/scripts/ci/deploy-v2preview.sh
+++ b/scripts/ci/deploy-v2preview.sh
@@ -69,7 +69,9 @@ for f in migrations/0[0-9][0-9][0-9]_*.sql; do
   echo "  → $base"
   WR d1 execute "$DB_NAME" --remote --config "$CONFIG" --file="$f"
 done
-echo "  → seed_preview_data.sql"
+echo "  → real centers (packages/backend/src/seed/centers.sql)"
+WR d1 execute "$DB_NAME" --remote --config "$CONFIG" --file=packages/backend/src/seed/centers.sql
+echo "  → seed_preview_data.sql (demo events on top of real centers)"
 WR d1 execute "$DB_NAME" --remote --config "$CONFIG" --file=migrations/seed_preview_data.sql
 
 echo "▶ (3/7) Deploy preview worker"

--- a/scripts/db/setup-preview-db.sh
+++ b/scripts/db/setup-preview-db.sh
@@ -50,7 +50,10 @@ for f in migrations/0[0-9][0-9][0-9]_*.sql; do
     || { echo "✗ FAILED on $base" >&2; exit 1; }
 done
 
-echo "▶ Loading preview dummy data (centers + events with badge/verified flags)"
+echo "▶ Loading real centers (packages/backend/src/seed/centers.sql)"
+npx wrangler d1 execute "$DB_NAME" --remote --file=packages/backend/src/seed/centers.sql --config "$CONFIG" >/dev/null 2>&1 \
+  || { echo "✗ FAILED seeding real centers" >&2; exit 1; }
+echo "▶ Loading preview demo events (on top of real centers)"
 npx wrangler d1 execute "$DB_NAME" --remote --file=migrations/seed_preview_data.sql --config "$CONFIG" >/dev/null 2>&1 \
   || { echo "✗ FAILED seeding preview data" >&2; exit 1; }
 

--- a/scripts/dev/setup-local-demo.sh
+++ b/scripts/dev/setup-local-demo.sh
@@ -29,7 +29,8 @@ for f in migrations/0[0-9][0-9][0-9]_*.sql; do
   npx wrangler d1 execute "$DB" --local --file="$f" --config "$CFG" >/dev/null
 done
 
-echo "▶ (3/5) seed centers + events"
+echo "▶ (3/5) seed real centers + demo events"
+npx wrangler d1 execute "$DB" --local --file=packages/backend/src/seed/centers.sql --config "$CFG" >/dev/null
 npx wrangler d1 execute "$DB" --local --file=migrations/seed_preview_data.sql --config "$CFG" >/dev/null
 
 echo "▶ (4/5) start a temp backend to register the 5 role accounts"


### PR DESCRIPTION
## Why
Abhiram flagged that the v2 preview site showed centers that didn't make sense. Root cause: the preview build was deleting all centers and inserting **10 fabricated placeholder centers** (Boston/NJ/SF/LA/... with mismatched addresses, e.g. a "Seattle" center carrying a Frisco, TX address). We use this link for testing, so it should show the real centers.

## What changed
- Every preview/local seed path now loads the real center list first (`packages/backend/src/seed/centers.sql` — all 93 real centers, including Chinmaya Vrindavan and the India centers): `scripts/ci/deploy-v2preview.sh`, `scripts/db/setup-preview-db.sh`, `scripts/dev/setup-local-demo.sh`.
- `migrations/seed_preview_data.sql` no longer touches the `centers` table. It now only resets + seeds the demo **events** that exercise v2 features (official badge #192, verified gate #191, home featured #199), each re-anchored to a real center id (Maruti, Sandeepany, Vrindavan).

## Notes for reviewer
- Member counts will display as **0** on preview (no real members yet). Names, locations, and verified badges are all real.
- Prod is untouched — these scripts are preview/local only.
- Takes effect on the next preview rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)