### PR TITLE
fix(explore): show center filter for users without a home center

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -292,6 +292,9 @@ export default function DiscoverScreen() {
     [isAllCenters, allCenters, areaCenterId, userCenter]
   )
   const isHomeArea = !!areaCenter && areaCenter.id === user?.centerID
+  // Users without a home center (or none selected) get the "All centers" view
+  // so the filter still renders and they can pick a center from the picker.
+  const showAllCenters = isAllCenters || !areaCenter
 
   useFocusEffect(
     useCallback(() => {
@@ -574,7 +577,7 @@ export default function DiscoverScreen() {
             {/* Center dropdown — picks which center's area to show events for.
                 Defaults to the member's home center; tapping opens the center
                 list so they can see what's on around any center. */}
-            {!centerPickerOpen && user && (isAllCenters || areaCenter) && (
+            {!centerPickerOpen && user && (isAllCenters || areaCenter || allCenters.length > 0) && (
               <Pressable
                 onPress={() => {
                   track('explore_area_center_opened', { centerId: areaCenter?.id ?? 'all' })
@@ -582,7 +585,7 @@ export default function DiscoverScreen() {
                 }}
                 accessibilityRole="button"
                 accessibilityLabel={
-                  isAllCenters
+                  showAllCenters
                     ? 'Showing events from all centers. Tap to change.'
                     : `Showing events near ${areaCenter?.name}. Tap to change center.`
                 }
@@ -599,14 +602,14 @@ export default function DiscoverScreen() {
                   className="w-10 h-10 rounded-xl items-center justify-center"
                   style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
                 >
-                  {isAllCenters ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
+                  {showAllCenters ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
                 </View>
                 <View style={{ flex: 1 }}>
                   <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
-                    {isAllCenters ? 'All centers' : areaCenter?.name}
+                    {showAllCenters ? 'All centers' : areaCenter?.name}
                   </Text>
                   <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
-                    {isAllCenters
+                    {showAllCenters
                       ? 'Events everywhere · tap to change'
                       : isHomeArea
                         ? `Your center${areaCenter?.memberCount ? ` · ${areaCenter.memberCount} members` : ''}`

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -479,6 +479,9 @@ function MobileDiscoverFallback() {
     [isAllCenters, allCenters, areaCenterId, userCenter]
   )
   const isHomeArea = !!areaCenter && areaCenter.id === user?.centerID
+  // Users without a home center (or none selected) get the "All centers" view
+  // so the filter still renders and they can pick a center from the picker.
+  const showAllCenters = isAllCenters || !areaCenter
 
   useFocusEffect(
     useCallback(() => {
@@ -747,7 +750,7 @@ function MobileDiscoverFallback() {
             {/* Center dropdown — picks which center's area to show events for.
                 Defaults to the member's home center; tapping opens the in-sheet
                 center list so they can see what's on around any center. */}
-            {!centerPickerOpen && user && (isAllCenters || areaCenter) && (
+            {!centerPickerOpen && user && (isAllCenters || areaCenter || allCenters.length > 0) && (
               <Pressable
                 onPress={() => {
                   track('explore_area_center_opened', { centerId: areaCenter?.id ?? 'all' })
@@ -756,7 +759,7 @@ function MobileDiscoverFallback() {
                 }}
                 accessibilityRole="button"
                 accessibilityLabel={
-                  isAllCenters
+                  showAllCenters
                     ? 'Showing events from all centers. Tap to change.'
                     : `Showing events near ${areaCenter?.name}. Tap to change center.`
                 }
@@ -773,14 +776,14 @@ function MobileDiscoverFallback() {
                   className="w-10 h-10 rounded-xl items-center justify-center"
                   style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
                 >
-                  {isAllCenters ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
+                  {showAllCenters ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
                 </View>
                 <View style={{ flex: 1 }}>
                   <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
-                    {isAllCenters ? 'All centers' : areaCenter?.name}
+                    {showAllCenters ? 'All centers' : areaCenter?.name}
                   </Text>
                   <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
-                    {isAllCenters
+                    {showAllCenters
                       ? 'Events everywhere · tap to change'
                       : isHomeArea
                         ? `Your center${areaCenter?.memberCount ? ` · ${areaCenter.memberCount} members` : ''}`
@@ -1054,6 +1057,9 @@ export default function DiscoverScreenWeb() {
     [isAllCentersDesktop, allCenters, areaCenterIdDesktop, userCenterFromList]
   )
   const isHomeAreaDesktop = !!areaCenterDesktop && areaCenterDesktop.id === user?.centerID
+  // Users without a home center (or none selected) get the "All centers" view
+  // so the filter still renders and they can pick a center from the picker.
+  const showAllCentersDesktop = isAllCentersDesktop || !areaCenterDesktop
 
   useFocusEffect(
     useCallback(() => {
@@ -1361,7 +1367,7 @@ export default function DiscoverScreenWeb() {
               {/* Center dropdown — picks which center's area to show events for.
                   Defaults to the member's home center; clicking opens the in-panel
                   center list so they can see what's on around any center. */}
-              {!centerPickerOpenDesktop && user && (isAllCentersDesktop || areaCenterDesktop) && (
+              {!centerPickerOpenDesktop && user && (isAllCentersDesktop || areaCenterDesktop || allCenters.length > 0) && (
                 <Pressable
                   onPress={() => {
                     track('explore_area_center_opened', { centerId: areaCenterDesktop?.id ?? 'all' })
@@ -1369,7 +1375,7 @@ export default function DiscoverScreenWeb() {
                   }}
                   accessibilityRole="button"
                   accessibilityLabel={
-                    isAllCentersDesktop
+                    showAllCentersDesktop
                       ? 'Showing events from all centers. Click to change.'
                       : `Showing events near ${areaCenterDesktop?.name}. Click to change center.`
                   }
@@ -1387,14 +1393,14 @@ export default function DiscoverScreenWeb() {
                     className="w-10 h-10 rounded-xl items-center justify-center"
                     style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
                   >
-                    {isAllCentersDesktop ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
+                    {showAllCentersDesktop ? <Globe size={18} color="#E8862A" /> : <Building2 size={18} color="#E8862A" />}
                   </View>
                   <View style={{ flex: 1 }}>
                     <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
-                      {isAllCentersDesktop ? 'All centers' : areaCenterDesktop?.name}
+                      {showAllCentersDesktop ? 'All centers' : areaCenterDesktop?.name}
                     </Text>
                     <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
-                      {isAllCentersDesktop
+                      {showAllCentersDesktop
                         ? 'Events everywhere · click to change'
                         : isHomeAreaDesktop
                           ? `Your center${areaCenterDesktop?.memberCount ? ` · ${areaCenterDesktop.memberCount} members` : ''}`


### PR DESCRIPTION
Fixes #343

## Problem
On Explore (web), the **center filter dropdown** did not render for a logged-in user with no home center (e.g. a Dev-Mode "New user" or any account with no `centerID`). The Today / Going / Create chips still showed, so only the center filter went missing — there was no way to filter by center and no entry point to "All centers" mode.

## Root cause
The dropdown was gated on `user && (isAllCenters || areaCenter)`. `areaCenter` resolves to `allCenters.find(c => c.id === user.centerID)`; with no `centerID` it's `undefined` and `isAllCenters` is `false`, so the whole block was hidden.

## Fix
- Render the dropdown whenever centers are loaded (`… || allCenters.length > 0`).
- New `showAllCenters` / `showAllCentersDesktop` derivation (`isAllCenters || !areaCenter`) drives the label, icon, and a11y text so the no-home-center case presents as **"All centers"** instead of a blank.
- A user **with** a home center is unchanged.
- Applied to all three render paths: native `explore.tsx`, mobile-web fallback, and desktop web in `explore.web.tsx`.

## Acceptance criteria
- [x] Centerless logged-in user sees the center filter, defaulting to "All centers"
- [x] User with a home center unchanged (anchors on their center)
- [x] Selecting a center / "All centers" filters as before
- [x] Mobile-web + desktop + native all covered

## Verification
- `tsc` parse/types reviewed; change is render-gating logic only (no new types/imports).
- ⚠️ **Local unit tests were not run** — this checkout has no `node_modules` installed and a full Expo/RN install was skipped (disk constraints). Please let CI / the runner's `verify.sh` run the frontend suite, and visually confirm on the preview: sign in via Dev Mode → "New user" → Explore → center filter shows "All centers".