### PR TITLE
feat(#330): redesign Profile as a social profile (web + native, Direction B)

### DIFF
--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -1,500 +1,257 @@
-import React, { useState, useEffect } from 'react'
+// Profile tab — native (iOS/Android). Direction B, stacked single column.
+// Mirrors the web Profile (app/(tabs)/profile.web.tsx): a display-only social
+// profile (identity + interests, then engagement: stats, upcoming events,
+// centers). Editing lives on /edit-profile; account management on /settings.
+// The "You" header + settings gear are provided by the navigator (TabHeader).
+import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share } from 'react-native'
-import { BadgeCheck, Building2 } from 'lucide-react-native'
-import { Badge, useRouter } from 'expo-router'
-import { useUser, useTheme } from '../../components/contexts'
-import { Section, Text } from '../../components/ui'
-import TabHeader from '../../components/ui/TabHeader'
+import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  fetchCenters,
-  fetchUserEvents,
-  fetchUserGroups,
-  fetchUserPosts,
-  CenterData,
-} from '../../utils/api'
+  Pencil, Share2, ChevronRight, BadgeCheck, MapPin,
+  Megaphone, CalendarDays, Building2,
+} from 'lucide-react-native'
+import { useUser, useTheme } from '../../components/contexts'
+import { Text } from '../../components/ui'
 import { useAnalytics } from '../../utils/analytics'
+import { LIGHT, DARK } from '../../tokens/colors'
+import { extractCityState } from '../../utils/addressParsing'
+import {
+  fetchCenters, fetchUserEvents, fetchUserPosts, fetchUserGroups,
+  type CenterData, type EventData,
+} from '../../utils/api'
 
-export default function ProfileNative() {
+function datePill(dateStr?: string | null): { m: string; d: string } {
+  if (!dateStr) return { m: '', d: '' }
+  const dt = new Date(dateStr + 'T00:00:00')
+  if (isNaN(dt.getTime())) return { m: '', d: '' }
+  return { m: dt.toLocaleDateString('en-US', { month: 'short' }).toUpperCase(), d: String(dt.getDate()) }
+}
+
+export default function Profile() {
   const router = useRouter()
-  const { user, refreshUser } = useUser()
+  const { user } = useUser()
   const { isDark } = useTheme()
+  const c = isDark ? DARK : LIGHT
   const { track } = useAnalytics()
+
   const [allCenters, setAllCenters] = useState<CenterData[]>([])
-  const [postCount, setPostCount] = useState(0)
-  const [eventCount, setEventCount] = useState(0)
-  const [groupCount, setGroupCount] = useState(0)
-  const [userGroups, setUserGroups] = useState<CenterData[]>([])
+  const [createdCount, setCreatedCount] = useState(0)
+  const [events, setEvents] = useState<EventData[]>([])
+  const [groups, setGroups] = useState<CenterData[]>([])
 
-  useEffect(() => {
-    refreshUser()
-    fetchCenters()
-      .then(setAllCenters)
-      .catch(() => {})
-    if (user?.username) {
-      fetchUserPosts(user.username)
-        .then((p) => setPostCount(p.length))
-        .catch(() => {})
-      fetchUserEvents(user.username)
-        .then((e) => setEventCount(e.length))
-        .catch(() => {})
-      fetchUserGroups(user.username)
-        .then((g) => {
-          setUserGroups(g)
-          setGroupCount(g.length)
-        })
-        .catch(() => {})
-    }
-  }, [])
+  useFocusEffect(
+    useCallback(() => {
+      fetchCenters().then(setAllCenters).catch(() => {})
+      if (user?.username) {
+        fetchUserPosts(user.username).then((p) => setCreatedCount(p.length)).catch(() => {})
+        fetchUserEvents(user.username).then(setEvents).catch(() => {})
+        fetchUserGroups(user.username).then(setGroups).catch(() => {})
+      }
+    }, [user?.username])
+  )
 
-  const getDisplayName = () => {
-    if (user?.firstName && user?.lastName) return `${user.firstName} ${user.lastName}`
-    if (user?.firstName) return user.firstName
-    return user?.username || ''
-  }
-
-  const getInitials = () => {
-    if (user?.firstName && user?.lastName) {
-      return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
-    }
+  const displayName =
+    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
+  const initials = (() => {
+    if (user?.firstName && user?.lastName) return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
     if (user?.firstName) return user.firstName[0].toUpperCase()
     if (user?.username) return user.username[0].toUpperCase()
     return '?'
-  }
-
-  const getUserRole = () => {
-    const age = user?.dateOfBirth
-      ? Math.floor((Date.now() - new Date(user.dateOfBirth).getTime()) / 31557600000)
+  })()
+  const vl = user?.verificationLevel ?? 0
+  const roleLabel =
+    vl >= 1000008 ? 'Global Head'
+      : vl >= 1008 ? 'Swami'
+      : vl >= 108 ? 'Brahmachari'
+      : vl >= 54 ? 'Sevak'
+      : vl >= 45 ? 'Verified member'
       : null
-    if (age !== null && (user?.verificationLevel ?? 0) < 108) {
-      if (age >= 18 && age <= 35) return 'CHYK'
-      if (age > 35) return 'Sevak'
-    } else {
-      if (user?.verificationLevel ?? 0 >= 108) return 'Brahmachari'
-      if (user?.verificationLevel ?? 0 >= 1008) return 'Swami'
-      if (user?.verificationLevel ?? 0 >= 1000008) return 'Global Head'
-    }
-  }
-
-  const getUserCity = () => {
-    const center = allCenters.find((c) => c.centerID === user?.centerID)
-    const addressParts = center?.address?.split(',')
-    return `${addressParts?.[1]?.trim()}, ${addressParts?.[2]?.split(' ')[1] ?? null}`
-  }
-
-  const getDateJoined = () => {
-    if (!user?.createdAt) return null
-    const date = new Date(user.createdAt)
-    return date.toLocaleDateString(undefined, { year: 'numeric' })
-  }
-
-  const handleShare = async () => {
-    try {
-      await Share.share({
-        message: `Check out ${getDisplayName()} on Janata!`,
-        title: getDisplayName(),
-      })
-      track('profile_shared', { source: 'profile', username: user?.username })
-    } catch {
-      // Silently fail
-    }
-  }
-
-  const textColor = isDark ? '#FAFAFA' : '#1C1917'
-  const mutedTextColor = isDark ? '#A8A29E' : '#78716C'
-  const borderColor = isDark ? '#262626' : '#ECE7DE'
-  const cardBg = isDark ? '#262626' : '#FFFFFF'
-  const chipBg = isDark ? '#333333' : '#F0EFED'
-
-  const centerName = allCenters.find((c) => c.centerID === user?.centerID)?.name
+  const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
   const interests = user?.interests || []
-  const lookingFor = user?.lookingFor || []
+
+  const today = new Date().toISOString().split('T')[0]
+  const upcoming = [...events]
+    .filter((e) => !e.date || e.date >= today)
+    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+    .slice(0, 4)
+
+  const onEdit = () => { track('nav_edit_profile', { source: 'profile' }); router.push('/edit-profile') }
+  const onShare = async () => {
+    try {
+      await Share.share({ message: `Check out ${displayName} on Janata!`, title: displayName })
+      track('profile_shared', { source: 'profile', username: user?.username })
+    } catch { /* dismissed */ }
+  }
+  const onSettings = () => { track('nav_settings_opened', { source: 'profile', destination: 'preferences' }); router.push('/settings') }
+  const onExplore = () => { track('profile_explore_cta', { source: 'profile' }); router.push('/explore') }
+
+  const card = { backgroundColor: c.card, borderWidth: 1, borderColor: c.border, borderRadius: 20 } as const
+
+  const StatCard = ({ icon, value, label }: { icon: React.ReactNode; value: number; label: string }) => (
+    <View style={[card, { flex: 1, padding: 14 }]}>
+      <View style={{ width: 32, height: 32, borderRadius: 10, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 9 }}>{icon}</View>
+      <Text style={{ fontSize: 22, fontWeight: '700', color: c.text }}>{value}</Text>
+      <Text style={{ fontSize: 12.5, color: c.textMuted }}>{label}</Text>
+    </View>
+  )
+
+  const SectionLabel = ({ children }: { children: string }) => (
+    <Text style={{ fontSize: 12.5, fontWeight: '600', color: c.textMuted, letterSpacing: 0.5, textTransform: 'uppercase', marginBottom: 12, marginTop: 24, marginLeft: 2 }}>{children}</Text>
+  )
 
   return (
-    <View style={{ flex: 1 }}>
-      <ScrollView style={{ flex: 1, backgroundColor: isDark ? '#1A1A1A' : '#F5F5F4' }}>
-        {/* Profile header */}
-        <View style={{ paddingTop: 28, paddingHorizontal: 20, gap: 12 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 16 }}>
-            {/* Avatar */}
-            {user?.profileImage ? (
-              <Image
-                source={{ uri: user.profileImage }}
-                style={{
-                  width: 88,
-                  height: 88,
-                  borderRadius: 44,
-                  borderWidth: 3,
-                  borderColor: cardBg,
-                  backgroundColor: '#D6D3D1',
-                }}
-              />
-            ) : (
-              <View
-                style={{
-                  width: 88,
-                  height: 88,
-                  borderRadius: 44,
-                  borderWidth: 3,
-                  borderColor: cardBg,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Text style={{ color: '#fff', fontSize: 28, fontWeight: '600' }}>
-                  {getInitials()}
-                </Text>
-              </View>
-            )}
-
-            {/* Name, role, email */}
-            <View style={{ flex: 1, minWidth: 0, paddingTop: 4, gap: 4 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 22,
-                    color: textColor,
-                    letterSpacing: -0.5,
-                    flexShrink: 1,
-                  }}
-                  numberOfLines={1}
-                >
-                  {getDisplayName() || '—'}
-                </Text>
-                {getUserRole() && (
-                  <View
-                    style={{
-                      backgroundColor: '#C2410C20',
-                      paddingHorizontal: 5,
-                      paddingVertical: 3,
-                      borderRadius: 6,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        fontFamily: 'Inclusive Sans',
-                        fontSize: 10,
-                        color: '#C2410C',
-                        fontWeight: '700',
-                        letterSpacing: 0.5,
-                      }}
-                    >
-                      {getUserRole()}
-                    </Text>
-                  </View>
-                )}
-              </View>
-              {getUserCity() && getDateJoined() ? (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}>
-                  <Text
-                    style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: mutedTextColor }}
-                    numberOfLines={1}
-                  >
-                    {getUserCity()} • Member since {getDateJoined() || '—'}
-                  </Text>
-                </View>
-              ) : null}
-              {user?.isVerified ? (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}>
-                  <BadgeCheck size={14} color="#C2410C" />
-                  <Text
-                    style={{
-                      fontFamily: 'Inclusive Sans',
-                      fontSize: 13,
-                      color: '#C2410C',
-                      fontWeight: '600',
-                    }}
-                    numberOfLines={1}
-                  >
-                    Verified by {centerName}
-                  </Text>
-                </View>
-              ) : null}
+    <ScrollView
+      style={{ flex: 1, backgroundColor: c.bg }}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 18, paddingBottom: 48 }}
+    >
+      {/* Profile card */}
+      <View style={[card, { padding: 22 }]}>
+        <View style={{ alignItems: 'center' }}>
+          {user?.profileImage ? (
+            <Image source={{ uri: user.profileImage }} style={{ width: 92, height: 92, borderRadius: 46, borderWidth: 4, borderColor: c.card, backgroundColor: c.surface }} />
+          ) : (
+            <View style={{ width: 92, height: 92, borderRadius: 46, borderWidth: 4, borderColor: c.card, backgroundColor: '#C2410C', alignItems: 'center', justifyContent: 'center' }}>
+              <Text style={{ color: '#fff', fontSize: 32, fontWeight: '600' }}>{initials}</Text>
             </View>
-          </View>
-
-          {/* Bio — no label, inline with header */}
-          {user?.bio ? (
-            <Text
-              style={{
-                fontSize: 15,
-                color: textColor,
-                lineHeight: 22,
-              }}
-            >
-              {user.bio}
-            </Text>
+          )}
+          <Text style={{ fontSize: 21, fontWeight: '700', color: c.text, marginTop: 14, textAlign: 'center' }}>{displayName}</Text>
+          {user?.username ? <Text style={{ fontSize: 14, color: c.textMuted, marginTop: 1 }}>@{user.username}</Text> : null}
+          {roleLabel ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10, backgroundColor: c.accentSoft, paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999 }}>
+              <BadgeCheck size={14} color="#C2410C" />
+              <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
+            </View>
           ) : null}
-
-          {/* About — minimal profile fields (#210). Empty fields don't render. */}
-          {(user?.work || user?.school || user?.region) ? (
-            <View style={{ marginTop: 12, gap: 4 }}>
-              {user?.work ? (
-                <Text style={{ fontSize: 14, color: textColor }}>{user.work}</Text>
-              ) : null}
-              {user?.school ? (
-                <Text style={{ fontSize: 14, color: mutedTextColor }}>{user.school}</Text>
-              ) : null}
-              {user?.region ? (
-                <Text style={{ fontSize: 14, color: mutedTextColor }}>{user.region}</Text>
-              ) : null}
+          {homeCenter ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
+              <MapPin size={13} color={c.textFaint} />
+              <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
             </View>
           ) : null}
         </View>
 
-        {/* Profile Stats */}
-        <View
-          style={{
-            marginTop: 16,
-            marginHorizontal: 20,
-            borderWidth: 1,
-            borderColor,
-            borderRadius: 12,
-            flexDirection: 'row',
-            backgroundColor: cardBg,
-            overflow: 'hidden',
-          }}
-        >
-          {[
-            { label: 'Events', value: eventCount },
-            { label: 'Groups', value: groupCount },
-            { label: 'Posts', value: postCount },
-          ].map((stat, i, arr) => (
-            <View
-              key={stat.label}
-              accessible
-              accessibilityLabel={`${stat.value} ${stat.label}`}
-              style={{
-                flex: 1,
-                alignItems: 'center',
-                paddingVertical: 14,
-                paddingHorizontal: 4,
-                borderRightWidth: i < arr.length - 1 ? 1 : 0,
-                borderColor,
-              }}
-            >
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 20,
-                  color: textColor,
-                  fontWeight: '500',
-                }}
-              >
-                {stat.value}
-              </Text>
-              <Text
-                numberOfLines={1}
-                adjustsFontSizeToFit
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 11,
-                  color: mutedTextColor,
-                  marginTop: 2,
-                  letterSpacing: 0.4,
-                  textTransform: 'uppercase',
-                }}
-              >
-                {stat.label}
-              </Text>
-            </View>
-          ))}
-        </View>
+        {user?.bio ? (
+          <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
+        ) : (
+          <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
+            No bio yet — tap Edit to introduce yourself.
+          </Text>
+        )}
 
-        {/* Edit / Share buttons */}
-        <View
-          style={{
-            paddingHorizontal: 20,
-            paddingTop: 16,
-            flexDirection: 'row',
-            gap: 8,
-          }}
-        >
-          <Pressable
-            onPress={() => {
-              track('profile_edit_opened', { source: 'profile', username: user?.username })
-              router.push('/edit-profile')
-            }}
-            accessibilityRole="button"
-            accessibilityLabel="Edit profile"
-            style={{
-              flex: 1,
-              paddingVertical: 9,
-              borderRadius: 10,
-              borderWidth: 1,
-              borderColor,
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: cardBg,
-            }}
-          >
-            <Text
-              style={{ fontSize: 14, color: textColor, fontWeight: '700' }}
-            >
-              Edit Profile
-            </Text>
+        <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
+          <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 11, borderRadius: 12, backgroundColor: c.text }}>
+            <Pencil size={15} color={c.textInverse} />
+            <Text style={{ fontSize: 14, fontWeight: '600', color: c.textInverse }}>Edit</Text>
           </Pressable>
-          <Pressable
-            onPress={handleShare}
-            accessibilityRole="button"
-            accessibilityLabel="Share profile"
-            style={{
-              flex: 1,
-              paddingVertical: 9,
-              borderRadius: 10,
-              borderWidth: 1,
-              borderColor,
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: cardBg,
-            }}
-          >
-            <Text
-              style={{ fontSize: 14, color: textColor, fontWeight: '700' }}
-            >
-              Share
-            </Text>
+          <Pressable onPress={onShare} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 11, borderRadius: 12, borderWidth: 1, borderColor: c.border, backgroundColor: c.card }}>
+            <Share2 size={15} color={c.text} />
+            <Text style={{ fontSize: 14, fontWeight: '600', color: c.text }}>Share</Text>
           </Pressable>
         </View>
 
-        {/* Interests */}
         {interests.length > 0 ? (
-          <View
-            style={{
-              paddingHorizontal: 20,
-              marginTop: 16,
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              gap: 8,
-            }}
-          >
-            {interests.map((interest) => (
-              <View
-                key={interest}
-                style={{
-                  paddingHorizontal: 14,
-                  paddingVertical: 7,
-                  borderRadius: 100,
-                  backgroundColor: chipBg,
-                }}
-              >
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: mutedTextColor }}>
-                  {interest}
-                </Text>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 7, marginTop: 18 }}>
+            {interests.map((it) => (
+              <View key={it} style={{ paddingHorizontal: 12, paddingVertical: 6, borderRadius: 999, backgroundColor: c.bg, borderWidth: 1, borderColor: c.border }}>
+                <Text style={{ fontSize: 12.5, color: c.textMuted }}>{it}</Text>
               </View>
             ))}
           </View>
         ) : null}
 
-        {/* Looking for — multi-select chips (#210). Same UX as Interests. */}
-        {lookingFor.length > 0 ? (
-          <View style={{ paddingHorizontal: 20, marginTop: 16 }}>
-            <Text
-              style={{
-                fontFamily: 'Inclusive Sans',
-                fontSize: 11,
-                color: mutedTextColor,
-                letterSpacing: 0.4,
-                textTransform: 'uppercase',
-                marginBottom: 8,
-              }}
-            >
-              Looking for
-            </Text>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-              {lookingFor.map((option) => (
-                <View
-                  key={option}
-                  style={{
-                    paddingHorizontal: 14,
-                    paddingVertical: 7,
-                    borderRadius: 100,
-                    backgroundColor: chipBg,
-                  }}
-                >
-                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: mutedTextColor }}>
-                    {option}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          </View>
-        ) : null}
+        <Pressable
+          onPress={onSettings}
+          style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
+        >
+          <Text style={{ fontSize: 14, color: c.textSecondary }}>Account &amp; Settings</Text>
+          <ChevronRight size={18} color={c.iconMuted} />
+        </Pressable>
+      </View>
 
-        {/* Communities */}
-        <View style={{ paddingHorizontal: 20, marginTop: 24 }}>
-          <Section title="COMMUNITIES" titleColor={mutedTextColor}>
-            <View
-              style={{
-                marginTop: 16,
-                borderWidth: 1,
-                borderColor,
-                borderRadius: 12,
-                backgroundColor: cardBg,
-                overflow: 'hidden',
-              }}
-            >
-              {userGroups.length > 0 ? (
-                userGroups.map((group) => (
-                  <View
-                    key={group.centerID}
-                    style={{
-                      paddingVertical: 14,
-                      paddingHorizontal: 20,
-                      backgroundColor: cardBg,
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      gap: 12,
-                    }}
-                  >
-                    <View
-                      style={{
-                        width: 32,
-                        height: 32,
-                        borderRadius: 6,
-                        backgroundColor: '#C2410C20',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <Building2 size={16} color="#C2410C" />
-                    </View>
-                    <View style={{ flex: 1 }}>
-                      <Text
-                        style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: textColor }}
-                      >
-                        {group.name}
-                      </Text>
-                      <Text
-                        style={{
-                          fontFamily: 'Inclusive Sans',
-                          fontSize: 13,
-                          color: mutedTextColor,
-                        }}
-                      >
-                        My center • {group.memberCount ?? 0} members
-                      </Text>
-                    </View>
-                  </View>
-                ))
-              ) : (
-                <View
-                  style={{ paddingVertical: 14, paddingHorizontal: 20, backgroundColor: cardBg }}
-                >
-                  <Text
-                    style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: mutedTextColor }}
-                  >
-                    No center selected
-                  </Text>
+      {/* Stats */}
+      <View style={{ flexDirection: 'row', gap: 12, marginTop: 18 }}>
+        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
+      </View>
+
+      {/* Upcoming events */}
+      <SectionLabel>Upcoming events</SectionLabel>
+      {upcoming.length > 0 ? (
+        <View style={[card, { overflow: 'hidden' }]}>
+          {upcoming.map((e, i) => {
+            const { m, d } = datePill(e.date)
+            const centerName = allCenters.find((cc) => cc.centerID === e.centerID)?.name
+            return (
+              <Pressable
+                key={e.eventID}
+                onPress={() => { track('event_list_item_pressed', { eventId: e.eventID, source: 'profile' }); router.push(`/events/${e.eventID}`) }}
+                style={{ flexDirection: 'row', gap: 13, alignItems: 'center', padding: 16, borderBottomWidth: i < upcoming.length - 1 ? 1 : 0, borderBottomColor: c.border }}
+              >
+                <View style={{ width: 46, height: 52, borderRadius: 12, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
+                  <Text style={{ fontSize: 10, fontWeight: '700', color: '#C2410C', letterSpacing: 0.5 }}>{m}</Text>
+                  <Text style={{ fontSize: 18, fontWeight: '700', color: c.text }}>{d}</Text>
                 </View>
-              )}
-            </View>
-          </Section>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={{ fontSize: 14.5, fontWeight: '600', color: c.text }} numberOfLines={1}>{e.title}</Text>
+                  <Text style={{ fontSize: 12.5, color: c.textMuted, marginTop: 2 }} numberOfLines={1}>{centerName || extractCityState(e.address ?? undefined) || 'Event'}</Text>
+                </View>
+                <ChevronRight size={16} color={c.iconMuted} />
+              </Pressable>
+            )
+          })}
         </View>
+      ) : (
+        <View style={[card, { padding: 24, alignItems: 'center' }]}>
+          <View style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+            <CalendarDays size={20} color="#C2410C" />
+          </View>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: c.text }}>No upcoming events yet</Text>
+          <Text style={{ fontSize: 13.5, lineHeight: 20, color: c.textMuted, textAlign: 'center', marginTop: 4 }}>
+            RSVP to satsangs, study groups, and events near you — they'll show up here.
+          </Text>
+          <Pressable onPress={onExplore} style={{ marginTop: 14, paddingHorizontal: 18, paddingVertical: 9, borderRadius: 999, backgroundColor: '#C2410C' }}>
+            <Text style={{ fontSize: 13.5, fontWeight: '600', color: '#fff' }}>Explore events</Text>
+          </Pressable>
+        </View>
+      )}
 
-        <View style={{ height: 40 }} />
-      </ScrollView>
-    </View>
+      {/* Your centers */}
+      <SectionLabel>Your centers</SectionLabel>
+      {groups.length > 0 ? (
+        <View style={[card, { overflow: 'hidden' }]}>
+          {groups.map((g, i) => (
+            <Pressable
+              key={g.centerID}
+              onPress={() => { track('center_list_item_pressed', { centerId: g.centerID, source: 'profile' }); router.push(`/center/${g.centerID}`) }}
+              style={{ flexDirection: 'row', gap: 13, alignItems: 'center', padding: 16, borderBottomWidth: i < groups.length - 1 ? 1 : 0, borderBottomColor: c.border }}
+            >
+              <View style={{ width: 40, height: 40, borderRadius: 11, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+                {g.image ? <Image source={{ uri: g.image }} style={{ width: 40, height: 40 }} /> : <Building2 size={18} color="#C2410C" />}
+              </View>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ fontSize: 14.5, fontWeight: '600', color: c.text }} numberOfLines={1}>{g.name}</Text>
+                <Text style={{ fontSize: 12.5, color: c.textMuted, marginTop: 2 }} numberOfLines={1}>{extractCityState(g.address ?? undefined) || 'Center'}</Text>
+              </View>
+              <ChevronRight size={16} color={c.iconMuted} />
+            </Pressable>
+          ))}
+        </View>
+      ) : (
+        <View style={[card, { padding: 24, alignItems: 'center' }]}>
+          <View style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+            <Building2 size={20} color="#C2410C" />
+          </View>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: c.text }}>No center yet</Text>
+          <Text style={{ fontSize: 13.5, lineHeight: 20, color: c.textMuted, textAlign: 'center', marginTop: 4 }}>
+            Find your Chinmaya center to connect with your local community.
+          </Text>
+          <Pressable onPress={onExplore} style={{ marginTop: 14, paddingHorizontal: 18, paddingVertical: 9, borderRadius: 999, backgroundColor: '#C2410C' }}>
+            <Text style={{ fontSize: 13.5, fontWeight: '600', color: '#fff' }}>Find a center</Text>
+          </Pressable>
+        </View>
+      )}
+    </ScrollView>
   )
 }

--- a/packages/frontend/app/(tabs)/profile.web.tsx
+++ b/packages/frontend/app/(tabs)/profile.web.tsx
@@ -1,1429 +1,273 @@
-import React, { useState, useEffect, useRef } from 'react'
+// Profile tab — web (desktop two-column / mobile stacked). Direction B.
+// Display-only social profile: identity + interests on the left, engagement
+// (stats, upcoming events, centers) on the right. Editing lives on /edit-profile;
+// account management lives on /settings (reached via "Account & Settings").
+import React, { useState, useCallback } from 'react'
+import { ScrollView, View, Pressable, Image, Share, Platform, useWindowDimensions } from 'react-native'
+import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  ScrollView,
-  View,
-  TextInput,
-  Pressable,
-  Image,
-  ActivityIndicator,
-  Platform,
-  useWindowDimensions,
-} from 'react-native'
-import { Camera, Pencil, MapPin, BadgeCheck } from 'lucide-react-native'
+  Pencil, Share2, ChevronRight, BadgeCheck, MapPin,
+  Megaphone, CalendarDays, Building2,
+} from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { Text } from '../../components/ui'
-import BirthdatePicker from '../../components/profile/BirthdatePicker'
-import WebAvatarCropper from '../../components/profile/AvatarCropper.web'
-import { fetchCenters, CenterData } from '../../utils/api'
 import { useAnalytics } from '../../utils/analytics'
+import { LIGHT, DARK } from '../../tokens/colors'
+import { extractCityState } from '../../utils/addressParsing'
+import {
+  fetchCenters, fetchUserEvents, fetchUserPosts, fetchUserGroups,
+  type CenterData, type EventData,
+} from '../../utils/api'
 
-type ProfileData = {
-  name: string
-  bio: string
-  birthday: Date | null
-  interests: string[]
-  profileImage: string | null
-  centerID: string | null
+function datePill(dateStr?: string | null): { m: string; d: string } {
+  if (!dateStr) return { m: '', d: '' }
+  const dt = new Date(dateStr + 'T00:00:00')
+  if (isNaN(dt.getTime())) return { m: '', d: '' }
+  return { m: dt.toLocaleDateString('en-US', { month: 'short' }).toUpperCase(), d: String(dt.getDate()) }
 }
-
-function formatBirthday(date: Date | null): string {
-  if (!date) return ''
-  return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
-}
-
-/** ISO date string (YYYY-MM-DD) from a Date, or empty string */
-function toISODate(date: Date | null): string {
-  if (!date) return ''
-  return date.toISOString().split('T')[0]
-}
-
-/** Parse YYYY-MM-DD to Date, or null */
-function parseISODate(str: string): Date | null {
-  if (!str) return null
-  const d = new Date(str + 'T00:00:00')
-  return isNaN(d.getTime()) ? null : d
-}
-
-const PREFERENCE_OPTIONS = [
-  'Satsangs',
-  'Bhiksha',
-  'Global events',
-  'Local events',
-  'Casual',
-  'Formal',
-]
 
 export default function Profile() {
-  const { user, updateProfile, setUser } = useUser()
+  const router = useRouter()
+  const { user } = useUser()
   const { isDark } = useTheme()
+  const c = isDark ? DARK : LIGHT
   const { track } = useAnalytics()
-  const [isEditing, setIsEditing] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [errors, setErrors] = useState<{ [key: string]: string }>({})
-  const isWeb = Platform.OS === 'web'
+  const { width } = useWindowDimensions()
+  const isDesktop = Platform.OS === 'web' && width >= 880
 
-  const getDisplayName = () => {
-    if (user?.firstName && user?.lastName) return `${user.firstName} ${user.lastName}`
-    if (user?.firstName) return user.firstName
-    return user?.username || ''
-  }
+  const [allCenters, setAllCenters] = useState<CenterData[]>([])
+  const [createdCount, setCreatedCount] = useState(0)
+  const [events, setEvents] = useState<EventData[]>([])
+  const [groups, setGroups] = useState<CenterData[]>([])
 
-  const getInitials = () => {
-    if (user?.firstName && user?.lastName) {
-      return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
-    }
+  useFocusEffect(
+    useCallback(() => {
+      fetchCenters().then(setAllCenters).catch(() => {})
+      if (user?.username) {
+        fetchUserPosts(user.username).then((p) => setCreatedCount(p.length)).catch(() => {})
+        fetchUserEvents(user.username).then(setEvents).catch(() => {})
+        fetchUserGroups(user.username).then(setGroups).catch(() => {})
+      }
+    }, [user?.username])
+  )
+
+  const displayName =
+    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
+  const initials = (() => {
+    if (user?.firstName && user?.lastName) return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
     if (user?.firstName) return user.firstName[0].toUpperCase()
     if (user?.username) return user.username[0].toUpperCase()
     return '?'
-  }
+  })()
+  const vl = user?.verificationLevel ?? 0
+  const roleLabel =
+    vl >= 1000008 ? 'Global Head'
+      : vl >= 1008 ? 'Swami'
+      : vl >= 108 ? 'Brahmachari'
+      : vl >= 54 ? 'Sevak'
+      : vl >= 45 ? 'Verified member'
+      : null
+  const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
+  const interests = user?.interests || []
 
-  const hasExistingProfileImage = !!user?.profileImage
+  const today = new Date().toISOString().split('T')[0]
+  const upcoming = [...events]
+    .filter((e) => !e.date || e.date >= today)
+    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+    .slice(0, 4)
 
-  // Store the original uploaded image (before cropping) for re-editing
-  const [originalImage, setOriginalImage] = useState<string | null>(user?.originalImage || null)
-
-  const [profileData, setProfileData] = useState<ProfileData>({
-    name: getDisplayName(),
-    bio: user?.bio || '',
-    birthday: user?.dateOfBirth ? new Date(user.dateOfBirth) : null,
-    interests: user?.interests || [],
-    profileImage: user?.profileImage || null,
-    centerID: user?.centerID || null,
-  })
-
-  const [allCenters, setAllCenters] = useState<CenterData[]>([])
-  const [centerSearch, setCenterSearch] = useState('')
-  const [centerResults, setCenterResults] = useState<CenterData[]>([])
-  const [showCenterPicker, setShowCenterPicker] = useState(false)
-  const [showBirthdayPicker, setShowBirthdayPicker] = useState(false)
-  const [centerSearchLoading, setCenterSearchLoading] = useState(false)
-  const centerSearchTimer = useRef<NodeJS.Timeout | null>(null)
-
-  const draftName = useRef(profileData.name)
-  const draftBio = useRef(profileData.bio)
-  const draftBirthday = useRef<Date | null>(profileData.birthday)
-  const savedInterests = useRef<string[]>(profileData.interests)
-  const savedProfileImage = useRef<string | null>(profileData.profileImage)
-  const savedCenterID = useRef<string | null>(profileData.centerID)
-
-  const [cropperImage, setCropperImage] = useState<string | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const handleAvatarPress = () => {
-    track('profile_avatar_edit_opened', { source: 'profile', has_existing_image: !!profileData.profileImage })
-    // If user has an existing profile image, use the original (uncropped) if available in session
-    if (originalImage || user?.originalImage) {
-      setCropperImage(originalImage || user?.originalImage || null)
-    } else if (profileData.profileImage) {
-      setCropperImage(profileData.profileImage)
-    } else {
-      // New user - open file picker directly
-      fileInputRef.current?.click()
-    }
-  }
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file) {
-      const url = URL.createObjectURL(file)
-      setOriginalImage(url)
-      setCropperImage(url)
-      track('profile_avatar_file_selected', { source: 'profile', file_type: file.type })
-    }
-  }
-
-  const [profileImageChanged, setProfileImageChanged] = useState(false)
-
-  const handleCropComplete = (blob: Blob) => {
-    const url = URL.createObjectURL(blob)
-    setProfileData((prev) => ({ ...prev, profileImage: url }))
-    setProfileImageChanged(true)
-    setCropperImage(null)
-    track('profile_avatar_cropped', { source: 'profile' })
-  }
-
-  const handleCropCancel = () => {
-    setCropperImage(null)
-    track('profile_avatar_crop_cancelled', { source: 'profile' })
-  }
-
-  const handleReplacePhoto = () => {
-    fileInputRef.current?.click()
-  }
-
-  useEffect(() => {
-    if (user && !isEditing) {
-      setProfileData((prev) => ({
-        ...prev,
-        name: getDisplayName() || prev.name,
-        bio: user.bio || prev.bio,
-        profileImage: user.profileImage || prev.profileImage,
-        interests: user.interests || prev.interests,
-        centerID: user.centerID || prev.centerID,
-      }))
-    }
-  }, [
-    user?.firstName,
-    user?.lastName,
-    user?.profileImage,
-    user?.bio,
-    user?.interests,
-    user?.centerID,
-  ])
-
-  useEffect(() => {
-    const loadCenters = async () => {
-      try {
-        const centers = await fetchCenters()
-        setAllCenters(centers)
-      } catch (e) {
-        // Silently fail
-      }
-    }
-    loadCenters()
-  }, [])
-
-  useEffect(() => {
-    if (centerSearchTimer.current) {
-      clearTimeout(centerSearchTimer.current)
-    }
-
-    if (centerSearch.length >= 3) {
-      setCenterSearchLoading(true)
-      centerSearchTimer.current = setTimeout(async () => {
-        try {
-          const response = await fetch(
-            `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
-              centerSearch
-            )}&format=json&limit=1&countrycodes=us`
-          )
-          if (response.ok) {
-            const data = await response.json()
-            if (data.length > 0) {
-              const userLat = parseFloat(data[0].lat)
-              const userLon = parseFloat(data[0].lon)
-
-              const centersWithDistance = allCenters
-                .filter((c) => c.latitude != null && c.longitude != null)
-                .map((center) => ({
-                  ...center,
-                  distance: Math.sqrt(
-                    Math.pow((center.latitude - userLat) * 69, 2) +
-                      Math.pow((center.longitude - userLon) * 54.6, 2)
-                  ),
-                }))
-                .sort((a, b) => a.distance - b.distance)
-                .slice(0, 5)
-
-              setCenterResults(centersWithDistance)
-              setShowCenterPicker(true)
-            }
-          }
-        } catch (e) {
-          // Silently fail
-        } finally {
-          setCenterSearchLoading(false)
-        }
-      }, 500)
-    } else {
-      setCenterResults([])
-      setShowCenterPicker(false)
-    }
-
-    return () => {
-      if (centerSearchTimer.current) {
-        clearTimeout(centerSearchTimer.current)
-      }
-    }
-  }, [centerSearch, allCenters])
-
-  useEffect(() => {
-    draftName.current = profileData.name
-    draftBio.current = profileData.bio
-  }, [profileData.name, profileData.bio])
-
-  const readDrafts = () => ({
-    name: draftName.current,
-    bio: draftBio.current,
-    birthday: draftBirthday.current,
-    interests: profileData.interests,
-    centerID: profileData.centerID,
-  })
-
-  const validateForm = (): boolean => {
-    const drafts = readDrafts()
-    const newErrors: { [key: string]: string } = {}
-    if (!drafts.name.trim()) newErrors.name = 'Name is required'
-    if (!drafts.birthday) newErrors.birthday = 'Birthday is required'
-    if (profileData.interests.length === 0)
-      newErrors.interests = 'At least one interest must be selected'
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
-
-  const nameRef = useRef<any>(null)
-  const bioRef = useRef<any>(null)
-
-  const handleEdit = () => {
-    draftName.current = profileData.name
-    draftBio.current = profileData.bio
-    draftBirthday.current = profileData.birthday
-    savedInterests.current = [...profileData.interests]
-    savedProfileImage.current = profileData.profileImage
-    savedCenterID.current = profileData.centerID
-    setIsEditing(true)
-    track('profile_edit_started', { source: 'profile', username: user?.username })
-  }
-
-  const handleCancel = () => {
-    // Reset input values back to original via refs
-    if (isWeb) {
-      if (nameRef.current) nameRef.current.value = profileData.name
-      if (bioRef.current) bioRef.current.value = profileData.bio
-    }
-    draftBirthday.current = profileData.birthday
-    setProfileData((prev) => ({
-      ...prev,
-      interests: savedInterests.current,
-      profileImage: savedProfileImage.current,
-      centerID: savedCenterID.current,
-    }))
-    setProfileImageChanged(false)
-    setErrors({})
-    setIsEditing(false)
-    track('profile_edit_cancelled', { source: 'profile', username: user?.username })
-  }
-
-  const handleSave = async () => {
-    if (!validateForm()) return
-    const drafts = readDrafts()
-    setProfileData((prev) => ({
-      ...prev,
-      name: drafts.name,
-      bio: drafts.bio,
-      birthday: drafts.birthday,
-    }))
-    setIsSaving(true)
+  const onEdit = () => { track('nav_edit_profile', { source: 'profile_web' }); router.push('/edit-profile') }
+  const onShare = async () => {
     try {
-      const nameParts = drafts.name.trim().split(' ')
-
-      // Prepare profile image if changed
-      let profileImageBase64: string | undefined
-      if (profileImageChanged && profileData.profileImage) {
-        try {
-          const response = await fetch(profileData.profileImage)
-          if (!response.ok) {
-            throw new Error(`Fetch failed: ${response.status}`)
-          }
-          const blob = await response.blob()
-          profileImageBase64 = await new Promise<string>((resolve, reject) => {
-            const reader = new FileReader()
-            reader.onloadend = () => resolve(reader.result as string)
-            reader.onerror = () => reject(new Error('Failed to read blob'))
-            reader.readAsDataURL(blob)
-          })
-        } catch (e) {
-          console.error('Error converting image:', e)
-          setErrors((prev) => ({
-            ...prev,
-            profileImage: 'Failed to upload image. Please try again.',
-          }))
-          track('profile_update_failed', { source: 'profile', username: user?.username, reason: 'image_upload_error' })
-          setIsSaving(false)
-          return
-        }
-      }
-
-      const result = await updateProfile({
-        firstName: nameParts[0],
-        lastName: nameParts.slice(1).join(' '),
-        bio: drafts.bio || '',
-        interests: drafts.interests,
-        ...(drafts.centerID ? { centerID: drafts.centerID } : {}),
-        ...(drafts.birthday ? { dateOfBirth: drafts.birthday.toISOString().split('T')[0] } : {}),
-        ...(profileImageBase64 ? { profileImage: profileImageBase64 } : {}),
-      })
-
-      if (!result.success) {
-        setErrors((prev) => ({ ...prev, form: result.message || 'Failed to save profile' }))
-        track('profile_update_failed', { source: 'profile', username: user?.username, reason: result.message || 'api_error' })
-        setIsSaving(false)
-        return
-      }
-      setProfileImageChanged(false)
-      // Cache the cropped image as the original for re-editing in this session
-      if (originalImage && user) {
-        setUser({ ...user, originalImage: originalImage })
-      }
-      track('profile_updated', { source: 'profile', username: user?.username })
-      setIsEditing(false)
-      setErrors({})
-    } catch (error) {
-      if (__DEV__) console.error('Error saving profile:', error)
-      track('profile_update_failed', { source: 'profile', username: user?.username, reason: 'exception' })
-      setIsEditing(false)
-      setErrors({})
-    } finally {
-      setIsSaving(false)
-    }
+      await Share.share({ message: `Check out ${displayName} on Janata!`, title: displayName })
+      track('profile_shared', { source: 'profile_web', username: user?.username })
+    } catch { /* dismissed */ }
   }
+  const onSettings = () => { track('nav_settings_opened', { source: 'profile_web', destination: 'preferences' }); router.push('/settings') }
+  const onExplore = () => { track('profile_explore_cta', { source: 'profile_web' }); router.push('/explore') }
 
-  const handlePreferenceToggle = (preference: string) => {
-    if (!isEditing) return
-    const willSelect = !profileData.interests.includes(preference)
-    setProfileData((prev) => ({
-      ...prev,
-      interests: prev.interests.includes(preference)
-        ? prev.interests.filter((p) => p !== preference)
-        : [...prev.interests, preference],
-    }))
-    track('profile_interest_toggled', { source: 'profile', interest: preference, selected: willSelect })
-  }
+  // ── Reusable pieces ──────────────────────────────────────
+  const card = { backgroundColor: c.card, borderWidth: 1, borderColor: c.border, borderRadius: 20 } as const
 
-  const labelColor = isDark ? '#78716C' : '#A8A29E'
-  const textColor = isDark ? '#FAFAFA' : '#1C1917'
-  const mutedTextColor = isDark ? '#A8A29E' : '#78716C'
-  const borderColor = isDark ? '#262626' : '#ECE7DE'
-  const cardBg = isDark ? '#262626' : '#FFFFFF'
-  const chipBg = isDark ? '#262626' : '#F3F0ED'
-
-  const inputStyle = {
-    fontFamily: 'Inclusive Sans' as const,
-    fontSize: 15,
-    color: textColor,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor,
-    backgroundColor: cardBg,
-  }
-
-  const multilineInputStyle = {
-    ...inputStyle,
-    minHeight: 100,
-  }
-
-  const labelStyle = {
-    fontFamily: 'Inclusive Sans' as const,
-    fontSize: 12,
-    color: labelColor,
-    letterSpacing: 1,
-    textTransform: 'uppercase' as const,
-    marginBottom: 6,
-  }
-
-  const hiddenStyle = { display: 'none' as const }
-
-  // ═══════════════════════════════════════════
-  //  MOBILE LAYOUT
-  // ═══════════════════════════════════════════
-  if (!isWeb) {
-    return (
-      <ScrollView style={{ flex: 1, backgroundColor: isDark ? '#171717' : '#FAFAF7' }}>
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'flex-start',
-            paddingTop: 28,
-            paddingBottom: 24,
-            paddingHorizontal: 20,
-            gap: 16,
-          }}
-        >
-          <View style={{ position: 'relative' }}>
-            {profileData.profileImage ? (
-              <Image
-                source={{ uri: profileData.profileImage }}
-                style={{
-                  width: 88,
-                  height: 88,
-                  borderRadius: 44,
-                  borderWidth: 3,
-                  borderColor: cardBg,
-                  backgroundColor: '#D6D3D1',
-                }}
-              />
-            ) : (
-              <View
-                style={{
-                  width: 88,
-                  height: 88,
-                  borderRadius: 44,
-                  borderWidth: 3,
-                  borderColor: cardBg,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Text style={{ color: '#fff', fontSize: 28, fontWeight: '600' }}>
-                  {getInitials()}
-                </Text>
-              </View>
-            )}
-            {isEditing && (
-              <Pressable
-                style={{
-                  position: 'absolute',
-                  bottom: -6,
-                  right: -6,
-                  width: 44,
-                  height: 44,
-                  borderRadius: 22,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  borderWidth: 2,
-                  borderColor: isDark ? '#171717' : '#FAFAF7',
-                }}
-                onPress={handleAvatarPress}
-              >
-                <Camera size={16} color="#fff" />
-              </Pressable>
-            )}
+  const ProfileCard = (
+    <View style={[card, { padding: 24, ...(isDesktop ? { position: 'sticky' as 'absolute', top: 80 } : {}) }]}>
+      <View style={{ alignItems: 'center' }}>
+        {user?.profileImage ? (
+          <Image source={{ uri: user.profileImage }} style={{ width: 92, height: 92, borderRadius: 46, borderWidth: 4, borderColor: c.card, backgroundColor: c.surface }} />
+        ) : (
+          <View style={{ width: 92, height: 92, borderRadius: 46, borderWidth: 4, borderColor: c.card, backgroundColor: '#C2410C', alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ color: '#fff', fontSize: 32, fontWeight: '600' }}>{initials}</Text>
           </View>
-          <View style={{ flex: 1, minWidth: 0, justifyContent: 'center', paddingTop: 2 }}>
-            {isEditing ? (
-              <TextInput
-                defaultValue={profileData.name}
-                onChangeText={(v) => {
-                  draftName.current = v
-                }}
-                placeholderTextColor="#9ca3af"
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 22,
-                  color: textColor,
-                  letterSpacing: -0.5,
-                  marginBottom: 6,
-                  width: '100%',
-                  padding: 0,
-                  textAlign: 'left',
-                }}
-              />
-            ) : (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 22,
-                  color: textColor,
-                  letterSpacing: -0.5,
-                  marginBottom: 6,
-                }}
-              >
-                {profileData.name || '—'}
-              </Text>
-            )}
-            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: mutedTextColor }}>
-              {user?.email ||
-                (user?.username ? `@${user.username}` : '') ||
-                '—'}
-            </Text>
-            {user?.isVerified ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 6 }}>
-                <BadgeCheck size={14} color="#E8862A" />
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#E8862A' }}>
-                  {allCenters.find((c) => c.centerID === profileData.centerID)?.name
-                    ? `Verified by ${allCenters.find((c) => c.centerID === profileData.centerID)?.name}`
-                    : 'Verified'}
-                </Text>
-              </View>
-            ) : null}
-            {isEditing && user?.email && user.email !== user.username && (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: mutedTextColor,
-                  marginTop: 4,
-                }}
-              >
-                @{user.username}
-              </Text>
-            )}
+        )}
+        <Text style={{ fontSize: 21, fontWeight: '700', color: c.text, marginTop: 14, textAlign: 'center' }}>{displayName}</Text>
+        {user?.username ? <Text style={{ fontSize: 14, color: c.textMuted, marginTop: 1 }}>@{user.username}</Text> : null}
+        {roleLabel ? (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10, backgroundColor: c.accentSoft, paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999 }}>
+            <BadgeCheck size={14} color="#C2410C" />
+            <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
           </View>
-        </View>
+        ) : null}
+        {homeCenter ? (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
+            <MapPin size={13} color={c.textFaint} />
+            <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
+          </View>
+        ) : null}
+      </View>
 
-        <View style={{ paddingHorizontal: 20, gap: 20 }}>
-          <View>
-            <Text style={labelStyle}>Bio</Text>
-            {isEditing ? (
-              <TextInput
-                defaultValue={profileData.bio}
-                onChangeText={(v) => {
-                  draftBio.current = v
-                }}
-                multiline
-                textAlignVertical="top"
-                placeholderTextColor="#9ca3af"
-                style={multilineInputStyle}
-              />
-            ) : (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 15,
-                  color: mutedTextColor,
-                  lineHeight: 22,
-                }}
-              >
-                {profileData.bio || '—'}
-              </Text>
-            )}
-            {errors.bio && (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: '#DC2626',
-                  marginTop: 6,
-                }}
-              >
-                {errors.bio}
-              </Text>
-            )}
-          </View>
-          <View>
-            <Text style={labelStyle}>Birthday</Text>
-            {isEditing ? (
-              <BirthdatePicker
-                value={draftBirthday.current ?? undefined}
-                onChange={(d: Date) => {
-                  draftBirthday.current = d
-                }}
-              />
-            ) : (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 16,
-                  color: textColor,
-                  lineHeight: 24,
-                }}
-              >
-                {formatBirthday(profileData.birthday) || '—'}
-              </Text>
-            )}
-            {errors.birthday && (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: '#DC2626',
-                  marginTop: 6,
-                }}
-              >
-                {errors.birthday}
-              </Text>
-            )}
-          </View>
+      {user?.bio ? (
+        <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
+      ) : (
+        <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
+          No bio yet — tap Edit to introduce yourself.
+        </Text>
+      )}
 
-          <View>
-            <Text style={labelStyle}>Center</Text>
-            {isEditing ? (
-              <View
-                style={{
-                  position: 'relative',
-                  marginBottom: showCenterPicker && centerResults.length > 0 ? 200 : 0,
-                }}
-              >
-                <TextInput
-                  value={
-                    centerSearch ||
-                    allCenters.find((c) => c.centerID === profileData.centerID)?.name ||
-                    ''
-                  }
-                  onChangeText={(text) => {
-                    setCenterSearch(text)
-                    if (text.length < 3) {
-                      setShowCenterPicker(false)
-                    }
-                    if (text === '') {
-                      setProfileData((prev) => ({ ...prev, centerID: null }))
-                    }
-                  }}
-                  onFocus={() => {
-                    if (centerResults.length > 0) {
-                      setShowCenterPicker(true)
-                    }
-                  }}
-                  placeholder="Search by city or town"
-                  placeholderTextColor="#9ca3af"
-                  style={inputStyle}
-                />
-                {centerSearchLoading && (
-                  <View style={{ position: 'absolute', right: 12, top: 14 }}>
-                    <ActivityIndicator size="small" color="#C2410C" />
-                  </View>
-                )}
-                {showCenterPicker && centerResults.length > 0 && (
-                  <View
-                    style={{
-                      position: 'absolute',
-                      top: '100%',
-                      left: 0,
-                      right: 0,
-                      backgroundColor: cardBg,
-                      borderRadius: 12,
-                      borderWidth: 1,
-                      borderColor,
-                      maxHeight: 200,
-                      zIndex: 200,
-                      marginTop: 8,
-                      shadowColor: '#000',
-                      shadowOffset: { width: 0, height: 2 },
-                      shadowOpacity: 0.1,
-                      shadowRadius: 8,
-                      elevation: 5,
-                    }}
-                  >
-                    {centerResults.map((center) => (
-                      <Pressable
-                        key={center.centerID}
-                        onPress={() => {
-                          setProfileData((prev) => ({ ...prev, centerID: center.centerID }))
-                          setCenterSearch('')
-                          setShowCenterPicker(false)
-                          track('profile_center_selected', { source: 'profile', center_id: center.centerID, center_name: center.name })
-                        }}
-                        style={{
-                          paddingHorizontal: 16,
-                          paddingVertical: 12,
-                          borderBottomWidth: 1,
-                          borderBottomColor: borderColor,
-                          backgroundColor:
-                            profileData.centerID === center.centerID
-                              ? '#C2410C' + '20'
-                              : 'transparent',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            fontFamily: 'Inclusive Sans',
-                            fontSize: 14,
-                            color:
-                              profileData.centerID === center.centerID ? '#C2410C' : textColor,
-                          }}
-                        >
-                          {center.name}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  </View>
-                )}
-              </View>
-            ) : (
-              <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 8 }}>
-                <MapPin size={18} color={mutedTextColor} style={{ marginTop: 2 }} />
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 15,
-                    color: mutedTextColor,
-                    flex: 1,
-                    lineHeight: 22,
-                  }}
-                >
-                  {profileData.centerID
-                    ? allCenters.find((c) => c.centerID === profileData.centerID)?.name || '—'
-                    : '—'}
-                </Text>
-              </View>
-            )}
-          </View>
+      <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
+        <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 10, borderRadius: 12, backgroundColor: c.text }}>
+          <Pencil size={15} color={c.textInverse} />
+          <Text style={{ fontSize: 14, fontWeight: '600', color: c.textInverse }}>Edit</Text>
+        </Pressable>
+        <Pressable onPress={onShare} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 10, borderRadius: 12, borderWidth: 1, borderColor: c.border, backgroundColor: c.card }}>
+          <Share2 size={15} color={c.text} />
+          <Text style={{ fontSize: 14, fontWeight: '600', color: c.text }}>Share</Text>
+        </Pressable>
+      </View>
 
-          <View>
-            <Text
-              style={{
-                fontFamily: 'Inclusive Sans',
-                fontSize: 12,
-                color: labelColor,
-                letterSpacing: 1,
-                textTransform: 'uppercase',
-                marginBottom: 12,
-              }}
-            >
-              Interests
-            </Text>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-              {PREFERENCE_OPTIONS.map((pref) => {
-                const selected = profileData.interests.includes(pref)
-                return (
-                  <Pressable
-                    key={pref}
-                    onPress={() => handlePreferenceToggle(pref)}
-                    disabled={!isEditing}
-                    style={{
-                      paddingHorizontal: 18,
-                      paddingVertical: 12,
-                      borderRadius: 100,
-                      minHeight: 44,
-                      justifyContent: 'center',
-                      backgroundColor: selected ? '#C2410C' : chipBg,
-                      opacity: !isEditing && !selected ? 0.5 : 1,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        fontFamily: 'Inclusive Sans',
-                        fontSize: 14,
-                        color: selected ? '#FFFFFF' : mutedTextColor,
-                      }}
-                    >
-                      {pref}
-                    </Text>
-                  </Pressable>
-                )
-              })}
+      {interests.length > 0 ? (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 7, marginTop: 18 }}>
+          {interests.map((it) => (
+            <View key={it} style={{ paddingHorizontal: 12, paddingVertical: 6, borderRadius: 999, backgroundColor: c.bg, borderWidth: 1, borderColor: c.border }}>
+              <Text style={{ fontSize: 12.5, color: c.textMuted }}>{it}</Text>
             </View>
-            {errors.interests && (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: '#DC2626',
-                  marginTop: 8,
-                }}
+          ))}
+        </View>
+      ) : null}
+
+      <Pressable
+        onPress={onSettings}
+        style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
+      >
+        <Text style={{ fontSize: 14, color: c.textSecondary }}>Account &amp; Settings</Text>
+        <ChevronRight size={18} color={c.iconMuted} />
+      </Pressable>
+    </View>
+  )
+
+  const StatCard = ({ icon, value, label }: { icon: React.ReactNode; value: number; label: string }) => (
+    <View style={[card, { flex: 1, padding: 16 }]}>
+      <View style={{ width: 34, height: 34, borderRadius: 10, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 10 }}>{icon}</View>
+      <Text style={{ fontSize: 24, fontWeight: '700', color: c.text }}>{value}</Text>
+      <Text style={{ fontSize: 13, color: c.textMuted }}>{label}</Text>
+    </View>
+  )
+
+  const SectionLabel = ({ children }: { children: string }) => (
+    <Text style={{ fontSize: 12.5, fontWeight: '600', color: c.textMuted, letterSpacing: 0.5, textTransform: 'uppercase', marginBottom: 12, marginTop: 26, marginLeft: 2 }}>{children}</Text>
+  )
+
+  const RightColumn = (
+    <View>
+      <View style={{ flexDirection: 'row', gap: 14 }}>
+        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
+      </View>
+
+      <SectionLabel>Upcoming events</SectionLabel>
+      {upcoming.length > 0 ? (
+        <View style={[card, { overflow: 'hidden' }]}>
+          {upcoming.map((e, i) => {
+            const { m, d } = datePill(e.date)
+            const centerName = allCenters.find((cc) => cc.centerID === e.centerID)?.name
+            return (
+              <Pressable
+                key={e.eventID}
+                onPress={() => { track('event_list_item_pressed', { eventId: e.eventID, source: 'profile_web' }); router.push(`/events/${e.eventID}`) }}
+                style={{ flexDirection: 'row', gap: 13, alignItems: 'center', padding: 16, borderBottomWidth: i < upcoming.length - 1 ? 1 : 0, borderBottomColor: c.border }}
               >
-                {errors.interests}
-              </Text>
-            )}
+                <View style={{ width: 46, height: 52, borderRadius: 12, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center' }}>
+                  <Text style={{ fontSize: 10, fontWeight: '700', color: '#C2410C', letterSpacing: 0.5 }}>{m}</Text>
+                  <Text style={{ fontSize: 18, fontWeight: '700', color: c.text }}>{d}</Text>
+                </View>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={{ fontSize: 14.5, fontWeight: '600', color: c.text }} numberOfLines={1}>{e.title}</Text>
+                  <Text style={{ fontSize: 12.5, color: c.textMuted, marginTop: 2 }} numberOfLines={1}>{centerName || extractCityState(e.address ?? undefined) || 'Event'}</Text>
+                </View>
+                <ChevronRight size={16} color={c.iconMuted} />
+              </Pressable>
+            )
+          })}
+        </View>
+      ) : (
+        <View style={[card, { padding: 24, alignItems: 'center' }]}>
+          <View style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+            <CalendarDays size={20} color="#C2410C" />
           </View>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: c.text }}>No upcoming events yet</Text>
+          <Text style={{ fontSize: 13.5, lineHeight: 20, color: c.textMuted, textAlign: 'center', marginTop: 4, maxWidth: 320 }}>
+            RSVP to satsangs, study groups, and events near you — they'll show up here.
+          </Text>
+          <Pressable onPress={onExplore} style={{ marginTop: 14, paddingHorizontal: 18, paddingVertical: 9, borderRadius: 999, backgroundColor: '#C2410C' }}>
+            <Text style={{ fontSize: 13.5, fontWeight: '600', color: '#fff' }}>Explore events</Text>
+          </Pressable>
+        </View>
+      )}
 
-          {/* Form-level errors */}
-          {(errors.form || errors.profileImage) && (
-            <Text
-              style={{
-                fontFamily: 'Inclusive Sans',
-                fontSize: 13,
-                color: '#DC2626',
-                marginTop: 8,
-              }}
-            >
-              {errors.form || errors.profileImage}
-            </Text>
-          )}
-
-          {!isEditing && (
+      <SectionLabel>Your centers</SectionLabel>
+      {groups.length > 0 ? (
+        <View style={[card, { overflow: 'hidden' }]}>
+          {groups.map((g, i) => (
             <Pressable
-              onPress={handleEdit}
-              style={{
-                marginTop: 16,
-                paddingVertical: 14,
-                borderRadius: 12,
-                minHeight: 48,
-                backgroundColor: isDark ? '#F5F5F5' : '#1C1917',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexDirection: 'row',
-                gap: 8,
-              }}
+              key={g.centerID}
+              onPress={() => { track('center_list_item_pressed', { centerId: g.centerID, source: 'profile_web' }); router.push(`/center/${g.centerID}`) }}
+              style={{ flexDirection: 'row', gap: 13, alignItems: 'center', padding: 16, borderBottomWidth: i < groups.length - 1 ? 1 : 0, borderBottomColor: c.border }}
             >
-              <Pencil size={16} color={isDark ? '#1C1917' : '#FFFFFF'} />
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: isDark ? '#1C1917' : '#FFFFFF' }}>
-                Edit Profile
-              </Text>
+              <View style={{ width: 40, height: 40, borderRadius: 11, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}>
+                {g.image ? <Image source={{ uri: g.image }} style={{ width: 40, height: 40 }} /> : <Building2 size={18} color="#C2410C" />}
+              </View>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ fontSize: 14.5, fontWeight: '600', color: c.text }} numberOfLines={1}>{g.name}</Text>
+                <Text style={{ fontSize: 12.5, color: c.textMuted, marginTop: 2 }} numberOfLines={1}>{extractCityState(g.address ?? undefined) || 'Center'}</Text>
+              </View>
+              <ChevronRight size={16} color={c.iconMuted} />
             </Pressable>
-          )}
-
-          {isEditing && (
-            <View style={{ flexDirection: 'row', gap: 12, marginTop: 8 }}>
-              <Pressable
-                onPress={handleCancel}
-                style={{
-                  flex: 1,
-                  paddingVertical: 14,
-                  borderRadius: 12,
-                  minHeight: 48,
-                  backgroundColor: isDark ? '#262626' : '#F3F0ED',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: textColor }}>
-                  Cancel
-                </Text>
-              </Pressable>
-              <Pressable
-                onPress={handleSave}
-                disabled={isSaving}
-                style={{
-                  flex: 1,
-                  paddingVertical: 14,
-                  borderRadius: 12,
-                  minHeight: 48,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                {isSaving ? (
-                  <ActivityIndicator size="small" color="#fff" />
-                ) : (
-                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: '#FFFFFF' }}>
-                    Save Changes
-                  </Text>
-                )}
-              </Pressable>
-            </View>
-          )}
+          ))}
         </View>
-      </ScrollView>
-    )
-  }
-
-  // WEB LAYOUT
-  const { width: viewportWidth } = useWindowDimensions()
-  const isNarrowWeb = viewportWidth < 768
-  // Wide desktop gets a two-column field grid; mobile web keeps the stacked
-  // single column. Native iOS uses the entirely separate layout above.
-  const isWideWeb = viewportWidth >= 1024
-  const webPaddingH = isNarrowWeb ? 16 : viewportWidth < 1024 ? 32 : 60
-  const faintColor = isDark ? '#525252' : '#C4BEB4'
-
-  // Quiet placeholder for an empty read-only field — reads as "not set yet"
-  // instead of a bare em-dash. Only shown when viewing (not editing).
-  const EmptyValue = ({ label }: { label: string }) => (
-    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: faintColor, fontStyle: 'italic' }}>
-      {label}
-    </Text>
+      ) : (
+        <View style={[card, { padding: 24, alignItems: 'center' }]}>
+          <View style={{ width: 44, height: 44, borderRadius: 22, backgroundColor: c.accentSoft, alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+            <Building2 size={20} color="#C2410C" />
+          </View>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: c.text }}>No center yet</Text>
+          <Text style={{ fontSize: 13.5, lineHeight: 20, color: c.textMuted, textAlign: 'center', marginTop: 4, maxWidth: 320 }}>
+            Find your Chinmaya center to connect with your local community.
+          </Text>
+          <Pressable onPress={onExplore} style={{ marginTop: 14, paddingHorizontal: 18, paddingVertical: 9, borderRadius: 999, backgroundColor: '#C2410C' }}>
+            <Text style={{ fontSize: 13.5, fontWeight: '600', color: '#fff' }}>Find a center</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
   )
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: isDark ? '#171717' : '#FAFAF7' }}>
+    <ScrollView style={{ flex: 1, backgroundColor: c.bg }} contentContainerStyle={{ paddingBottom: 60 }}>
       <View
         style={{
-          maxWidth: isWideWeb ? 1080 : 900,
+          maxWidth: 980,
           width: '100%',
           alignSelf: 'center',
-          padding: isNarrowWeb ? 20 : 40,
-          paddingHorizontal: webPaddingH,
-          gap: isNarrowWeb ? 24 : 36,
+          paddingHorizontal: isDesktop ? 24 : 14,
+          paddingTop: isDesktop ? 28 : 16,
+          ...(isDesktop
+            ? { flexDirection: 'row', alignItems: 'flex-start', gap: 24 }
+            : { flexDirection: 'column', gap: 18 }),
         }}
       >
-        {/* Header row */}
-        <View
-          style={{
-            flexDirection: isNarrowWeb ? 'column' : 'row',
-            justifyContent: 'space-between',
-            alignItems: isNarrowWeb ? 'stretch' : 'flex-start',
-            gap: isNarrowWeb ? 16 : 0,
-          }}
-        >
-          <View style={{ gap: 4 }}>
-            <Text
-              style={{
-                fontSize: isNarrowWeb ? 28 : 34,
-                fontWeight: '600',
-                color: textColor,
-                letterSpacing: -0.5,
-              }}
-            >
-              Profile
-            </Text>
-            <Text style={{ fontSize: 15, color: mutedTextColor, marginTop: 4 }}>
-              Manage your public profile information
-            </Text>
-          </View>
-          <Pressable
-            onPress={isEditing ? handleSave : handleEdit}
-            disabled={isSaving}
-            style={{
-              paddingHorizontal: 24,
-              paddingVertical: 12,
-              borderRadius: 10,
-              minHeight: 44,
-              backgroundColor: isEditing ? '#C2410C' : isDark ? '#F5F5F5' : '#1C1917',
-              alignItems: 'center',
-              justifyContent: 'center',
-              alignSelf: isNarrowWeb ? 'stretch' : 'auto',
-              flexDirection: 'row',
-              gap: 8,
-            }}
-          >
-            {isSaving ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <>
-                <Pencil size={16} color={isEditing ? '#FFFFFF' : isDark ? '#1C1917' : '#FFFFFF'} />
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 14,
-                    color: isEditing ? '#FFFFFF' : isDark ? '#1C1917' : '#FFFFFF',
-                  }}
-                >
-                  {isEditing ? 'Save Changes' : 'Edit Profile'}
-                </Text>
-              </>
-            )}
-          </Pressable>
-        </View>
-
-        {/* Profile card — avatar + name row on all breakpoints */}
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: isNarrowWeb ? 16 : 28,
-            padding: isNarrowWeb ? 20 : 28,
-            backgroundColor: cardBg,
-            borderRadius: 20,
-            borderWidth: 1,
-            borderColor,
-          }}
-        >
-          <View style={{ position: 'relative' }}>
-            {profileData.profileImage ? (
-              <Image
-                source={{ uri: profileData.profileImage }}
-                style={{ width: 96, height: 96, borderRadius: 48, backgroundColor: '#D6D3D1' }}
-              />
-            ) : (
-              <View
-                style={{
-                  width: 96,
-                  height: 96,
-                  borderRadius: 48,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Text style={{ color: '#fff', fontSize: 32, fontWeight: '600' }}>
-                  {getInitials()}
-                </Text>
-              </View>
-            )}
-            {isEditing && (
-              <Pressable
-                style={{
-                  position: 'absolute',
-                  bottom: -4,
-                  right: -4,
-                  width: 44,
-                  height: 44,
-                  borderRadius: 22,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  borderWidth: 2,
-                  borderColor: cardBg,
-                }}
-                onPress={handleAvatarPress}
-              >
-                <Camera size={16} color="#fff" />
-              </Pressable>
-            )}
-          </View>
-          <View style={{ gap: 6, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
-            {isEditing ? (
-              <View
-                style={{
-                  borderBottomWidth: 2,
-                  borderBottomColor: '#C2410C',
-                  paddingBottom: 2,
-                  width: '100%',
-                }}
-              >
-                <TextInput
-                  defaultValue={profileData.name}
-                  onChangeText={(v) => {
-                    draftName.current = v
-                  }}
-                  placeholderTextColor="#9ca3af"
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: isNarrowWeb ? 22 : 24,
-                    color: textColor,
-                    letterSpacing: -0.3,
-                    width: '100%',
-                    padding: 0,
-                    margin: 0,
-                  }}
-                />
-              </View>
-            ) : (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: isNarrowWeb ? 22 : 24,
-                  color: textColor,
-                  letterSpacing: -0.3,
-                }}
-              >
-                {profileData.name || '—'}
-              </Text>
-            )}
-            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: mutedTextColor }}>
-              {user?.email ||
-                (user?.username ? `@${user.username}` : '') ||
-                '—'}
-            </Text>
-            {user?.isVerified ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 6 }}>
-                <BadgeCheck size={14} color="#E8862A" />
-                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#E8862A' }}>
-                  {allCenters.find((c) => c.centerID === profileData.centerID)?.name
-                    ? `Verified by ${allCenters.find((c) => c.centerID === profileData.centerID)?.name}`
-                    : 'Verified'}
-                </Text>
-              </View>
-            ) : null}
-            {isEditing && user?.email && user.email !== user.username && (
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: mutedTextColor }}>
-                @{user.username}
-              </Text>
-            )}
-          </View>
-        </View>
-
-        {/* Birthday + Center — side by side on wide desktop, stacked otherwise.
-            Both are compact fields, so pairing them tightens the page and uses
-            the extra width instead of leaving a tall, sparse single column. */}
-        <View style={{ flexDirection: isWideWeb ? 'row' : 'column', gap: isWideWeb ? 28 : (isNarrowWeb ? 20 : 28) }}>
-          <View style={{ flex: 1, gap: 8 }}>
-            <Text style={labelStyle}>Birthday</Text>
-            {isEditing ? (
-              <View>
-                <BirthdatePicker
-                  value={draftBirthday.current ?? undefined}
-                  onChange={(d: Date) => {
-                    draftBirthday.current = d
-                  }}
-                />
-              </View>
-            ) : (
-              <View
-                style={{
-                  paddingHorizontal: 16,
-                  paddingVertical: 14,
-                  backgroundColor: cardBg,
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor,
-                }}
-              >
-                {profileData.birthday ? (
-                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: textColor }}>
-                    {formatBirthday(profileData.birthday)}
-                  </Text>
-                ) : (
-                  <EmptyValue label="Not added yet" />
-                )}
-              </View>
-            )}
-            {errors.birthday && (
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 13,
-                  color: '#DC2626',
-                  marginTop: 6,
-                }}
-              >
-                {errors.birthday}
-              </Text>
-            )}
-          </View>
-
-          {/* Center */}
-          <View style={{ flex: 1, gap: 8 }}>
-            <Text style={labelStyle}>Center</Text>
-            {isEditing ? (
-            <View
-              style={{
-                position: 'relative',
-                marginBottom: showCenterPicker && centerResults.length > 0 ? 200 : 0,
-              }}
-            >
-              <TextInput
-                value={
-                  centerSearch ||
-                  allCenters.find((c) => c.centerID === profileData.centerID)?.name ||
-                  ''
-                }
-                onChangeText={(text) => {
-                  setCenterSearch(text)
-                  if (text.length < 3) {
-                    setShowCenterPicker(false)
-                  }
-                  if (text === '') {
-                    setProfileData((prev) => ({ ...prev, centerID: null }))
-                  }
-                }}
-                onFocus={() => {
-                  if (centerResults.length > 0) {
-                    setShowCenterPicker(true)
-                  }
-                }}
-                placeholder="Search by city or town"
-                placeholderTextColor="#9ca3af"
-                style={inputStyle}
-              />
-              {centerSearchLoading && (
-                <View style={{ position: 'absolute', right: 12, top: 14 }}>
-                  <ActivityIndicator size="small" color="#C2410C" />
-                </View>
-              )}
-              {showCenterPicker && centerResults.length > 0 && (
-                <View
-                  style={{
-                    position: 'absolute',
-                    top: '100%',
-                    left: 0,
-                    right: 0,
-                    backgroundColor: cardBg,
-                    borderRadius: 12,
-                    borderWidth: 1,
-                    borderColor,
-                    maxHeight: 200,
-                    zIndex: 200,
-                    marginTop: 8,
-                    shadowColor: '#000',
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.1,
-                    shadowRadius: 8,
-                    elevation: 5,
-                  }}
-                >
-                  <ScrollView style={{ maxHeight: 200 }}>
-                    {centerResults.map((center) => (
-                      <Pressable
-                        key={center.centerID}
-                        onPressIn={() => {
-                          setProfileData((prev) => ({ ...prev, centerID: center.centerID }))
-                          setCenterSearch('')
-                          setShowCenterPicker(false)
-                          track('profile_center_selected', { source: 'profile', center_id: center.centerID, center_name: center.name })
-                        }}
-                        style={{
-                          paddingHorizontal: 16,
-                          paddingVertical: 12,
-                          borderBottomWidth: 1,
-                          borderBottomColor: borderColor,
-                          backgroundColor:
-                            profileData.centerID === center.centerID
-                              ? '#C2410C' + '20'
-                              : 'transparent',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            fontFamily: 'Inclusive Sans',
-                            fontSize: 14,
-                            color:
-                              profileData.centerID === center.centerID ? '#C2410C' : textColor,
-                          }}
-                        >
-                          {center.name}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  </ScrollView>
-                </View>
-              )}
-            </View>
-          ) : (
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'flex-start',
-                gap: 10,
-                paddingHorizontal: 16,
-                paddingVertical: 14,
-                backgroundColor: cardBg,
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor,
-              }}
-            >
-              {(() => {
-                const centerName = profileData.centerID
-                  ? allCenters.find((c) => c.centerID === profileData.centerID)?.name
-                  : undefined
-                return (
-                  <>
-                    <MapPin size={18} color={centerName ? mutedTextColor : faintColor} style={{ marginTop: 2 }} />
-                    {centerName ? (
-                      <Text
-                        style={{
-                          fontFamily: 'Inclusive Sans',
-                          fontSize: 15,
-                          color: mutedTextColor,
-                          flex: 1,
-                          lineHeight: 22,
-                        }}
-                      >
-                        {centerName}
-                      </Text>
-                    ) : (
-                      <View style={{ flex: 1 }}>
-                        <EmptyValue label="No center selected" />
-                      </View>
-                    )}
-                  </>
-                )
-              })()}
-            </View>
-          )}
-          </View>
-        </View>
-
-        {/* Bio — full width below the Birthday + Center row */}
-        <View style={{ gap: 8 }}>
-          <Text style={labelStyle}>Bio</Text>
-          <TextInput
-            ref={bioRef}
-            defaultValue={profileData.bio}
-            onChangeText={(v) => {
-              draftBio.current = v
-            }}
-            multiline
-            textAlignVertical="top"
-            placeholderTextColor="#9ca3af"
-            style={[multilineInputStyle, !isEditing && hiddenStyle]}
-          />
-          {!isEditing && (
-            <View
-              style={{
-                paddingHorizontal: 16,
-                paddingVertical: 14,
-                backgroundColor: cardBg,
-                borderRadius: 12,
-                borderWidth: 1,
-                borderColor,
-                minHeight: 80,
-              }}
-            >
-              {profileData.bio ? (
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 15,
-                    color: mutedTextColor,
-                    lineHeight: 24,
-                  }}
-                >
-                  {profileData.bio}
-                </Text>
-              ) : (
-                <EmptyValue label="No bio yet — tap Edit Profile to add one" />
-              )}
-            </View>
-          )}
-          {errors.bio && (
-            <Text
-              style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 6 }}
-            >
-              {errors.bio}
-            </Text>
-          )}
-        </View>
-
-        {/* Interests */}
-        <View>
-          <Text
-            style={{
-              fontFamily: 'Inclusive Sans',
-              fontSize: 12,
-              color: labelColor,
-              letterSpacing: 1,
-              textTransform: 'uppercase',
-              marginBottom: 12,
-            }}
-          >
-            Interests
-          </Text>
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-            {PREFERENCE_OPTIONS.map((pref) => {
-              const selected = profileData.interests.includes(pref)
-              return (
-                <Pressable
-                  key={pref}
-                  onPress={() => handlePreferenceToggle(pref)}
-                  disabled={!isEditing}
-                  style={{
-                    paddingHorizontal: 18,
-                    paddingVertical: 12,
-                    borderRadius: 100,
-                    minHeight: 44,
-                    justifyContent: 'center',
-                    backgroundColor: selected ? '#C2410C' : chipBg,
-                    opacity: !isEditing && !selected ? 0.5 : 1,
-                  }}
-                >
-                  <Text
-                    style={{
-                      fontFamily: 'Inclusive Sans',
-                      fontSize: 14,
-                      color: selected ? '#FFFFFF' : mutedTextColor,
-                    }}
-                  >
-                    {pref}
-                  </Text>
-                </Pressable>
-              )
-            })}
-          </View>
-          {errors.interests && (
-            <Text
-              style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 8 }}
-            >
-              {errors.interests}
-            </Text>
-          )}
-        </View>
-
-        {/* Form-level errors */}
-        {(errors.form || errors.profileImage) && (
-          <Text
-            style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 8 }}
-          >
-            {errors.form || errors.profileImage}
-          </Text>
-        )}
-
-        {/* Cancel button when editing */}
-        {isEditing && (
-          <Pressable
-            onPress={handleCancel}
-            style={{
-              alignSelf: isNarrowWeb ? 'stretch' : 'flex-start',
-              paddingHorizontal: 24,
-              paddingVertical: 12,
-              borderRadius: 10,
-              minHeight: 44,
-              backgroundColor: isDark ? '#262626' : '#F3F0ED',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: textColor }}>
-              Cancel
-            </Text>
-          </Pressable>
-        )}
-
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          style={{ display: 'none' }}
-          onChange={handleFileChange}
-        />
-
-        {cropperImage && (
-          <WebAvatarCropper
-            visible={!!cropperImage}
-            imageUri={cropperImage}
-            originalImageUri={originalImage || undefined}
-            onCropComplete={handleCropComplete}
-            onCancel={handleCropCancel}
-            onReplacePhoto={handleReplacePhoto}
-          />
-        )}
+        <View style={isDesktop ? { width: 330 } : { width: '100%' }}>{ProfileCard}</View>
+        <View style={{ flex: 1, width: '100%' }}>{RightColumn}</View>
       </View>
     </ScrollView>
   )


### PR DESCRIPTION
Closes #330. Design direction picked via a comp 'shotgun' round (Direction B — two-column dashboard / stacked).

## What changed
The Profile tab was a barren, read-only form and a dead-end (no path to Settings, no engagement). It's now a proper **public social profile** on **both web and native**:

- **Web** (`profile.web.tsx`) — two-column on desktop, stacked on mobile.
- **Native** (`profile.tsx`) — stacked, same content + copy.

**Left card:** avatar, name, @handle, role chip, home center, bio, **Edit** (→ `/edit-profile`) + **Share**, interest chips, and an **Account & Settings** link into the combined Settings page.
**Right / below:** engagement **stat cards** (Posts / Events / Centers) + **Upcoming events** and **Your centers** lists, each with friendly **empty states** + Explore CTAs.

Real design-system tokens (`tokens/colors`) + lucide icons (no emoji). Profile stays reachable via the avatar dropdown (already wired in SettingsPanel → `/profile`); no nav link added. Inline editing removed in favor of the single `/edit-profile` editor (parity with Settings).

## Verification
- **Web:** verified live on the preview at desktop (1280) + mobile (402) — both layouts + empty states render correctly.
- **Native:** typecheck-clean; **not yet sim-verified** (per the 'write now, verify on sim later' approach). Web paths verified.

frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)