### PR TITLE
fix(center): hide empty About section instead of an orphaned header

### DIFF
--- a/packages/frontend/app/center/[id].tsx
+++ b/packages/frontend/app/center/[id].tsx
@@ -329,17 +329,19 @@ export default function CenterDetailPage() {
         ) : null}
 
         {/* ABOUT (editable by admins — #285) */}
-        <DetailSection title="About" first>
-          <CenterAbout
-            centerId={center.id}
-            description={center.description}
-            pointOfContact={center.pointOfContact}
-            canEdit={canEditCenter}
-          />
-        </DetailSection>
+        {(canEditCenter || !!center.description?.trim() || !!center.pointOfContact?.trim()) ? (
+          <DetailSection title="About" first>
+            <CenterAbout
+              centerId={center.id}
+              description={center.description}
+              pointOfContact={center.pointOfContact}
+              canEdit={canEditCenter}
+            />
+          </DetailSection>
+        ) : null}
 
         {/* DETAILS */}
-        <DetailSection title="Details">
+        <DetailSection title="Details" first={!(canEditCenter || !!center.description?.trim() || !!center.pointOfContact?.trim())}>
           <View style={{ gap: 16 }}>
             {/* Address */}
             {center.address ? (

--- a/packages/frontend/app/center/[id].web.tsx
+++ b/packages/frontend/app/center/[id].web.tsx
@@ -271,17 +271,19 @@ function MobileCenterDetail({ centerId }: { centerId: string }) {
         ) : null}
 
         {/* ABOUT (editable by admins — #285) */}
-        <DetailSection title="About" first>
-          <CenterAbout
-            centerId={center.id}
-            description={center.description}
-            pointOfContact={center.pointOfContact}
-            canEdit={canEditCenter}
-          />
-        </DetailSection>
+        {(canEditCenter || !!center.description?.trim() || !!center.pointOfContact?.trim()) ? (
+          <DetailSection title="About" first>
+            <CenterAbout
+              centerId={center.id}
+              description={center.description}
+              pointOfContact={center.pointOfContact}
+              canEdit={canEditCenter}
+            />
+          </DetailSection>
+        ) : null}
 
         {/* DETAILS */}
-        <DetailSection title="Details">
+        <DetailSection title="Details" first={!(canEditCenter || !!center.description?.trim() || !!center.pointOfContact?.trim())}>
           <View style={{ gap: 16 }}>
             {center.address ? (
               <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 10 }}>

--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -64,6 +64,11 @@ export default function CenterDetailPanel({
   const canPostToThread =
     !!user && (user.centerID === center.id || (user.verificationLevel ?? 0) >= 107)
   const canEditCenter = !!user && (user.verificationLevel ?? 0) >= 107
+  // Only render the About section when there's something to show (description or
+  // point of contact) or the viewer can add it — otherwise CenterAbout returns
+  // null and the section header is left orphaned above Details.
+  const showAbout =
+    canEditCenter || !!center.description?.trim() || !!center.pointOfContact?.trim()
   const { posts: boardPosts, refetch: refetchBoard } = useBoard('center', center.id, canPostToThread)
   const boardMessages = useMemo(() => boardPosts.map(boardPostToMessage), [boardPosts])
 
@@ -176,17 +181,19 @@ export default function CenterDetailPanel({
         />
 
         {/* ── ABOUT (editable by admins — #285) ───────────────────── */}
-        <DetailSection title="About" first>
-          <CenterAbout
-            centerId={center.id}
-            description={center.description}
-            pointOfContact={center.pointOfContact}
-            canEdit={canEditCenter}
-          />
-        </DetailSection>
+        {showAbout ? (
+          <DetailSection title="About" first>
+            <CenterAbout
+              centerId={center.id}
+              description={center.description}
+              pointOfContact={center.pointOfContact}
+              canEdit={canEditCenter}
+            />
+          </DetailSection>
+        ) : null}
 
         {/* ── DETAILS ─────────────────────────────────────────────── */}
-        <DetailSection title="Details">
+        <DetailSection title="Details" first={!showAbout}>
           {/* ── Meta rows ────────────────────────────────────────── */}
           <View style={{ gap: 16 }}>
             {/* Address */}


### PR DESCRIPTION
Found during a Center-detail QA pass (desktop).

`CenterAbout` returns `null` when a center has no description/point-of-contact **and** the viewer can't edit (`verificationLevel < 107`), but the **About** `DetailSection` header rendered regardless — leaving an empty labeled section floating above Details. Now the section is gated on the same condition (content exists *or* viewer can edit), and Details takes `first` when About is hidden.

Applied to all three center surfaces: `CenterDetailPanel.web.tsx` (desktop), `app/center/[id].web.tsx` (mobile-web), `app/center/[id].tsx` (native). Verified on the preview — the orphaned 'ABOUT' header is gone; panel flows hero → Details → Events → Board. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)