### PR TITLE
fix(home): hide "your boards" empty state from guests

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -266,7 +266,7 @@ export default function HomeScreen() {
   // Boards peek (#199): the 1-2 latest posts from the user's center board.
   // New users get their center + a feed peek inside the first-run overview,
   // so this section is for returning members only.
-  const boardsSection = !isNewUser ? (
+  const boardsSection = user && !isNewUser ? (
     <SectionHeader
       eyebrow="LATEST ON YOUR BOARDS"
       trailing="Open Feed"


### PR DESCRIPTION
Guests have no boards, so Home showed a confusing "Latest on your boards → No posts yet on your boards" block. Gate the boards section on a signed-in user. Guests keep the "Make Janata yours" nudge + public events. Verified as a guest on the preview.