### PR TITLE
feat(admin): relabel "Invite Codes" → "Invite Links" (#318 part 1)

### DIFF
--- a/packages/frontend/components/admin/AdminSidebar.tsx
+++ b/packages/frontend/components/admin/AdminSidebar.tsx
@@ -22,7 +22,7 @@ const tabs: { key: AdminTab; label: string; Icon: typeof Building2 }[] = [
   { key: 'Centers', label: 'Centers', Icon: Building2 },
   { key: 'Events', label: 'Events', Icon: CalendarDays },
   { key: 'Users', label: 'Users', Icon: Users },
-  { key: 'Invite Codes', label: 'Invite Codes', Icon: Ticket },
+  { key: 'Invite Codes', label: 'Invite Links', Icon: Ticket },
   { key: 'Moderation', label: 'Moderation', Icon: ShieldAlert },
   { key: 'Notifications', label: 'Notifications', Icon: Bell },
 ]

--- a/packages/frontend/components/admin/InviteCodesTab.tsx
+++ b/packages/frontend/components/admin/InviteCodesTab.tsx
@@ -336,7 +336,7 @@ export default function InviteCodesTab() {
       <View style={[createStyles.overlay, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>
         <View style={[createStyles.modal, { backgroundColor: colors.panelBg, borderColor: colors.border }]}>
           <View style={createStyles.modalHeader}>
-            <Text style={[createStyles.modalTitle, { color: colors.text }]}>Create Invite Code</Text>
+            <Text style={[createStyles.modalTitle, { color: colors.text }]}>Create Invite Link</Text>
             <Pressable onPress={() => { setShowCreate(false); setCreateError('') }}>
               <X size={18} color={colors.textMuted} />
             </Pressable>
@@ -378,7 +378,7 @@ export default function InviteCodesTab() {
             style={[createStyles.createBtn, creating && { opacity: 0.6 }]}
           >
             <Text style={createStyles.createBtnText}>
-              {creating ? 'Creating...' : 'Create Code'}
+              {creating ? 'Creating...' : 'Create Link'}
             </Text>
           </Pressable>
         </View>
@@ -411,13 +411,13 @@ export default function InviteCodesTab() {
     <View style={styles.container}>
       <View style={styles.tablePanel}>
         <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>Invite Codes ({codes.length})</Text>
+          <Text style={[styles.title, { color: colors.text }]}>Invite Links ({codes.length})</Text>
           <Pressable
             onPress={() => setShowCreate(true)}
             style={styles.addBtn}
           >
             <Plus size={14} color="#fff" />
-            <Text style={styles.addBtnText}>New Code</Text>
+            <Text style={styles.addBtnText}>New Link</Text>
           </Pressable>
         </View>
 
@@ -433,14 +433,14 @@ export default function InviteCodesTab() {
       </View>
 
       {selectedCode && (
-        <AdminDetailPanel title="Invite Code" onClose={() => setSelectedCode(null)}>
+        <AdminDetailPanel title="Invite Link" onClose={() => setSelectedCode(null)}>
           {renderDetailContent()}
         </AdminDetailPanel>
       )}
 
       <ConfirmDialog
         visible={confirmToggleVisible}
-        title={selectedCode?.isActive ? 'Deactivate Code' : 'Activate Code'}
+        title={selectedCode?.isActive ? 'Deactivate Link' : 'Activate Link'}
         message={
           selectedCode?.isActive
             ? `Deactivating "${selectedCode?.code}" will prevent new signups with this code. Existing users are unaffected.`


### PR DESCRIPTION
## What
The product moved from invite **codes** to invite **links**, but the admin dashboard still said "Invite Codes". Relabel the whole section (the entity/API is unchanged — a link is a code wrapped in a URL).

Updated user-facing copy: sidebar item, tab title (**Invite Links (N)**), **New Link** / **Create Invite Link** / **Create Link**, detail panel (**Invite Link**), and activate/deactivate confirm dialog.

## Verified (Claude Preview, Admin)
- ✅ Admin sidebar shows **Invite Links**; tab content reads **"Invite Links (0)"**; no "Invite Codes" strings remain. Text-only change → identical on mobile.

## Scope
Part 1 (relabel). **Part 2** of #318 — PostHog telemetry + admin controls across all admin pages — is a larger, separate follow-up; left open.