### PR TITLE
fix(feed): hide compose (+) from signed-out guests

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -228,7 +228,9 @@ export default function TabLayout() {
               title: 'Feed',
               header: isDesktopWeb
                 ? () => <WebHeader />
-                : () => <TabHeader title="Feed" action="create" />,
+                // Compose (+) is only for signed-in members — guests have no
+                // boards to post to (they see the Feed sign-in wall instead).
+                : () => <TabHeader title="Feed" action={user ? 'create' : undefined} />,
               tabBarIcon: ({ color, size }) => <Newspaper size={size} color={color} />,
             }}
           />

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -183,10 +183,13 @@ export default function FeedScreen() {
     }, [refetchMyEvents, refetchCenters])
   )
 
+  // Only offer the compose (+) action to signed-in members — a guest has no
+  // boards to post to, so the affordance sat above the sign-in wall doing nothing.
   useEffect(() => {
+    if (!user) { setCreateHandler(null); return }
     setCreateHandler(() => setCreatePostOpen(true))
     return () => setCreateHandler(null)
-  }, [setCreateHandler])
+  }, [setCreateHandler, user])
 
   const threadColors = toThreadColors(colors)
 


### PR DESCRIPTION
Small beta-polish found during a logged-out Feed QA pass (desktop + mobile).

A signed-out guest saw a compose **+** in the Feed header sitting above the sign-in wall — but a guest has no boards to post to, so it was a dead affordance. Now the create action is gated on auth in two places:
- `(tabs)/_layout.tsx` — `TabHeader action={user ? 'create' : undefined}` so the **+** isn't rendered for guests.
- `(tabs)/feed.tsx` — the create handler is only registered when signed in (defense-in-depth).

Members are unaffected (`user` truthy → `action='create'`, same as before). Verified on the preview: guest Feed header no longer shows **+**. `tsc` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)