### PR TITLE
fix(backend): add description to CenterRow — unblocks preview deploy

### DIFF
--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -74,6 +74,7 @@ export interface CenterRow {
   latitude: number
   longitude: number
   address: string | null
+  description: string | null
   website: string | null
   phone: string | null
   image: string | null


### PR DESCRIPTION
**Hotfix.** #285 added `updates.description` to `PUT /admin/centers/:id`, but `CenterRow` had no `description` field → `tsc --noEmit` error. The web Cloudflare merge-check doesn't run backend tsc, so it merged — but the **deploy's typecheck gate** failed, **blocking every v2preview deploy since #355** (the deployed preview has been stale; #356–#363 never went live). The DB column already exists; this just adds it to the type. `tsc` now exits 0.