### PR TITLE
fix(explore): sync map markers with active list filters (#337)

### DIFF
--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -793,7 +793,11 @@ export function useDiscoverData(
     refresh()
   }, [refresh])
 
-  const items = useMemo<DiscoverItem[]>(() => {
+  // Single source of truth for "what passes the active filters" — both the
+  // list (`items`) and the map (`filteredPoints`) derive from these, so the
+  // two can never drift out of sync (searching/Going/interests/past-events
+  // used to narrow the list while the map kept showing every pin).
+  const { filteredEventList, filteredCenterList } = useMemo(() => {
     const query = searchQuery.toLowerCase().trim()
     const todayStr = new Date().toISOString().split('T')[0]
 
@@ -803,7 +807,7 @@ export function useDiscoverData(
       : allEvents.filter((e) => !e.date || e.date >= todayStr)
 
     // Filter events by user interests if set
-    const filteredEvents = userInterests && userInterests.length > 0
+    const interestEvents = userInterests && userInterests.length > 0
       ? visibleEvents.filter((e) => {
           if (e.category == null) return true
           const interestName = CATEGORY_TO_INTEREST[e.category]
@@ -811,66 +815,57 @@ export function useDiscoverData(
         })
       : visibleEvents
 
-    let result: DiscoverItem[] = []
+    // Going-only toggle
+    const goingEvents = showGoingOnly
+      ? interestEvents.filter((e) => e.isRegistered)
+      : interestEvents
 
-    if (filter === 'Centers') {
-      result = groupCenterItems(allCenters, userCenterID)
-    } else {
-      const eventsToShow = showGoingOnly
-        ? filteredEvents.filter((e) => e.isRegistered)
-        : filteredEvents
-      const sortByDate = (a: EventDisplay, b: EventDisplay) =>
-        a.date.localeCompare(b.date)
-      const registered = eventsToShow.filter((e) => e.isRegistered).sort(sortByDate)
-      const unregistered = eventsToShow.filter((e) => !e.isRegistered).sort(sortByDate)
-
-      result = [
-        ...registered.map((e) => ({ type: 'event' as const, data: e })),
-        ...unregistered.map((e) => ({ type: 'event' as const, data: e })),
-      ]
-    }
-
-    // Apply search query
-    if (query) {
-      if (filter === 'Centers') {
-        const matchingCenters = allCenters.filter(
+    // Search query (events: title/location, centers: name/address)
+    const events = query
+      ? goingEvents.filter(
+          (e) =>
+            e.title.toLowerCase().includes(query) ||
+            e.location.toLowerCase().includes(query)
+        )
+      : goingEvents
+    const centers = query
+      ? allCenters.filter(
           (c) =>
             c.name.toLowerCase().includes(query) ||
             (c.address?.toLowerCase().includes(query) ?? false)
         )
-        result = groupCenterItems(matchingCenters, userCenterID)
-      } else {
-        result = result.filter((item) => {
-          if (item.type === 'event') {
-            return (
-              item.data.title.toLowerCase().includes(query) ||
-              item.data.location.toLowerCase().includes(query)
-            )
-          }
-          if (item.type === 'center') {
-            return (
-              item.data.name.toLowerCase().includes(query) ||
-              (item.data.address?.toLowerCase().includes(query) ?? false)
-            )
-          }
-          return false
-        })
-      }
+      : allCenters
+
+    return { filteredEventList: events, filteredCenterList: centers }
+  }, [allEvents, allCenters, searchQuery, showPastEvents, showGoingOnly, userInterests])
+
+  const items = useMemo<DiscoverItem[]>(() => {
+    if (filter === 'Centers') {
+      return groupCenterItems(filteredCenterList, userCenterID)
     }
+    const sortByDate = (a: EventDisplay, b: EventDisplay) =>
+      a.date.localeCompare(b.date)
+    const registered = filteredEventList.filter((e) => e.isRegistered).sort(sortByDate)
+    const unregistered = filteredEventList.filter((e) => !e.isRegistered).sort(sortByDate)
+    return [
+      ...registered.map((e) => ({ type: 'event' as const, data: e })),
+      ...unregistered.map((e) => ({ type: 'event' as const, data: e })),
+    ]
+  }, [filter, filteredEventList, filteredCenterList, userCenterID])
 
-    return result
-  }, [allEvents, allCenters, filter, searchQuery, showPastEvents, showGoingOnly, userInterests, userCenterID])
-
-  // Map points from current data
+  // Map points — derived from the same filtered sets as the list above.
   const filteredPoints = useMemo<MapPoint[]>(() => {
-    const centerPoints: MapPoint[] = allCenters.map((c) => ({
+    const centerPoints: MapPoint[] = filteredCenterList.map((c) => ({
       id: c.id,
       type: 'center' as const,
       name: c.name,
       latitude: c.latitude,
       longitude: c.longitude,
     }))
-    const eventPoints: MapPoint[] = allEvents
+    if (filter === 'Centers') {
+      return centerPoints
+    }
+    const eventPoints: MapPoint[] = filteredEventList
       .filter((e) => e.latitude != null && e.longitude != null)
       .map((e) => ({
         id: e.id,
@@ -879,14 +874,8 @@ export function useDiscoverData(
         latitude: e.latitude!,
         longitude: e.longitude!,
       }))
-
-    const allPoints = [...centerPoints, ...eventPoints]
-
-    if (filter === 'Centers') {
-      return allPoints.filter((p) => p.type === 'center')
-    }
-    return allPoints
-  }, [allCenters, allEvents, filter])
+    return [...centerPoints, ...eventPoints]
+  }, [filteredCenterList, filteredEventList, filter])
 
   const updateEventStatus = useCallback(
     (


### PR DESCRIPTION
## What
On the Explore tab, the map markers ignored every active filter. `useDiscoverData.filteredPoints` was built straight from raw `allEvents` / `allCenters`, so:

- **Search** narrowed the list but the map kept showing all ~90 pins.
- **Going** filtered the list to registered events; map showed everything.
- **Interests** and **past-events** hiding applied to the list only — the map still rendered past-event pins and out-of-interest pins.

## Fix
Introduced one shared `{ filteredEventList, filteredCenterList }` memo that applies past-events → interests → Going → search once. Both `items` (list) and `filteredPoints` (map) now derive from it, so the two can't drift out of sync. List behavior is unchanged; the map now reflects the same filtered set.

One hook fix covers **all three surfaces** (native `explore.tsx`, mobile-web + desktop-web `explore.web.tsx`) since they all consume this hook.

## Test (on v2preview)
1. Explore → type a query in search → confirm map pins narrow to match the list (was: all pins stayed).
2. Toggle **Going** → map shows only your registered events.
3. Switch to **Centers** tab + search → map shows only matching centers.

## Notes / out of scope
- **Today/date chip → map sync:** the `selectedDate` filter lives in the screen component, not this hook, so the date chip still doesn't narrow the map. Left for a focused follow-up (would need threading `selectedDate` through the hook).
- **Dead past-events toggle:** `showPastEvents` is permanently `false` on every surface — `setShowPastEvents` is declared but never wired to any UI. Whether members should ever see past events is a product call; flagging here, not building it.

## Verification gap
No `node_modules` in the checkout (RN/Expo install skipped per disk constraints), so this was not typechecked locally — relying on CI `verify.sh`. Change is a pure-logic refactor within pre-existing types.

Fixes #337