### PR TITLE
feat(settings): combine Profile into Settings (top section) + fix #346 404

### DIFF
--- a/packages/frontend/app/settings/_layout.tsx
+++ b/packages/frontend/app/settings/_layout.tsx
@@ -1,32 +1,20 @@
 import React from 'react'
-import { View, Text, Pressable, ScrollView, Platform, useWindowDimensions } from 'react-native'
+import { View, Pressable, Platform } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useRouter, usePathname, Slot, Stack } from 'expo-router'
-import { ArrowLeft, User, Settings as SettingsIcon } from 'lucide-react-native'
+import { useRouter, Slot, Stack } from 'expo-router'
+import { ArrowLeft } from 'lucide-react-native'
 import { useTheme } from '../../components/contexts'
+import { Text } from '../../components/ui'
 
-const SETTINGS_TABS = [
-  { id: 'profile', label: 'Profile', icon: User, path: '/settings/profile' },
-  { id: 'index', label: 'Preferences', icon: SettingsIcon, path: '/settings' },
-]
-
+// Settings is one combined page (Profile section + preferences) on web, and a
+// stack on native. The old web sidebar (Profile / Preferences tabs) was removed
+// because Profile now lives as the top section of the page — see
+// settings/index.web.tsx. The /settings/profile route redirects here (#346).
 export default function SettingsLayout() {
   const router = useRouter()
-  const pathname = usePathname()
   const { isDark } = useTheme()
-  const { width } = useWindowDimensions()
 
-  const showSidebar = Platform.OS === 'web' && width >= 768
-
-  const handleTabPress = (path: string) => {
-    router.push(path as any)
-  }
-
-  const handleClose = () => {
-    router.push('/')
-  }
-
-  // Native: Stack with slide animation
+  // Native: stack with slide animation (unchanged)
   if (Platform.OS !== 'web') {
     return (
       <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
@@ -36,105 +24,41 @@ export default function SettingsLayout() {
     )
   }
 
-  // Web: sidebar layout
+  const handleClose = () => {
+    if (router.canGoBack()) router.back()
+    else router.push('/')
+  }
+
   return (
-    <>
-      <Stack.Screen options={{ headerShown: false }} />
-      <SafeAreaView
-        style={{ flex: 1, backgroundColor: isDark ? '#171717' : '#FFFFFF' }}
-        edges={['bottom']}
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: isDark ? '#1A1A1A' : '#F5F5F4' }}
+      edges={['top', 'bottom']}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 8,
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+          borderBottomWidth: 1,
+          borderBottomColor: isDark ? '#262626' : '#E7E5E4',
+          backgroundColor: isDark ? '#171717' : '#FFFFFF',
+        }}
       >
-        <View style={{ flex: 1, flexDirection: 'row' }}>
-          {showSidebar && (
-            <View
-              style={{
-                width: 256,
-                borderRightWidth: 1,
-                borderRightColor: isDark ? '#44403C' : '#E7E5E4',
-                backgroundColor: isDark ? '#1C1917' : '#FAFAF9',
-              }}
-            >
-              <View
-                style={{
-                  padding: 24,
-                  borderBottomWidth: 1,
-                  borderBottomColor: isDark ? '#44403C' : '#E7E5E4',
-                }}
-              >
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    marginBottom: 8,
-                  }}
-                >
-                  <Pressable
-                    onPress={handleClose}
-                    style={{
-                      minWidth: 44,
-                      minHeight: 44,
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <ArrowLeft size={20} color={isDark ? '#a1a1aa' : '#71717a'} />
-                  </Pressable>
-                  <Text
-                    style={{
-                      fontFamily: 'Inclusive Sans',
-                      fontSize: 24,
-                      color: isDark ? '#FAFAF9' : '#1C1917',
-                    }}
-                  >
-                    Settings
-                  </Text>
-                  <View style={{ width: 44 }} />
-                </View>
-              </View>
-              <ScrollView style={{ flex: 1, padding: 12 }}>
-                {SETTINGS_TABS.map((tab) => {
-                  const isActive = pathname === tab.path || pathname.startsWith(tab.path + '/')
-                  const Icon = tab.icon
-                  return (
-                    <Pressable
-                      key={tab.id}
-                      onPress={() => handleTabPress(tab.path)}
-                      style={{
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        gap: 12,
-                        paddingHorizontal: 16,
-                        paddingVertical: 12,
-                        borderRadius: 12,
-                        marginBottom: 4,
-                        minHeight: 44,
-                        backgroundColor: isActive ? '#E8862A' : 'transparent',
-                      }}
-                    >
-                      <Icon
-                        size={20}
-                        color={isActive ? '#FFFFFF' : isDark ? '#A8A29E' : '#78716C'}
-                      />
-                      <Text
-                        style={{
-                          fontSize: 16,
-                          color: isActive ? '#FFFFFF' : isDark ? '#FAFAF9' : '#1C1917',
-                        }}
-                      >
-                        {tab.label}
-                      </Text>
-                    </Pressable>
-                  )
-                })}
-              </ScrollView>
-            </View>
-          )}
-          <View style={{ flex: 1 }}>
-            <Slot />
-          </View>
-        </View>
-      </SafeAreaView>
-    </>
+        <Pressable
+          onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          style={{ width: 40, height: 40, justifyContent: 'center', alignItems: 'center' }}
+        >
+          <ArrowLeft size={22} color={isDark ? '#a1a1aa' : '#71717a'} />
+        </Pressable>
+        <Text style={{ fontSize: 18, color: isDark ? '#FAFAF9' : '#1C1917' }}>Settings</Text>
+      </View>
+      <View style={{ flex: 1 }}>
+        <Slot />
+      </View>
+    </SafeAreaView>
   )
 }

--- a/packages/frontend/app/settings/index.web.tsx
+++ b/packages/frontend/app/settings/index.web.tsx
@@ -10,10 +10,10 @@ import {
   useWindowDimensions,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { Eye, Shield, Info, ExternalLink, AlertTriangle, UserPlus, LogOut, ChevronRight } from 'lucide-react-native'
+import { Eye, Shield, Info, ExternalLink, AlertTriangle, UserPlus, LogOut, ChevronRight, User } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { useRouter } from 'expo-router'
-import { DestructiveButton, SecondaryButton, Text } from '../../components/ui'
+import { DestructiveButton, SecondaryButton, Text, Avatar } from '../../components/ui'
 import ThemeSelector from '../../components/settings/ThemeSelector'
 import { useAnalytics } from '../../utils/analytics'
 import Constants from 'expo-constants'
@@ -22,8 +22,20 @@ const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
 
 export default function Preferences() {
   const { isDark } = useTheme()
-  const { deleteAccount, logout } = useUser()
+  const { deleteAccount, logout, user } = useUser()
   const router = useRouter()
+  const displayName =
+    user?.firstName && user?.lastName
+      ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
+  const vl = user?.verificationLevel ?? 0
+  const roleLabel =
+    vl >= 1000008 ? 'Global Head'
+      : vl >= 1008 ? 'Swami'
+      : vl >= 108 ? 'Brahmachari'
+      : vl >= 54 ? 'Sevak'
+      : vl >= 45 ? 'Verified member'
+      : null
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const { track } = useAnalytics()
@@ -78,20 +90,47 @@ export default function Preferences() {
           gap: isNarrowWeb ? 24 : 36,
         }}
       >
-        {/* Header */}
+        {/* Profile — top section of the combined Settings page (#346/#330) */}
         <View>
-          <Text
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+            <User size={20} color={iconColor} />
+            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Profile</Text>
+          </View>
+          <View
             style={{
-              fontSize: 30,
-              color: textColor,
-              letterSpacing: -0.5,
+              backgroundColor: cardBg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor,
+              padding: isNarrowWeb ? 20 : 28,
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 16,
             }}
           >
-            Preferences
-          </Text>
-          <Text style={{ fontSize: 15, color: mutedTextColor, marginTop: 4 }}>
-            Manage your app preferences
-          </Text>
+            <Avatar image={user?.profileImage || undefined} name={displayName} size={isNarrowWeb ? 56 : 64} />
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text style={{ fontSize: 18, color: textColor }} numberOfLines={1}>
+                {displayName}
+              </Text>
+              {user?.username ? (
+                <Text style={{ fontSize: 14, color: mutedTextColor, marginTop: 1 }} numberOfLines={1}>
+                  @{user.username}
+                </Text>
+              ) : null}
+              {roleLabel ? (
+                <Text style={{ fontSize: 13, color: '#C2410C', marginTop: 3 }}>{roleLabel}</Text>
+              ) : null}
+            </View>
+            <SecondaryButton
+              onPress={() => {
+                track('nav_edit_profile', { source: 'settings_web' })
+                router.push('/edit-profile')
+              }}
+            >
+              Edit
+            </SecondaryButton>
+          </View>
         </View>
 
         {/* Account Section (invite + log out — parity with the native settings) */}

--- a/packages/frontend/app/settings/profile.tsx
+++ b/packages/frontend/app/settings/profile.tsx
@@ -1,0 +1,7 @@
+import { Redirect } from 'expo-router'
+
+// Profile now lives as the top section of the combined Settings page.
+// This route used to 404 (#346); redirect any /settings/profile link there.
+export default function SettingsProfileRedirect() {
+  return <Redirect href="/settings" />
+}


### PR DESCRIPTION
## What
Combines Profile and Settings into one page, with **Profile as the top section** (per product direction), and fixes the `/settings/profile` 404 (#346).

- **Settings** is now a single combined page: **Profile card** (avatar, name, @username, role, **Edit** → `/edit-profile`) at the top, followed by Account (Invite, Log Out) / Appearance / Privacy / About / Danger Zone.
- Removed the web sidebar (Profile/Preferences tabs) from `settings/_layout.tsx`; it now renders a back-header + `Slot`. Profile lives in-page, not a separate tab.
- `/settings/profile` (previously 404 — **#346**) now redirects to `/settings`.

## Verified (Claude Preview, preview backend, logged in as Admin)
- ✅ Desktop (1280) + ✅ mobile (375): Profile card + all sections render responsively.
- ✅ `/settings/profile` → redirects to `/settings`, no 404.
- ✅ Edit → `/edit-profile` editor; Invite sub-page intact.

## Notes / follow-up
- Web "Change Photo" in the editor still uses native `expo-image-picker` (no web file-input) — pre-existing gap, separate fix.
- Deeper profile redesign (richer profile view, inline edit) remains **#330**; this lands the structural combine + kills the 404.

Fixes #346 · advances #330