### PR TITLE
feat(boards): photo attachment on board posts (#283)

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2104,6 +2104,40 @@ app.post('/profile/uploadImage', authMiddleware, async (c) => {
   return c.json({ message: 'Profile image uploaded successfully', imageUrl: url })
 })
 
+// Board image upload (#283). Mirrors /profile/uploadImage but stores under a
+// `boards/` prefix and does NOT touch the user's profile — it just returns a
+// URL the client passes to createBoardPost as `imageUrl`.
+app.post('/board/uploadImage', authMiddleware, async (c) => {
+  const user = c.get('user')
+
+  const body = await c.req.parseBody()
+  const file = body['file']
+
+  if (!(file instanceof File)) {
+    return c.json({ message: 'No file uploaded' }, 400)
+  }
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return c.json(
+      { message: 'Unsupported file type. Allowed types are JPEG, PNG, GIF, WebP, HEIC' },
+      400
+    )
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return c.json({ message: 'File size exceeds 5MB limit' }, 400)
+  }
+
+  const ext = file.name.split('.').pop() || 'jpg'
+  const key = `boards/${user.id}/${crypto.randomUUID()}.${ext}`
+
+  await c.env.AVATARS.put(key, file.stream(), {
+    httpMetadata: { contentType: file.type },
+    customMetadata: { userId: user.id, originalFileName: file.name },
+  })
+
+  const url = `https://avatars.chinmayajanata.org/avatars/${key}`
+  return c.json({ message: 'Image uploaded', imageUrl: url })
+})
+
 // ── Fun route ─────────────────────────────────────────────────────────
 
 app.post('/brewCoffee', (c) => {

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -385,10 +385,11 @@ export default function FeedScreen() {
 
   const handleCreatePost = async (
     group: { kind: 'center' | 'event'; parentId: string },
-    body: string
+    body: string,
+    imageUrl?: string | null
   ) => {
     try {
-      await createBoardPost(group.kind, group.parentId, body)
+      await createBoardPost(group.kind, group.parentId, body, imageUrl)
       track('feed_post_created', { kind: group.kind, parentId: group.parentId, source: 'feed' })
       await loadBoards()
     } catch (err) {

--- a/packages/frontend/components/boards/CreatePostSheet.tsx
+++ b/packages/frontend/components/boards/CreatePostSheet.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
-import { Building2, CalendarDays, ChevronDown, X } from 'lucide-react-native'
+import { ActivityIndicator, Image, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { Building2, CalendarDays, ChevronDown, ImagePlus, X } from 'lucide-react-native'
 import { Avatar } from '../ui'
 import type { AppColors } from '../../tokens'
 import { useAnalytics } from '../../utils/analytics'
+import { uploadBoardImage } from '../../utils/api'
 
 type GroupOption = {
   id: string
@@ -23,13 +24,40 @@ export function CreatePostSheet({
   colors: AppColors
   groups: GroupOption[]
   onClose: () => void
-  onSubmit?: (group: GroupOption, body: string) => Promise<void> | void
+  onSubmit?: (group: GroupOption, body: string, imageUrl?: string | null) => Promise<void> | void
 }) {
   const { track } = useAnalytics()
   const [body, setBody] = useState('')
   const [groupId, setGroupId] = useState<string | undefined>()
   const [groupPickerOpen, setGroupPickerOpen] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+
+  const clearImage = () => {
+    if (imagePreview) URL.revokeObjectURL(imagePreview)
+    setImageFile(null)
+    setImagePreview(null)
+  }
+
+  // Web image picker via a transient file input. Native photo attach (expo-
+  // image-picker) is a follow-up, so the button is web-only for now.
+  const pickImageWeb = () => {
+    if (typeof document === 'undefined') return
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/*'
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (file) {
+        clearImage()
+        setImageFile(file)
+        setImagePreview(URL.createObjectURL(file))
+        track('board_post_image_added', { source: 'create_post_sheet' })
+      }
+    }
+    input.click()
+  }
 
   const sortedGroups = useMemo(
     () => [...groups].sort((a, b) => (a.kind !== b.kind ? (a.kind === 'center' ? -1 : 1) : a.title.localeCompare(b.title))),
@@ -38,25 +66,29 @@ export function CreatePostSheet({
   const selectedGroup = sortedGroups.find((g) => g.id === groupId) ?? sortedGroups[0]
 
   useEffect(() => {
-    if (!visible) { setBody(''); setGroupPickerOpen(false); return }
+    if (!visible) { setBody(''); setGroupPickerOpen(false); clearImage(); return }
     if (!groupId && sortedGroups[0]) setGroupId(sortedGroups[0].id)
   }, [visible, groupId, sortedGroups])
 
-  const canPost = body.trim().length > 0 && !!selectedGroup && !submitting
+  const canPost = (body.trim().length > 0 || !!imageFile) && !!selectedGroup && !submitting
 
   const handleSubmit = async () => {
     if (!canPost || !selectedGroup) return
     try {
       setSubmitting(true)
-      await onSubmit?.(selectedGroup, body.trim())
+      let imageUrl: string | null = null
+      if (imageFile) imageUrl = await uploadBoardImage(imageFile)
+      await onSubmit?.(selectedGroup, body.trim(), imageUrl)
       track('board_post_created', {
         source: 'create_post_sheet',
         group_id: selectedGroup.id,
         group_kind: selectedGroup.kind,
         group_title: selectedGroup.title,
         body_length: body.trim().length,
+        has_image: !!imageFile,
       })
       setBody('')
+      clearImage()
       onClose()
     } catch (err) {
       track('board_post_create_failed', {
@@ -161,6 +193,33 @@ export function CreatePostSheet({
               style={{ flex: 1, minHeight: 160, fontFamily: 'Inclusive Sans', fontSize: 16, lineHeight: 23, color: colors.text, textAlignVertical: 'top', paddingTop: 6 }}
             />
           </View>
+
+          {imagePreview ? (
+            <View style={{ marginTop: 14, alignSelf: 'flex-start' }}>
+              <Image
+                source={{ uri: imagePreview }}
+                style={{ width: 168, height: 168, borderRadius: 14, backgroundColor: colors.panel }}
+                resizeMode="cover"
+              />
+              <Pressable
+                onPress={clearImage}
+                accessibilityRole="button"
+                accessibilityLabel="Remove photo"
+                style={{ position: 'absolute', top: 8, right: 8, width: 26, height: 26, borderRadius: 13, backgroundColor: 'rgba(0,0,0,0.6)', alignItems: 'center', justifyContent: 'center' }}
+              >
+                <X size={15} color="#fff" />
+              </Pressable>
+            </View>
+          ) : Platform.OS === 'web' ? (
+            <Pressable
+              onPress={pickImageWeb}
+              accessibilityRole="button"
+              style={{ marginTop: 14, flexDirection: 'row', alignItems: 'center', gap: 8, alignSelf: 'flex-start', paddingVertical: 9, paddingHorizontal: 14, borderRadius: 999, borderWidth: 1, borderColor: colors.border }}
+            >
+              <ImagePlus size={17} color={colors.accent} />
+              <Text style={{ fontSize: 14, color: colors.text }}>Add photo</Text>
+            </Pressable>
+          ) : null}
 
           <Text style={{ marginTop: 16, fontSize: 12, lineHeight: 18, color: colors.textFaint }}>
             Visible to members in {selectedGroup?.title || 'your group'}.

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar } from '../ui'
 import type { BoardMessage } from './__mocks__/mockData'
@@ -442,23 +442,12 @@ export function BoardPostCard({
             {message.body}
           </Text>
 
-          {message.attachmentLabel ? (
-            <View
-              style={{
-                marginTop: 2,
-                height: 76,
-                borderRadius: 18,
-                backgroundColor: colors.iconBoxBg,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Text
-                style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textSecondary }}
-              >
-                {message.attachmentLabel}
-              </Text>
-            </View>
+          {message.imageUrl ? (
+            <Image
+              source={{ uri: message.imageUrl }}
+              style={{ marginTop: 8, width: '100%', maxWidth: 360, height: 220, borderRadius: 16, backgroundColor: colors.iconBoxBg }}
+              resizeMode="cover"
+            />
           ) : null}
 
           <View

--- a/packages/frontend/components/boards/__mocks__/mockData.ts
+++ b/packages/frontend/components/boards/__mocks__/mockData.ts
@@ -15,6 +15,7 @@ export interface BoardMessage {
   timestamp: string
   body: string
   attachmentLabel?: string
+  imageUrl?: string
   reactions?: Array<{ emoji: string; count: number }>
   replyCount?: number
   pinned?: boolean

--- a/packages/frontend/components/boards/liveBoard.ts
+++ b/packages/frontend/components/boards/liveBoard.ts
@@ -47,7 +47,7 @@ export function boardPostToMessage(post: BoardPostData): BoardMessage {
     },
     timestamp: formatTimestamp(post.createdAt),
     body: post.body,
-    attachmentLabel: post.imageUrl ? 'Image attachment' : undefined,
+    imageUrl: post.imageUrl ?? undefined,
     reactions: post.reactions,
     replyCount: post.replyCount,
     // #249 — surface the pinned state so ThreadPanel renders its "Pinned" pill

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Pressable, Text, View } from 'react-native'
+import { Image, Pressable, Text, View } from 'react-native'
 import { Building2, CalendarDays, MessageCircle } from 'lucide-react-native'
 import { Avatar } from '../ui'
 import type { AppColors } from '../../tokens'
@@ -75,21 +75,12 @@ export function FeedPostCard({
 
           <Text style={{ fontSize: 14, lineHeight: 20, color: colors.text }}>{post.body}</Text>
 
-          {post.attachmentLabel ? (
-            <View
-              style={{
-                marginTop: 4,
-                height: 64,
-                borderRadius: 12,
-                backgroundColor: colors.panel,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Text style={{ fontSize: 11, color: colors.textMuted }}>
-                {post.attachmentLabel}
-              </Text>
-            </View>
+          {post.imageUrl ? (
+            <Image
+              source={{ uri: post.imageUrl }}
+              style={{ marginTop: 8, width: '100%', height: 200, borderRadius: 14, backgroundColor: colors.panel }}
+              resizeMode="cover"
+            />
           ) : null}
 
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16, marginTop: 6 }}>

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -541,6 +541,26 @@ export async function createBoardPost(
   return data.post
 }
 
+// Upload an image for a board post (#283) and return its hosted URL. Pass the
+// URL to createBoardPost as `imageUrl`. Multipart, so it does not go through the
+// JSON apiFetch wrapper.
+export async function uploadBoardImage(file: File | Blob): Promise<string> {
+  const token = await getStoredToken()
+  const form = new FormData()
+  form.append('file', file)
+  const response = await fetch(`${API_BASE_URL}/board/uploadImage`, {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    body: form,
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ message: 'Upload failed' }))
+    throw new Error(err.message || 'Upload failed')
+  }
+  const data = await response.json()
+  return data.imageUrl as string
+}
+
 export async function toggleBoardPostReaction(
   postId: string,
   emoji: string


### PR DESCRIPTION
## What
Adds photo attachments to board posts (#283). The plumbing was mostly there (`createBoardPost` already sent `imageUrl`, the backend stored `image_url`) — missing were the upload path and image rendering.

- **Backend:** `POST /board/uploadImage` → uploads to R2 under `boards/{userId}/…` and returns the URL. Mirrors the proven `/profile/uploadImage` but doesn't mutate the profile.
- **Client:** `uploadBoardImage(file)` (multipart).
- **Composer:** `CreatePostSheet` gets an **Add photo** button (web file picker) + preview + remove; uploads on submit, threads `imageUrl` through `onSubmit → handleCreatePost → createBoardPost`.
- **Rendering:** board posts now show the **actual image** (`ThreadPanel` + `FeedPostCard`) instead of the old "Image attachment" placeholder label.

## Verified (Claude Preview, member)
- ✅ Composer **Add photo** button + preview render on web (Feed → Write a post).
- ⏳ Full upload→post→display e2e takes effect once the preview **backend redeploys** (the `/board/uploadImage` endpoint is new), same as #285.

## Follow-up
Native photo picker (`expo-image-picker`) — the Add photo button is web-only for now.

Fixes #283 (web).