### PR TITLE
feat(#318 pt2): admin action telemetry

### DIFF
--- a/packages/frontend/components/admin/CentersTab.tsx
+++ b/packages/frontend/components/admin/CentersTab.tsx
@@ -19,10 +19,12 @@ import {
 } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
+import { useAnalytics } from '../../utils/analytics'
 
 export default function CentersTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [search, setSearch] = useState('')
   const [centers, setCenters] = useState<CenterData[]>([])
   const [total, setTotal] = useState(0)
@@ -152,6 +154,7 @@ export default function CentersTab() {
         acharya: form.acharya.trim() || null,
         pointOfContact: form.pointOfContact.trim() || null,
       })
+      track('admin_center_updated', { centerId: selected.centerID, source: 'admin' })
       await loadCenters(search)
       setEditing(false)
     } catch (err: any) {
@@ -165,6 +168,7 @@ export default function CentersTab() {
     if (!selected) return
     try {
       await adminVerifyCenter(selected.centerID)
+      track('admin_center_verified', { centerId: selected.centerID, source: 'admin' })
       loadCenters(search)
     } catch (err) {
       console.error('Failed to toggle verification:', err)
@@ -175,6 +179,7 @@ export default function CentersTab() {
     if (!deleteTarget) return
     try {
       await adminDeleteCenter(deleteTarget.centerID)
+      track('admin_center_deleted', { centerId: deleteTarget.centerID, source: 'admin' })
       setDeleteTarget(null)
       setSelectedId(null)
       loadCenters(search)

--- a/packages/frontend/components/admin/EventsTab.tsx
+++ b/packages/frontend/components/admin/EventsTab.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
+import { useAnalytics } from '../../utils/analytics'
 
 const formatDate = (dateStr: string) => {
   const d = new Date(dateStr)
@@ -27,6 +28,7 @@ const formatTime = (dateStr: string) => {
 export default function EventsTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [search, setSearch] = useState('')
   const [events, setEvents] = useState<EventData[]>([])
   const [total, setTotal] = useState(0)
@@ -71,6 +73,7 @@ export default function EventsTab() {
     if (!deleteTarget) return
     try {
       await adminDeleteEvent(deleteTarget.eventID)
+      track('admin_event_deleted', { eventId: deleteTarget.eventID, source: 'admin' })
       setDeleteTarget(null)
       setSelectedId(null)
       loadEvents(search)

--- a/packages/frontend/components/admin/InviteCodesTab.tsx
+++ b/packages/frontend/components/admin/InviteCodesTab.tsx
@@ -15,6 +15,7 @@ import {
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
 import { Avatar } from '../ui'
+import { useAnalytics } from '../../utils/analytics'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,6 +34,7 @@ function formatDate(iso?: string): string {
 export default function InviteCodesTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const [codes, setCodes] = useState<InviteCodeData[]>([])
   const [loading, setLoading] = useState(true)
@@ -168,6 +170,7 @@ export default function InviteCodesTab() {
     if (!selectedCode) return
     try {
       await adminToggleInviteCode(selectedCode.code)
+      track('admin_invite_code_toggled', { code: selectedCode.code, source: 'admin' })
       // Refresh
       const result = await fetchAdminInviteCodes()
       setCodes(result.data)
@@ -201,6 +204,7 @@ export default function InviteCodesTab() {
         label: newLabel.trim(),
         verificationLevel: verLevel,
       })
+      track('admin_invite_code_created', { source: 'admin' })
       setNewCode('')
       setNewLabel('')
       setNewVerLevel('45')

--- a/packages/frontend/components/admin/ModerationTab.tsx
+++ b/packages/frontend/components/admin/ModerationTab.tsx
@@ -13,6 +13,7 @@ import {
   type ModerationAuditEntry,
 } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
+import { useAnalytics } from '../../utils/analytics'
 
 function formatDate(iso?: string): string {
   if (!iso) return 'Unknown'
@@ -32,6 +33,7 @@ type PendingAction =
 
 export default function ModerationTab() {
   const colors = useDetailColors()
+  const { track } = useAnalytics()
 
   const [items, setItems] = useState<ModerationQueueItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -162,11 +164,13 @@ export default function ModerationTab() {
       setActing(true)
       if (pending.kind === 'delete') {
         await adminDeleteReportedPost(selected.post.id)
+        track('admin_reported_post_deleted', { postId: selected.post.id, source: 'admin' })
       } else {
         await adminSuspendUser(selected.post.author.id, {
           reason: selected.latestReason ?? 'Moderation action',
           durationDays: pending.durationDays,
         })
+        track('admin_user_suspended', { userId: selected.post.author.id, source: 'admin' })
       }
       setPending(null)
       setSelected(null)

--- a/packages/frontend/components/admin/NotificationsTab.tsx
+++ b/packages/frontend/components/admin/NotificationsTab.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
+import { useAnalytics } from '../../utils/analytics'
 
 const NOTIFICATION_TYPE_NAMES: Record<number, string> = {
   1: 'Event Reminder',
@@ -28,6 +29,7 @@ const NOTIFICATION_TYPE_NAMES: Record<number, string> = {
 export default function NotificationsTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
   const [notifications, setNotifications] = useState<AdminNotification[]>([])
   const [stats, setStats] = useState<AdminNotificationStats | null>(null)
   const [total, setTotal] = useState(0)
@@ -79,6 +81,7 @@ export default function NotificationsTab() {
     if (!deleteTarget) return
     try {
       await adminDeleteNotification(deleteTarget.id)
+      track('admin_notification_deleted', { notificationId: deleteTarget.id, source: 'admin' })
       setDeleteTarget(null)
       setSelectedId(null)
       loadNotifications()
@@ -100,6 +103,7 @@ export default function NotificationsTab() {
         broadcast: sendBroadcast,
         userId: sendBroadcast ? undefined : sendUserId.trim() || undefined,
       })
+      track('admin_notification_sent', { source: 'admin' })
       setSendResult(result.message)
       setSendTitle('')
       setSendMessage('')

--- a/packages/frontend/components/admin/UsersTab.tsx
+++ b/packages/frontend/components/admin/UsersTab.tsx
@@ -14,6 +14,7 @@ import {
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
 import { Avatar } from '../ui'
+import { useAnalytics } from '../../utils/analytics'
 
 // ---------------------------------------------------------------------------
 // Role badge config
@@ -47,6 +48,7 @@ function formatJoinDate(iso?: string): string {
 export default function UsersTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { track } = useAnalytics()
 
   const [search, setSearch] = useState('')
   const [users, setUsers] = useState<UserData[]>([])
@@ -162,6 +164,7 @@ export default function UsersTab() {
       const result = await adminVerifyUser(selectedUser.id, {
         isVerified: !selectedUser.isVerified,
       })
+      track('admin_user_verification_changed', { userId: selectedUser.id, source: 'admin' })
       // Update local state
       setUsers((prev) =>
         prev.map((u) =>
@@ -181,6 +184,7 @@ export default function UsersTab() {
     if (!selectedUser) return
     try {
       await adminDeleteUser(selectedUser.id)
+      track('admin_user_deleted', { userId: selectedUser.id, source: 'admin' })
       setSelectedUser(null)
       loadUsers(search)
     } catch (err) {


### PR DESCRIPTION
Closes the telemetry half of #318.

Admin pages had **zero** `track()` calls while the rest of the app instruments everything via `useAnalytics`/PostHog. This adds telemetry on the success path of the key admin mutations across all 6 tabs (12 events):

| Tab | Events |
|---|---|
| Centers | `admin_center_updated`, `admin_center_verified`, `admin_center_deleted` |
| Events | `admin_event_deleted` |
| Users | `admin_user_verification_changed`, `admin_user_deleted` |
| Invite codes | `admin_invite_code_created`, `admin_invite_code_toggled` |
| Moderation | `admin_reported_post_deleted`, `admin_user_suspended` |
| Notifications | `admin_notification_deleted`, `admin_notification_sent` |

All tagged `source: 'admin'` with the relevant entity id. Tracked only on success (never in catch). Web + native share these components, so this covers both. frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)