### PR TITLE
feat(feed): explain the feature in the guest sign-in state

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native'
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Building2, CalendarDays, Megaphone } from 'lucide-react-native'
 import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
@@ -423,17 +424,20 @@ export default function FeedScreen() {
 
         {!user ? (
           <SignInCallout
-            title="Sign in for Feed"
-            subtitle="Your member feed, group boards, and announcements live here."
+            title="Your community feed"
+            subtitle="One place for your center and the events you attend."
+            features={[
+              { icon: Building2, label: 'Your center board', hint: 'Stay in the loop with members at your home center.' },
+              { icon: CalendarDays, label: 'Event boards', hint: 'Coordinate around every event you RSVP to.' },
+              { icon: Megaphone, label: 'Announcements', hint: "What's new across Chinmaya Mission, as it happens." },
+            ]}
             colors={colors}
             onPress={() => {
               track('connect_signin_pressed', { source: 'feed_banner' })
               router.push('/auth')
             }}
           />
-        ) : null}
-
-        {isLoading ? (
+        ) : isLoading ? (
           <View style={{ gap: 12, paddingTop: 8 }}>
             {Array.from({ length: 3 }).map((_, i) => (
               <View

--- a/packages/frontend/components/boards/SignInCallout.tsx
+++ b/packages/frontend/components/boards/SignInCallout.tsx
@@ -1,19 +1,69 @@
 import React from 'react'
 import { Pressable, Text, View } from 'react-native'
-import { UsersRound } from 'lucide-react-native'
+import { UsersRound, type LucideIcon } from 'lucide-react-native'
 import type { AppColors } from '../../tokens'
+
+export type CalloutFeature = { icon: LucideIcon; label: string; hint?: string }
 
 export function SignInCallout({
   title,
   subtitle,
   colors,
   onPress,
+  features,
+  ctaLabel = 'Sign in',
 }: {
   title: string
   subtitle: string
   colors: AppColors
   onPress: () => void
+  /** When provided, renders a richer card that explains the feature. */
+  features?: CalloutFeature[]
+  ctaLabel?: string
 }) {
+  // Rich, explanatory card when feature highlights are passed.
+  if (features && features.length > 0) {
+    return (
+      <View style={{ backgroundColor: colors.accentSoft, borderRadius: 20, padding: 20, gap: 16 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <View style={{ width: 44, height: 44, borderRadius: 14, backgroundColor: colors.card, alignItems: 'center', justifyContent: 'center' }}>
+            <UsersRound size={22} color={colors.accent} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 18, color: colors.text }}>{title}</Text>
+            <Text style={{ fontSize: 13.5, lineHeight: 19, color: colors.textMuted, marginTop: 2 }}>{subtitle}</Text>
+          </View>
+        </View>
+        <View style={{ gap: 12 }}>
+          {features.map((f, i) => {
+            const Icon = f.icon
+            return (
+              <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+                <View style={{ width: 34, height: 34, borderRadius: 11, backgroundColor: colors.card, alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon size={17} color={colors.accent} />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={{ fontSize: 14.5, color: colors.text }}>{f.label}</Text>
+                  {f.hint ? (
+                    <Text style={{ fontSize: 12.5, lineHeight: 17, color: colors.textMuted }}>{f.hint}</Text>
+                  ) : null}
+                </View>
+              </View>
+            )
+          })}
+        </View>
+        <Pressable
+          onPress={onPress}
+          accessibilityRole="button"
+          style={{ backgroundColor: colors.accent, borderRadius: 999, paddingVertical: 13, alignItems: 'center' }}
+        >
+          <Text style={{ fontWeight: '600', fontSize: 14.5, color: '#FFFFFF' }}>{ctaLabel}</Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  // Compact banner (original) — used where space is tight.
   return (
     <View style={{ backgroundColor: colors.accentSoft, borderRadius: 18, padding: 16, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
       <View style={{ width: 42, height: 42, borderRadius: 14, backgroundColor: colors.card, alignItems: 'center', justifyContent: 'center' }}>
@@ -25,14 +75,10 @@ export function SignInCallout({
       </View>
       <Pressable
         onPress={onPress}
-        style={{
-          backgroundColor: colors.accent,
-          borderRadius: 999,
-          paddingHorizontal: 14,
-          paddingVertical: 10,
-        }}
+        accessibilityRole="button"
+        style={{ backgroundColor: colors.accent, borderRadius: 999, paddingHorizontal: 14, paddingVertical: 10 }}
       >
-        <Text style={{ fontWeight: '500', fontSize: 13, color: '#FFFFFF' }}>Sign in</Text>
+        <Text style={{ fontWeight: '500', fontSize: 13, color: '#FFFFFF' }}>{ctaLabel}</Text>
       </Pressable>
     </View>
   )


### PR DESCRIPTION
## What
The guest Feed showed a small "Sign in for Feed" banner **plus** a redundant locked panel, and neither explained what the Feed actually is. Replace both with a single informative callout.

- **"Your community feed"** card with three benefit rows — **Your center board**, **Event boards**, **Announcements** (each with a one-line hint) — and one clear **Sign in** CTA.
- `SignInCallout` gains an optional `features` list (rich-card variant; compact banner unchanged for other uses).
- Guests now see only this card (removed the duplicate locked panel).

## Verified (Claude Preview)
- ✅ Desktop + ✅ mobile: rich callout renders responsively as a guest.
- ✅ Signed-in empty state ("Your community feed" → Go to Explore) intact.

Addresses the "Feed sign-in / empty states should be friendlier and explain the feature" ask.