### PR TITLE
feat(center): native ports — About edit (#285), board photo (#283) + description type fix

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -24,6 +24,7 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../compon
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import { useUser } from '../../components/contexts'
+import { CenterAbout } from '../../components/center/CenterAbout'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -172,6 +173,7 @@ export default function CenterDetailPage() {
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const canPostToThread =
     !!user && (user.centerID === center?.id || (user.verificationLevel ?? 0) >= 107)
+  const canEditCenter = !!user && (user.verificationLevel ?? 0) >= 107
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center?.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -326,18 +328,19 @@ export default function CenterDetailPage() {
           <Image source={{ uri: center.image }} style={{ width: '100%', height: 200, marginBottom: 4 }} resizeMode="cover" />
         ) : null}
 
-        {/* DETAILS */}
-        <DetailSection title="Details" first>
-          <View style={{ gap: 16 }}>
-            {center.pointOfContact ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <MetaIcon icon={User} color="#E8862A" colors={colors} />
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.text }}>
-                  Contact: {center.pointOfContact}
-                </Text>
-              </View>
-            ) : null}
+        {/* ABOUT (editable by admins — #285) */}
+        <DetailSection title="About" first>
+          <CenterAbout
+            centerId={center.id}
+            description={center.description}
+            pointOfContact={center.pointOfContact}
+            canEdit={canEditCenter}
+          />
+        </DetailSection>
 
+        {/* DETAILS */}
+        <DetailSection title="Details">
+          <View style={{ gap: 16 }}>
             {/* Address */}
             {center.address ? (
               <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>

--- a/packages/frontend/components/boards/CreatePostSheet.tsx
+++ b/packages/frontend/components/boards/CreatePostSheet.tsx
@@ -6,6 +6,11 @@ import type { AppColors } from '../../tokens'
 import { useAnalytics } from '../../utils/analytics'
 import { uploadBoardImage } from '../../utils/api'
 
+let ImagePicker: typeof import('expo-image-picker') | null = null
+try {
+  ImagePicker = require('expo-image-picker')
+} catch {}
+
 type GroupOption = {
   id: string
   kind: 'center' | 'event'
@@ -31,7 +36,7 @@ export function CreatePostSheet({
   const [groupId, setGroupId] = useState<string | undefined>()
   const [groupPickerOpen, setGroupPickerOpen] = useState(false)
   const [submitting, setSubmitting] = useState(false)
-  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imageFile, setImageFile] = useState<File | { uri: string; name: string; type: string } | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
 
   const clearImage = () => {
@@ -40,8 +45,7 @@ export function CreatePostSheet({
     setImagePreview(null)
   }
 
-  // Web image picker via a transient file input. Native photo attach (expo-
-  // image-picker) is a follow-up, so the button is web-only for now.
+  // Web image picker via a transient file input. Native uses pickImageNative.
   const pickImageWeb = () => {
     if (typeof document === 'undefined') return
     const input = document.createElement('input')
@@ -57,6 +61,28 @@ export function CreatePostSheet({
       }
     }
     input.click()
+  }
+
+  // Native image picker (expo-image-picker). Mirrors the web flow; the upload
+  // takes the { uri, name, type } descriptor RN's FormData accepts.
+  const pickImageNative = async () => {
+    if (!ImagePicker) return
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync()
+    if (!perm.granted) return
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      quality: 0.85,
+    })
+    if (result.canceled || !result.assets.length) return
+    const asset = result.assets[0]
+    clearImage()
+    setImageFile({
+      uri: asset.uri,
+      name: asset.fileName || `photo-${asset.assetId ?? 'board'}.jpg`,
+      type: asset.mimeType || 'image/jpeg',
+    })
+    setImagePreview(asset.uri)
+    track('board_post_image_added', { source: 'create_post_sheet' })
   }
 
   const sortedGroups = useMemo(
@@ -210,16 +236,16 @@ export function CreatePostSheet({
                 <X size={15} color="#fff" />
               </Pressable>
             </View>
-          ) : Platform.OS === 'web' ? (
+          ) : (
             <Pressable
-              onPress={pickImageWeb}
+              onPress={Platform.OS === 'web' ? pickImageWeb : pickImageNative}
               accessibilityRole="button"
               style={{ marginTop: 14, flexDirection: 'row', alignItems: 'center', gap: 8, alignSelf: 'flex-start', paddingVertical: 9, paddingHorizontal: 14, borderRadius: 999, borderWidth: 1, borderColor: colors.border }}
             >
               <ImagePlus size={17} color={colors.accent} />
               <Text style={{ fontSize: 14, color: colors.text }}>Add photo</Text>
             </Pressable>
-          ) : null}
+          )}
 
           <Text style={{ marginTop: 16, fontSize: 12, lineHeight: 18, color: colors.textFaint }}>
             Visible to members in {selectedGroup?.title || 'your group'}.

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -441,6 +441,7 @@ export interface CenterDisplay {
   phone: string
   upcomingEvents: number
   pointOfContact: string
+  description?: string | null
   acharya: string
   latitude?: number
   longitude?: number
@@ -488,6 +489,7 @@ export function useCenterDetail(centerId: string) {
             phone: apiCenter.phone || '',
             upcomingEvents: apiEvents.length,
             pointOfContact: apiCenter.pointOfContact || '',
+            description: apiCenter.description ?? null,
             acharya: apiCenter.acharya || '',
             latitude: apiCenter.latitude,
             longitude: apiCenter.longitude,

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -545,10 +545,14 @@ export async function createBoardPost(
 // Upload an image for a board post (#283) and return its hosted URL. Pass the
 // URL to createBoardPost as `imageUrl`. Multipart, so it does not go through the
 // JSON apiFetch wrapper.
-export async function uploadBoardImage(file: File | Blob): Promise<string> {
+export async function uploadBoardImage(
+  file: File | Blob | { uri: string; name: string; type: string }
+): Promise<string> {
   const token = await getStoredToken()
   const form = new FormData()
-  form.append('file', file)
+  // Web passes a File/Blob; native passes a { uri, name, type } descriptor,
+  // which React Native's FormData accepts directly.
+  form.append('file', file as any)
   const response = await fetch(`${API_BASE_URL}/board/uploadImage`, {
     method: 'POST',
     headers: token ? { Authorization: `Bearer ${token}` } : undefined,

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -16,6 +16,7 @@ export interface CenterData {
   image: string | null
   acharya: string | null
   pointOfContact: string | null
+  description?: string | null
   memberCount: number
   isVerified: boolean
   createdAt?: string


### PR DESCRIPTION
Native ports (web paths unchanged + already verified; native not yet sim-verified, per plan to verify on sim later).

## #285 — Center About edit (native)
- `CenterAbout` shared RN component now rendered on native `app/center/[id].tsx` (admin inline-edit of description + point of contact).
- Fixes the `description` type chain end-to-end: backend `CenterRow` → `CenterData` → `CenterDisplay` → `useCenterDetail` mapper.

## #283 — Board photo attach (native)
- `CreatePostSheet` gains a native pick path via `expo-image-picker`, mirroring the web transient-input flow.
- `uploadBoardImage` accepts the `{ uri, name, type }` descriptor RN's FormData needs.
- 'Add photo' button now shows on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)