### PR TITLE
feat(center): admin in-place edit of About + Point of Contact (#285)

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2193,6 +2193,7 @@ app.put('/admin/centers/:id', adminMiddleware, async (c) => {
     image?: string
     acharya?: string
     pointOfContact?: string
+    description?: string
   }>()
 
   const updates: Partial<CenterRow> = {}
@@ -2203,6 +2204,7 @@ app.put('/admin/centers/:id', adminMiddleware, async (c) => {
   if (body.image !== undefined) updates.image = body.image
   if (body.acharya !== undefined) updates.acharya = body.acharya
   if (body.pointOfContact !== undefined) updates.point_of_contact = body.pointOfContact
+  if (body.description !== undefined) updates.description = body.description
 
   const result = await db.updateCenter(c.env.DB, centerId, updates)
   if (result.success) {

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -11,6 +11,7 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../compon
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { useUser } from '../../components/contexts'
+import { CenterAbout } from '../../components/center/CenterAbout'
 import { SeoHead } from '../../components/seo/SeoHead'
 import { buildCenterJsonLd } from '../../components/seo/jsonLd'
 import { useAnalytics } from '../../utils/analytics'
@@ -99,6 +100,7 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
   }, [loading, center?.id, center?.name])
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
+  const canEditCenter = !!user && (user.verificationLevel ?? 0) >= 107
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -268,16 +270,19 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
           <Image source={{ uri: center.image }} style={{ width: '100%', height: 200, marginBottom: 4 }} resizeMode="cover" />
         ) : null}
 
-        {/* DETAILS */}
-        <DetailSection title="Details" first>
-          <View style={{ gap: 16 }}>
-            {center.pointOfContact ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                <User size={18} color="#E8862A" />
-                <Text style={{ color: colors.text, fontSize: 15 }}>Contact: {center.pointOfContact}</Text>
-              </View>
-            ) : null}
+        {/* ABOUT (editable by admins — #285) */}
+        <DetailSection title="About" first>
+          <CenterAbout
+            centerId={center.id}
+            description={center.description}
+            pointOfContact={center.pointOfContact}
+            canEdit={canEditCenter}
+          />
+        </DetailSection>
 
+        {/* DETAILS */}
+        <DetailSection title="Details">
+          <View style={{ gap: 16 }}>
             {center.address ? (
               <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>
                 <MapPin size={18} color="#E8862A" style={{ marginTop: 2 }} />

--- a/packages/frontend/components/center/CenterAbout.tsx
+++ b/packages/frontend/components/center/CenterAbout.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react'
+import { View, TextInput, Pressable, ActivityIndicator } from 'react-native'
+import { Pencil, Check, X } from 'lucide-react-native'
+import { Text } from '../ui'
+import { useColors } from '../../hooks/useColors'
+import { adminUpdateCenter } from '../../utils/api'
+import { useAnalytics } from '../../utils/analytics'
+
+// Editable About + Point of Contact for a center (#285). Admins get an inline
+// editor; everyone else sees read-only. Uses a local override so a save is
+// reflected immediately without a parent refetch (useCenterDetail exposes none,
+// and the desktop panel receives `center` as a prop).
+export function CenterAbout({
+  centerId,
+  description,
+  pointOfContact,
+  canEdit,
+}: {
+  centerId: string
+  description?: string | null
+  pointOfContact?: string | null
+  canEdit: boolean
+}) {
+  const c = useColors()
+  const { track } = useAnalytics()
+  const [desc, setDesc] = useState((description ?? '').trim())
+  const [poc, setPoc] = useState((pointOfContact ?? '').trim())
+  const [editing, setEditing] = useState(false)
+  const [draftDesc, setDraftDesc] = useState(desc)
+  const [draftPoc, setDraftPoc] = useState(poc)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const hasContent = !!desc || !!poc
+  if (!hasContent && !canEdit) return null
+
+  const startEdit = () => {
+    setDraftDesc(desc)
+    setDraftPoc(poc)
+    setError(null)
+    setEditing(true)
+    track('center_about_edit_opened', { centerId })
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await adminUpdateCenter(centerId, {
+        description: draftDesc.trim(),
+        pointOfContact: draftPoc.trim() || null,
+      })
+      setDesc(draftDesc.trim())
+      setPoc(draftPoc.trim())
+      setEditing(false)
+      track('center_about_saved', { centerId })
+    } catch {
+      setError('Could not save. Please try again.')
+      track('center_about_save_failed', { centerId })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const label = (t: string) => (
+    <Text style={{ fontSize: 11, letterSpacing: 0.8, color: c.textFaint }}>{t}</Text>
+  )
+
+  return (
+    <View style={{ gap: 12 }}>
+      {canEdit && !editing ? (
+        <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+          <Pressable
+            onPress={startEdit}
+            accessibilityRole="button"
+            accessibilityLabel="Edit about"
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 4, paddingVertical: 4, paddingHorizontal: 9, borderRadius: 999, backgroundColor: c.accentSoft }}
+          >
+            <Pencil size={13} color={c.accent} />
+            <Text style={{ fontSize: 12.5, color: c.accent, fontWeight: '600' }}>Edit</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {editing ? (
+        <View style={{ gap: 12, borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 14 }}>
+          <View style={{ gap: 4 }}>
+            {label('DESCRIPTION')}
+            <TextInput
+              value={draftDesc}
+              onChangeText={setDraftDesc}
+              placeholder="Describe this center"
+              placeholderTextColor={c.textFaint}
+              multiline
+              textAlignVertical="top"
+              style={{ minHeight: 84, fontSize: 15, lineHeight: 21, color: c.text }}
+            />
+          </View>
+          <View style={{ height: 1, backgroundColor: c.border }} />
+          <View style={{ gap: 4 }}>
+            {label('POINT OF CONTACT')}
+            <TextInput
+              value={draftPoc}
+              onChangeText={setDraftPoc}
+              placeholder="Name of the coordinator"
+              placeholderTextColor={c.textFaint}
+              style={{ fontSize: 15, color: c.text }}
+            />
+          </View>
+          {error ? <Text style={{ fontSize: 13, color: '#DC2626' }}>{error}</Text> : null}
+          <View style={{ flexDirection: 'row', gap: 10, justifyContent: 'flex-end' }}>
+            <Pressable
+              onPress={() => setEditing(false)}
+              disabled={saving}
+              accessibilityRole="button"
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 4, paddingVertical: 8, paddingHorizontal: 14, borderRadius: 999, borderWidth: 1, borderColor: c.border }}
+            >
+              <X size={15} color={c.textMuted} />
+              <Text style={{ fontSize: 14, color: c.textMuted }}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={save}
+              disabled={saving}
+              accessibilityRole="button"
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 8, paddingHorizontal: 16, borderRadius: 999, backgroundColor: c.accent, opacity: saving ? 0.6 : 1 }}
+            >
+              {saving ? <ActivityIndicator size="small" color="#fff" /> : <Check size={15} color="#fff" />}
+              <Text style={{ fontSize: 14, fontWeight: '600', color: '#fff' }}>Save</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : (
+        <View style={{ gap: 8 }}>
+          {desc ? (
+            <Text style={{ fontSize: 15, lineHeight: 22, color: c.text }}>{desc}</Text>
+          ) : (
+            <Text style={{ fontSize: 14, color: c.textMuted, fontStyle: 'italic' }}>No description yet.</Text>
+          )}
+          {poc ? (
+            <Text style={{ fontSize: 14, color: c.textMuted }}>Point of Contact: {poc}</Text>
+          ) : null}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -3,6 +3,7 @@ import { View, Text, Image, ScrollView, Pressable, Linking } from 'react-native'
 import { MapPin, Globe, Phone, User, ChevronLeft, Navigation, BadgeCheck, Users } from 'lucide-react-native'
 import CopyLinkButton from '../ui/CopyLinkButton'
 import { DetailSection } from '../ui'
+import { CenterAbout } from './CenterAbout'
 import { useBoard, type CenterDisplay } from '../../hooks/useApiData'
 import { createBoardPost, type EventDisplay } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
@@ -62,6 +63,7 @@ export default function CenterDetailPanel({
     .replace(/\/$/, '')
   const canPostToThread =
     !!user && (user.centerID === center.id || (user.verificationLevel ?? 0) >= 107)
+  const canEditCenter = !!user && (user.verificationLevel ?? 0) >= 107
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -173,22 +175,18 @@ export default function CenterDetailPanel({
           resizeMode="cover"
         />
 
-        {/* ── DETAILS ─────────────────────────────────────────────── */}
-        <DetailSection title="Details" first>
-          {/* Point of contact subtitle */}
-          {center.pointOfContact ? (
-            <Text
-              style={{
-                fontFamily: 'Inclusive Sans',
-                fontSize: 13,
-                color: colors.textSecondary,
-                marginBottom: 16,
-              }}
-            >
-              Point of Contact: {center.pointOfContact}
-            </Text>
-          ) : null}
+        {/* ── ABOUT (editable by admins — #285) ───────────────────── */}
+        <DetailSection title="About" first>
+          <CenterAbout
+            centerId={center.id}
+            description={center.description}
+            pointOfContact={center.pointOfContact}
+            canEdit={canEditCenter}
+          />
+        </DetailSection>
 
+        {/* ── DETAILS ─────────────────────────────────────────────── */}
+        <DetailSection title="Details">
           {/* ── Meta rows ────────────────────────────────────────── */}
           <View style={{ gap: 16 }}>
             {/* Address */}


### PR DESCRIPTION
## What
Admins can now edit a center's **About (description)** and **Point of Contact** in place on the center page (#285).

- New `CenterAbout` component — read-only for everyone, inline **Edit** for admins (`verificationLevel >= 107`): Edit → description + point-of-contact fields → Save via `adminUpdateCenter`. Uses a local override so the save shows immediately (neither `useCenterDetail` nor the desktop panel expose a refetch).
- Wired into **both web surfaces** — desktop panel (`CenterDetailPanel.web`) and mobile-web (`MobileCenterDetail`); point-of-contact moved into the new About section (removed the Details duplicate).
- **Backend:** `PUT /admin/centers/:id` now persists `description` — it only saved `point_of_contact` before, which I caught in live testing (point-of-contact persisted, description silently dropped).

## Verified (Claude Preview, logged in as Admin)
- ✅ Desktop panel + ✅ mobile-web: About section renders, admin **Edit** opens the form, **Save** succeeds, **Point of Contact persists** across reload/surfaces.
- ⏳ Description persistence takes effect once the preview **backend redeploys** (this commit) — the frontend already sends it and point-of-contact proves the path works.

## Follow-up
Native center page (`app/center/[id].tsx`) — same component can be dropped in; deferred since it's not web-verifiable here.

Fixes #285 (web).