### PR TITLE
fix(events): stop labeling the first attendee as HOST (#356)

### DIFF
--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -581,9 +581,6 @@ function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: Detai
                   {a.subtitle}
                 </Text>
               </View>
-              {i === 0 && (
-                <Badge label="HOST" variant="host" />
-              )}
             </View>
           ))}
         </View>


### PR DESCRIPTION
The event People tab labeled whichever attendee was first (`i === 0`) as **HOST**, so a member who just RSVP'd showed up as the host. The `Attendee` type has no host/creator field and the event has no `createdBy` plumbed to this component, so the heuristic is wrong — removed it. A real host badge (driven by `created_by`) can be wired back when that data reaches the component. Compile-clean. Fixes #356.