### PR TITLE
feat(explore): guest-accessible center filter + 100mi radius filtering + picker redesign

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -406,6 +406,14 @@ export default function DiscoverScreen() {
         (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
       )
     }
+    // An explicit center pick filters events to that center + a ~100mi radius.
+    // The default / home-center case below only sorts, so the list never starts empty.
+    if (areaCenter && selectedCenter && !isAllCenters && result.every((i) => i.type === 'event')) {
+      result = result.filter((item) => {
+        const e = item.data as EventDisplay
+        return e.centerId === areaCenter.id || milesBetween(areaCenter, e) <= 100
+      })
+    }
     // Order the events by nearness to the selected area center so "what's on
     // around <center>" surfaces first. Sorting (not filtering) keeps the list
     // from ever going empty. Only applies to a flat events list.
@@ -417,7 +425,15 @@ export default function DiscoverScreen() {
       )
     }
     return result
-  }, [items, selectedDate, areaCenter])
+  }, [items, selectedDate, areaCenter, selectedCenter, isAllCenters])
+
+  // Map markers honor the same explicit-center radius filter as the list.
+  const mapPoints = useMemo(() => {
+    if (!areaCenter || !selectedCenter || isAllCenters) return filteredPoints
+    return filteredPoints.filter(
+      (p) => p.id === areaCenter.id || milesBetween(areaCenter, p) <= 100
+    )
+  }, [filteredPoints, areaCenter, selectedCenter, isAllCenters])
 
   // Count of items under each section header (e.g. centers per state) so the
   // grouped list shows "CALIFORNIA  3" — counts the rows even while collapsed.
@@ -518,7 +534,7 @@ export default function DiscoverScreen() {
     >
       {/* Map — full bleed behind the sheet */}
       <View style={StyleSheet.absoluteFill}>
-        <Map points={filteredPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} bottomPadding={90} />
+        <Map points={mapPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} bottomPadding={90} />
       </View>
 
       {/* Bottom Sheet — hidden until we measure the container */}
@@ -577,7 +593,7 @@ export default function DiscoverScreen() {
             {/* Center dropdown — picks which center's area to show events for.
                 Defaults to the member's home center; tapping opens the center
                 list so they can see what's on around any center. */}
-            {!centerPickerOpen && user && (isAllCenters || areaCenter || allCenters.length > 0) && (
+            {!centerPickerOpen && (isAllCenters || areaCenter || allCenters.length > 0) && (
               <Pressable
                 onPress={() => {
                   track('explore_area_center_opened', { centerId: areaCenter?.id ?? 'all' })

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -450,6 +450,7 @@ function MobileDiscoverFallback() {
   const [selectedCenter, setSelectedCenter] = useState<string | null>(null)
   // The center dropdown opens an in-sheet list (not a modal) — view, pick one, or close.
   const [centerPickerOpen, setCenterPickerOpen] = useState(false)
+  const [mapFlyTo, setMapFlyTo] = useState<{ latitude: number; longitude: number; key: number; zoom?: number } | null>(null)
   const { user } = useUser()
   const { items, filteredPoints, loading, allEvents, allCenters, refresh } = useDiscoverData(
     activeFilter,
@@ -527,6 +528,11 @@ function MobileDiscoverFallback() {
   // viewport (issue #321).
   const handleDragStart = useCallback(
     (e: React.PointerEvent) => {
+      // Don't hijack taps that begin on an interactive control (center card,
+      // filter chips, search) — capturing the pointer here swallows their
+      // click. Dragging still works from the handle bar and empty header gaps.
+      const target = e.target as HTMLElement | null
+      if (target?.closest('[role="button"], input, textarea, select, a')) return
       e.currentTarget.setPointerCapture(e.pointerId)
       dragStartY.current = e.clientY
       dragStartTranslate.current = currentTranslateY
@@ -603,6 +609,14 @@ function MobileDiscoverFallback() {
         (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
       )
     }
+    // An explicit center pick filters events to that center + a ~100mi radius.
+    // The default / home-center case below only sorts, so the list never starts empty.
+    if (areaCenter && selectedCenter && !isAllCenters && result.every((i) => i.type === 'event')) {
+      result = result.filter((item) => {
+        const e = item.data as EventDisplay
+        return e.centerId === areaCenter.id || milesBetween(areaCenter, e) <= 100
+      })
+    }
     // Order events by nearness to the selected area center so "what's on around
     // <center>" surfaces first. Sorting (not filtering) keeps the list from ever
     // going empty. Only applies to a flat events list.
@@ -614,7 +628,79 @@ function MobileDiscoverFallback() {
       )
     }
     return result
-  }, [items, selectedDate, areaCenter])
+  }, [items, selectedDate, areaCenter, selectedCenter, isAllCenters])
+
+  // Map markers honor the same explicit-center radius filter as the list.
+  const mapPoints = useMemo(() => {
+    if (!areaCenter || !selectedCenter || isAllCenters) return filteredPoints
+    return filteredPoints.filter(
+      (p) => p.id === areaCenter.id || milesBetween(areaCenter, p) <= 100
+    )
+  }, [filteredPoints, areaCenter, selectedCenter, isAllCenters])
+
+  // One picker row (mobile-web). Centers WITH events scope the list + fly the
+  // map; centers WITHOUT events only open the center page.
+  const renderCenterRow = (opt: FilterPickerOption<string>) => {
+    const selectable = opt.count > 0
+    const openPage = () => {
+      track('explore_center_page_opened', { centerId: opt.value })
+      setCenterPickerOpen(false)
+      router.push(`/center/${opt.value}`)
+    }
+    const scopeToCenter = () => {
+      track('explore_area_center_selected', { centerId: opt.value })
+      setSelectedCenter(opt.value)
+      setCenterPickerOpen(false)
+      setSearchQuery('')
+      const c = allCenters.find((cc) => cc.id === opt.value)
+      if (c && Number.isFinite(c.latitude) && Number.isFinite(c.longitude)) {
+        setMapFlyTo((prev) => ({
+          latitude: c.latitude as number,
+          longitude: c.longitude as number,
+          zoom: 10,
+          key: (prev?.key ?? 0) + 1,
+        }))
+      }
+    }
+    return (
+      <View key={opt.value}>
+        <View className="bg-stone-200/70 dark:bg-neutral-800" style={{ height: 1, marginHorizontal: 16 }} />
+        <View className="flex-row items-center px-4" style={{ minHeight: 56, gap: 8 }}>
+          <Pressable
+            onPress={selectable ? scopeToCenter : openPage}
+            accessibilityRole="button"
+            accessibilityLabel={selectable ? `Show events near ${opt.label}` : `View ${opt.label} page`}
+            className="flex-1 flex-row items-center active:opacity-60"
+            style={{ gap: 12, minHeight: 56 }}
+          >
+            <View className="w-10 h-10 rounded-xl items-center justify-center" style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}>
+              <Building2 size={18} color="#E8862A" />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>{opt.label}</Text>
+              <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>{opt.sublabel}</Text>
+            </View>
+          </Pressable>
+          {selectable ? (
+            <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}>
+              <Text className="font-sans" style={{ fontSize: 12, fontWeight: '600', color: '#E8862A' }}>{opt.count} {opt.count === 1 ? 'event' : 'events'}</Text>
+            </View>
+          ) : null}
+          {opt.value === areaCenterId ? <Check size={18} color="#E8862A" /> : null}
+          <Pressable
+            onPress={openPage}
+            accessibilityRole="button"
+            accessibilityLabel={`View ${opt.label} page`}
+            hitSlop={6}
+            className="items-center justify-center active:opacity-60"
+            style={{ width: 30, height: 30, borderRadius: 15, backgroundColor: isDark ? '#262626' : '#F3F4F6' }}
+          >
+            <ChevronRight size={16} color={isDark ? '#A8A29E' : '#78716C'} />
+          </Pressable>
+        </View>
+      </View>
+    )
+  }
 
   // Filter chip helpers — counts over upcoming events.
   const todayStr = new Date().toISOString().split('T')[0]
@@ -657,7 +743,7 @@ function MobileDiscoverFallback() {
             </View>
           }
         >
-          <Map points={filteredPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} />
+          <Map points={mapPoints} onPointPress={handlePointPress} userCenterID={user?.centerID} flyTo={mapFlyTo} />
         </Suspense>
       </View>
 
@@ -693,6 +779,8 @@ function MobileDiscoverFallback() {
             onPointerMove={handleDragMove}
             onPointerUp={handleDragEnd}
             style={{
+              display: 'flex',
+              flexDirection: 'column',
               touchAction: 'none',
               cursor: 'grab',
               userSelect: 'none',
@@ -734,7 +822,7 @@ function MobileDiscoverFallback() {
                   paddingVertical: 10,
                   fontSize: 16,
                 }}
-                placeholder="Search events and centers..."
+                placeholder={centerPickerOpen ? 'Search centers...' : 'Search events...'}
                 placeholderTextColor="#9CA3AF"
                 value={searchQuery}
                 onChangeText={setSearchQuery}
@@ -750,12 +838,11 @@ function MobileDiscoverFallback() {
             {/* Center dropdown — picks which center's area to show events for.
                 Defaults to the member's home center; tapping opens the in-sheet
                 center list so they can see what's on around any center. */}
-            {!centerPickerOpen && user && (isAllCenters || areaCenter || allCenters.length > 0) && (
+            {!centerPickerOpen && (isAllCenters || areaCenter || allCenters.length > 0) && (
               <Pressable
                 onPress={() => {
                   track('explore_area_center_opened', { centerId: areaCenter?.id ?? 'all' })
                   setCenterPickerOpen(true)
-                  setSheetSnap('expanded')
                 }}
                 accessibilityRole="button"
                 accessibilityLabel={
@@ -765,6 +852,7 @@ function MobileDiscoverFallback() {
                 }
                 className="flex-row items-center mx-3 mb-2 px-3 rounded-2xl active:opacity-70"
                 style={{
+                  alignSelf: 'stretch',
                   minHeight: 58,
                   gap: 12,
                   backgroundColor: isDark ? 'rgba(232,134,42,0.12)' : '#FFF7ED',
@@ -804,7 +892,7 @@ function MobileDiscoverFallback() {
                 <Text className="font-sans text-stone-500 dark:text-stone-400 uppercase" style={{ fontSize: 11.5, letterSpacing: 0.9 }}>
                   Show events near
                 </Text>
-                <Pressable onPress={() => setCenterPickerOpen(false)} hitSlop={8}>
+                <Pressable accessibilityRole="button" onPress={() => setCenterPickerOpen(false)} hitSlop={8}>
                   <Text style={{ fontSize: 13, fontWeight: '500', color: '#E8862A' }}>Close</Text>
                 </Pressable>
               </View>
@@ -891,6 +979,7 @@ function MobileDiscoverFallback() {
                     track('explore_area_all_selected')
                     setSelectedCenter('__all__')
                     setCenterPickerOpen(false)
+                    setSearchQuery('')
                   }}
                   accessibilityRole="button"
                   accessibilityLabel="Show events from all centers"
@@ -914,60 +1003,30 @@ function MobileDiscoverFallback() {
                   {isAllCenters ? <Check size={18} color="#E8862A" /> : null}
                 </Pressable>
 
-                {centerOptions.map((opt) => (
-                  <View key={opt.value}>
-                    <View className="bg-stone-200/70 dark:bg-neutral-800" style={{ height: 1, marginHorizontal: 16 }} />
-                    <View className="flex-row items-center px-4" style={{ minHeight: 56, gap: 8 }}>
-                      {/* Tap the row to scope events to this center's area. */}
-                      <Pressable
-                        onPress={() => {
-                          track('explore_area_center_selected', { centerId: opt.value })
-                          setSelectedCenter(opt.value)
-                          setCenterPickerOpen(false)
-                        }}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Show events near ${opt.label}`}
-                        className="flex-1 flex-row items-center active:opacity-60"
-                        style={{ gap: 12, minHeight: 56 }}
-                      >
-                        <View
-                          className="w-10 h-10 rounded-xl items-center justify-center"
-                          style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
-                        >
-                          <Building2 size={18} color="#E8862A" />
-                        </View>
-                        <View style={{ flex: 1 }}>
-                          <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
-                            {opt.label}
-                          </Text>
-                          <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
-                            {opt.sublabel}{opt.count ? ` · ${opt.count} event${opt.count === 1 ? '' : 's'}` : ''}
-                          </Text>
-                        </View>
-                      </Pressable>
-                      {opt.value === areaCenterId ? <Check size={18} color="#E8862A" /> : null}
-                      {/* Distinct "view this center's page" action. */}
-                      <Pressable
-                        onPress={() => {
-                          track('explore_center_page_opened', { centerId: opt.value })
-                          router.push(`/center/${opt.value}`)
-                        }}
-                        accessibilityRole="button"
-                        accessibilityLabel={`View ${opt.label} page`}
-                        hitSlop={6}
-                        className="items-center justify-center active:opacity-60"
-                        style={{
-                          width: 30,
-                          height: 30,
-                          borderRadius: 15,
-                          backgroundColor: isDark ? '#262626' : '#F3F4F6',
-                        }}
-                      >
-                        <ChevronRight size={16} color={isDark ? '#A8A29E' : '#78716C'} />
-                      </Pressable>
-                    </View>
-                  </View>
-                ))}
+                {(() => {
+                  const q = searchQuery.trim().toLowerCase()
+                  const matches = q
+                    ? centerOptions.filter((o) => o.label.toLowerCase().includes(q) || (o.sublabel ?? '').toLowerCase().includes(q))
+                    : centerOptions
+                  const withEvents = matches.filter((o) => o.count > 0)
+                  const withoutEvents = matches.filter((o) => o.count === 0)
+                  return (
+                    <>
+                      {withEvents.length > 0 && (
+                        <Text className="font-sans text-stone-400 dark:text-stone-500 uppercase px-4 pt-3 pb-1" style={{ fontSize: 11, letterSpacing: 0.8 }}>
+                          Centers with events
+                        </Text>
+                      )}
+                      {withEvents.map(renderCenterRow)}
+                      {withoutEvents.length > 0 && (
+                        <Text className="font-sans text-stone-400 dark:text-stone-500 uppercase px-4 pt-5 pb-1" style={{ fontSize: 11, letterSpacing: 0.8 }}>
+                          Other centers
+                        </Text>
+                      )}
+                      {withoutEvents.map(renderCenterRow)}
+                    </>
+                  )
+                })()}
               </>
             )}
             {!centerPickerOpen && !loading && displayItems.length === 0 && (
@@ -1138,6 +1197,14 @@ export default function DiscoverScreenWeb() {
         (item) => item.type === 'event' && (item.data as EventDisplay).date === selectedDate
       )
     }
+    // An explicit center pick filters events to that center + a ~100mi radius.
+    // The default / home-center case below only sorts, so the list never starts empty.
+    if (areaCenterDesktop && selectedCenterDesktop && !isAllCentersDesktop && result.every((i) => i.type === 'event')) {
+      result = result.filter((item) => {
+        const e = item.data as EventDisplay
+        return e.centerId === areaCenterDesktop.id || milesBetween(areaCenterDesktop, e) <= 100
+      })
+    }
     // Order events by nearness to the selected area center so "what's on around
     // <center>" surfaces first. Sorting (not filtering) keeps the list from ever
     // going empty — same approach as MobileDiscoverFallback.
@@ -1149,7 +1216,15 @@ export default function DiscoverScreenWeb() {
       )
     }
     return result
-  }, [items, selectedDate, areaCenterDesktop])
+  }, [items, selectedDate, areaCenterDesktop, selectedCenterDesktop, isAllCentersDesktop])
+
+  // Map markers honor the same explicit-center radius filter as the list.
+  const mapPointsDesktop = useMemo(() => {
+    if (!areaCenterDesktop || !selectedCenterDesktop || isAllCentersDesktop) return filteredPoints
+    return filteredPoints.filter(
+      (p) => p.id === areaCenterDesktop.id || milesBetween(areaCenterDesktop, p) <= 100
+    )
+  }, [filteredPoints, areaCenterDesktop, selectedCenterDesktop, isAllCentersDesktop])
 
   // Filter chip helpers — counts over upcoming events
   const todayStrDesktop = new Date().toISOString().split('T')[0]
@@ -1175,6 +1250,85 @@ export default function DiscoverScreenWeb() {
         return a.label.localeCompare(b.label)
       })
   }, [allCenters, eventsForCountsDesktop, user?.centerID])
+
+  // One picker row. Centers WITH events are selectable (scope the list + fly the
+  // map to that area); centers WITHOUT events are non-selectable and only offer
+  // the "view page" chevron — they're grouped separately below.
+  const renderCenterRowDesktop = (opt: FilterPickerOption<string>) => {
+    const selectable = opt.count > 0
+    const openPage = () => {
+      track('explore_center_page_opened', { centerId: opt.value })
+      setCenterPickerOpenDesktop(false)
+      setSelectedItem({ type: 'center', id: opt.value })
+    }
+    const scopeToCenter = () => {
+      track('explore_area_center_selected', { centerId: opt.value })
+      setSelectedCenterDesktop(opt.value)
+      setCenterPickerOpenDesktop(false)
+      setSearchQuery('')
+      const c = allCenters.find((cc) => cc.id === opt.value)
+      if (c && Number.isFinite(c.latitude) && Number.isFinite(c.longitude)) {
+        setMapFlyTo((prev) => ({
+          latitude: c.latitude as number,
+          longitude: c.longitude as number,
+          zoom: 10, // area view — a little more zoomed out than a single-pin focus
+          key: (prev?.key ?? 0) + 1,
+        }))
+      }
+    }
+    return (
+      <View key={opt.value}>
+        <View className="bg-stone-200/70 dark:bg-neutral-800" style={{ height: 1, marginHorizontal: 16 }} />
+        <View className="flex-row items-center px-4" style={{ minHeight: 56, gap: 8 }}>
+          <Pressable
+            onPress={selectable ? scopeToCenter : openPage}
+            accessibilityRole="button"
+            accessibilityLabel={selectable ? `Show events near ${opt.label}` : `View ${opt.label} page`}
+            className="flex-1 flex-row items-center active:opacity-60"
+            style={{ gap: 12, minHeight: 56 }}
+          >
+            <View
+              className="w-10 h-10 rounded-xl items-center justify-center"
+              style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
+            >
+              <Building2 size={18} color="#E8862A" />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
+                {opt.label}
+              </Text>
+              <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
+                {opt.sublabel}
+              </Text>
+            </View>
+          </Pressable>
+          {selectable ? (
+            <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}>
+              <Text className="font-sans" style={{ fontSize: 12, fontWeight: '600', color: '#E8862A' }}>
+                {opt.count} {opt.count === 1 ? 'event' : 'events'}
+              </Text>
+            </View>
+          ) : null}
+          {opt.value === areaCenterIdDesktop ? <Check size={18} color="#E8862A" /> : null}
+          {/* Distinct "view this center's page in the panel" action. */}
+          <Pressable
+            onPress={() => {
+              track('explore_center_page_opened', { centerId: opt.value })
+              setCenterPickerOpenDesktop(false)
+              setSelectedItem({ type: 'center', id: opt.value })
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={`View ${opt.label} page`}
+            hitSlop={6}
+            className="items-center justify-center active:opacity-60"
+            style={{ width: 30, height: 30, borderRadius: 15, backgroundColor: isDark ? '#262626' : '#F3F4F6' }}
+          >
+            <ChevronRight size={16} color={isDark ? '#A8A29E' : '#78716C'} />
+          </Pressable>
+        </View>
+      </View>
+    )
+  }
 
   // Map popover state
   const mapPanelRef = useRef<View>(null)
@@ -1268,7 +1422,7 @@ export default function DiscoverScreenWeb() {
           >
             <Map
               initialCenter={userCenter?.latitude && userCenter?.longitude ? [userCenter.latitude, userCenter.longitude] : undefined}
-              points={filteredPoints}
+              points={mapPointsDesktop}
               onPointPress={handlePointPress}
               onPointHover={handlePointHover}
               onPointClick={handlePointClick}
@@ -1351,7 +1505,7 @@ export default function DiscoverScreenWeb() {
                 <Search size={16} color="#9CA3AF" />
                 <TextInput
                   className="flex-1 ml-2 text-sm font-sans text-content dark:text-content-dark outline-none"
-                  placeholder="Search events and centers..."
+                  placeholder={centerPickerOpenDesktop ? 'Search centers...' : 'Search events...'}
                   placeholderTextColor="#9CA3AF"
                   value={searchQuery}
                   onChangeText={setSearchQuery}
@@ -1367,7 +1521,7 @@ export default function DiscoverScreenWeb() {
               {/* Center dropdown — picks which center's area to show events for.
                   Defaults to the member's home center; clicking opens the in-panel
                   center list so they can see what's on around any center. */}
-              {!centerPickerOpenDesktop && user && (isAllCentersDesktop || areaCenterDesktop || allCenters.length > 0) && (
+              {!centerPickerOpenDesktop && (isAllCentersDesktop || areaCenterDesktop || allCenters.length > 0) && (
                 <Pressable
                   onPress={() => {
                     track('explore_area_center_opened', { centerId: areaCenterDesktop?.id ?? 'all' })
@@ -1511,6 +1665,7 @@ export default function DiscoverScreenWeb() {
                       track('explore_area_all_selected')
                       setSelectedCenterDesktop('__all__')
                       setCenterPickerOpenDesktop(false)
+                      setSearchQuery('')
                     }}
                     accessibilityRole="button"
                     accessibilityLabel="Show events from all centers"
@@ -1534,61 +1689,30 @@ export default function DiscoverScreenWeb() {
                     {isAllCentersDesktop ? <Check size={18} color="#E8862A" /> : null}
                   </Pressable>
 
-                  {centerOptionsDesktop.map((opt) => (
-                    <View key={opt.value}>
-                      <View className="bg-stone-200/70 dark:bg-neutral-800" style={{ height: 1, marginHorizontal: 16 }} />
-                      <View className="flex-row items-center px-4" style={{ minHeight: 56, gap: 8 }}>
-                        {/* Click the row to scope events to this center's area. */}
-                        <Pressable
-                          onPress={() => {
-                            track('explore_area_center_selected', { centerId: opt.value })
-                            setSelectedCenterDesktop(opt.value)
-                            setCenterPickerOpenDesktop(false)
-                          }}
-                          accessibilityRole="button"
-                          accessibilityLabel={`Show events near ${opt.label}`}
-                          className="flex-1 flex-row items-center active:opacity-60"
-                          style={{ gap: 12, minHeight: 56 }}
-                        >
-                          <View
-                            className="w-10 h-10 rounded-xl items-center justify-center"
-                            style={{ backgroundColor: isDark ? 'rgba(232,134,42,0.18)' : '#FDE8D0' }}
-                          >
-                            <Building2 size={18} color="#E8862A" />
-                          </View>
-                          <View style={{ flex: 1 }}>
-                            <Text className="text-content dark:text-content-dark font-sans" style={{ fontSize: 15 }} numberOfLines={1}>
-                              {opt.label}
-                            </Text>
-                            <Text className="text-stone-500 dark:text-stone-400 font-sans" style={{ fontSize: 12.5 }} numberOfLines={1}>
-                              {opt.sublabel}{opt.count ? ` · ${opt.count} event${opt.count === 1 ? '' : 's'}` : ''}
-                            </Text>
-                          </View>
-                        </Pressable>
-                        {opt.value === areaCenterIdDesktop ? <Check size={18} color="#E8862A" /> : null}
-                        {/* Distinct "view this center's page in the panel" action. */}
-                        <Pressable
-                          onPress={() => {
-                            track('explore_center_page_opened', { centerId: opt.value })
-                            setCenterPickerOpenDesktop(false)
-                            setSelectedItem({ type: 'center', id: opt.value })
-                          }}
-                          accessibilityRole="button"
-                          accessibilityLabel={`View ${opt.label} page`}
-                          hitSlop={6}
-                          className="items-center justify-center active:opacity-60"
-                          style={{
-                            width: 30,
-                            height: 30,
-                            borderRadius: 15,
-                            backgroundColor: isDark ? '#262626' : '#F3F4F6',
-                          }}
-                        >
-                          <ChevronRight size={16} color={isDark ? '#A8A29E' : '#78716C'} />
-                        </Pressable>
-                      </View>
-                    </View>
-                  ))}
+                  {(() => {
+                    const q = searchQuery.trim().toLowerCase()
+                    const matches = q
+                      ? centerOptionsDesktop.filter((o) => o.label.toLowerCase().includes(q) || (o.sublabel ?? '').toLowerCase().includes(q))
+                      : centerOptionsDesktop
+                    const withEvents = matches.filter((o) => o.count > 0)
+                    const withoutEvents = matches.filter((o) => o.count === 0)
+                    return (
+                      <>
+                        {withEvents.length > 0 && (
+                          <Text className="font-sans text-stone-400 dark:text-stone-500 uppercase px-4 pt-3 pb-1" style={{ fontSize: 11, letterSpacing: 0.8 }}>
+                            Centers with events
+                          </Text>
+                        )}
+                        {withEvents.map(renderCenterRowDesktop)}
+                        {withoutEvents.length > 0 && (
+                          <Text className="font-sans text-stone-400 dark:text-stone-500 uppercase px-4 pt-5 pb-1" style={{ fontSize: 11, letterSpacing: 0.8 }}>
+                            Other centers
+                          </Text>
+                        )}
+                        {withoutEvents.map(renderCenterRowDesktop)}
+                      </>
+                    )
+                  })()}
                 </>
               )}
 

--- a/packages/frontend/components/map/Map.web.tsx
+++ b/packages/frontend/components/map/Map.web.tsx
@@ -43,7 +43,7 @@ export interface MapProps {
    * Programmatic fly-to (e.g. list selection). `key` must change each time you want a new animation,
    * including re-selecting the same place.
    */
-  flyTo?: { latitude: number; longitude: number; key: number } | null
+  flyTo?: { latitude: number; longitude: number; key: number; zoom?: number } | null
   /**
    * After the next fly-to settles, simulate a click on the matching marker so
    * the popover opens for THIS specific point. Necessary when several events
@@ -270,10 +270,10 @@ const MapComponent = memo<MapProps>(
       if (!isValidCoordinate(latitude, longitude)) return
       mapRef.current?.flyTo({
         center: [longitude, latitude],
-        zoom: 15,
+        zoom: flyTo.zoom ?? 15,
         duration: 1200,
       })
-    }, [flyTo?.key, flyTo?.latitude, flyTo?.longitude])
+    }, [flyTo?.key, flyTo?.latitude, flyTo?.longitude, flyTo?.zoom])
 
     // After fly-to settles, programmatically open the popover for the
     // requested point. Solves the "click event A in list, see event B's


### PR DESCRIPTION
## What
Reworks the Explore center filter based on live testing.

### Behavior
- **Guest-accessible:** the center filter no longer requires login. Guests default to **All centers** and can scope events or open any center page.
- **Real filtering:** picking a specific center filters events to **that center + a ~100 mi radius** (both the list **and** the map markers), instead of only re-sorting. "All centers" is the show-all escape; the default/home view still just sorts so it never starts empty.

### Picker redesign (web — desktop + mobile-web)
- Centers split into **"Centers with events"** (selectable, **event-count pill**, **map flies to the area** on select) and **"Other centers"** (no events → row opens the center page only).
- **Search filters the visible center list** while the picker is open, and **clears on select** (so a typed center name doesn't then wrongly filter the event list).
- **Mode-aware placeholder:** "Search events…" normally, "Search centers…" when the picker is open.
- Mobile-web: **full-width card**, and the bottom-sheet drag handler no longer swallows taps on interactive controls (this is what broke the picker + Close from opening).

### Misc
- `Map.web` `flyTo` now accepts an optional `zoom` (center selection lands at an area-level zoom, not a tight pin zoom).

## Test
Sign in (or stay logged out) → Explore → open the center dropdown:
1. Pick a center with events → list + map narrow to its ~100 mi area; map flies there.
2. "Other centers" rows are page-only; tap → center page.
3. Type in search while the picker is open → center list filters; pick one → search clears.
4. Mobile-web (< 768px): card is full-width, tapping it opens the picker, Close works.

## Follow-up
**Native (`explore.tsx`) has the guest access + radius filter, but not the full picker redesign / map fly-to yet** — porting next (needs `Map.native` fly-to). Verified on the local v2 build against the preview backend.