### PR TITLE
fix(#331): clean fresh migrate + one-command local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,20 @@ Om Sri Chinmaya Sadgurave Namaha. Om Sri Gurubyo Namaha.
 ```bash
 git clone https://github.com/Project-Janatha/Project-Janatha.git
 cd Project-Janatha
-npm run setup    # Installs deps + runs D1 migrations + seeds test data
+
+# One command for a fully working local stack: installs deps, applies all
+# migrations to a sandboxed local D1, seeds centers/events, and registers the
+# 5 Developer-Mode role accounts (member@/sevak@/admin@… · PreviewTest2026!).
+npm run setup:local
+
+# (lower-level: `npm run setup` installs + migrates + seeds, no role accounts)
 ```
 
 ### Running
 
 ```bash
-npm run dev      # Starts both API (8787) + Frontend (8081)
+npm run local    # setup:local, then start API (8787) + Frontend (8081)
+npm run dev      # Just start both (API 8787 + Frontend 8081)
 ```
 
 - **API**: http://localhost:8787 — Hono backend on Cloudflare Workers

--- a/migrations/0008_add_chinmaya_centers.sql
+++ b/migrations/0008_add_chinmaya_centers.sql
@@ -77,3 +77,26 @@ INSERT INTO centers (
   NULL,
   datetime('now'), datetime('now')
 );
+
+-- Centers 008/009/015/016/047/057/065/067/088 are referenced by the events in
+-- 0010_seed_chinmaya_events_2026.sql but were never created by any migration
+-- (they predate the c1000001-prefixed seed_centers.sql rewrite, which left these
+-- c0000001 references orphaned). A fresh `npm run d1:migrate:all` therefore
+-- FK-failed on 0010. Recreate them here (before 0010) so the chain applies
+-- cleanly. INSERT OR IGNORE keeps this idempotent — environments where these
+-- rows already exist (e.g. the stateful preview/prod D1) are left untouched.
+-- Geo/address are a representative event location per center; richer metadata
+-- can be backfilled later. See issue #331.
+INSERT OR IGNORE INTO centers (
+  id, name, latitude, longitude, address, member_count, is_verified,
+  created_at, updated_at
+) VALUES
+  ('c0000001-0000-0000-0000-000000000008', 'Chinmaya Sandeepany San Jose', 37.3593226, -121.8095066, '10160 Clayton Rd, San Jose, CA - 95127, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000009', 'Chinmaya Prabha (Houston)', 29.6659766, -95.615816, '10353 Synott Rd, Sugar Land, TX - 77498, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000015', 'Chinmaya Mission Chicago', 41.7143174, -87.9470168, '11S080 Kingery Hwy, Willowbrook, IL - 60527, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000016', 'Chinmaya Mission Orlando', 28.6680904, -81.2926141, 'Casselberry, FL, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000047', 'Chinmaya Mission Portland', 45.5446737, -122.8807329, '3551 NW John Olsen Pl, Hillsboro, OR - 97124, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000057', 'Chinmaya Somnath (Washington DC)', 38.903992, -77.478483, '4350 Blue Spring Dr, Chantilly, VA - 20151, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000065', 'Chinmaya Mission Atlanta', 33.9004478, -84.1743202, '5511 Williams Rd, Norcross, GA - 30093, US', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000067', 'Chinmaya Mission Niagara', 43.0986956, -79.0896157, 'Niagara Region, ON, CA', 0, 1, datetime('now'), datetime('now')),
+  ('c0000001-0000-0000-0000-000000000088', 'Chinmaya-Saaket (Dallas-Fort Worth)', 32.9903214, -96.7942022, '17701 Davenport Rd, Dallas, TX - 75252, US', 0, 1, datetime('now'), datetime('now'));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "packages/*"
   ],
   "scripts": {
-    "setup": "npm install && npm run d1:migrate:local && npm run d1:seed",
+    "setup": "npm install && npm run d1:migrate:all && npm run d1:seed",
+    "setup:local": "bash scripts/dev/setup-local-demo.sh",
+    "local": "bash scripts/dev/setup-local-demo.sh && npm run dev",
+    "db:fresh": "npm run d1:migrate:all -- --reset",
     "postinstall": "node scripts/patch-css.cjs",
     "dev": "pkill -f wrangler 2>/dev/null; pkill -f expo 2>/dev/null; pkill -f react-native 2>/dev/null; sleep 1; concurrently -n api,web -c blue,green \"npm run dev:backend\" \"npm run dev:frontend\"",
     "dev:backend": "cd packages/backend && npm run dev",

--- a/scripts/db/migrate-all.sh
+++ b/scripts/db/migrate-all.sh
@@ -79,8 +79,14 @@ echo
 
 for f in "${FILES[@]}"; do
   echo "  → $(basename "$f")"
-  npx wrangler d1 execute "$DB_NAME" $MODE --file="$f" --config "$CONFIG" >/dev/null 2>&1 \
-    || { echo "✗ FAILED on $(basename "$f")" >&2; exit 1; }
+  # Capture stderr so a failure shows WHY (e.g. a FOREIGN KEY violation) instead
+  # of a silent "FAILED on X" — that opacity is what made the 0010 ordering bug
+  # hard to spot (see #331).
+  if ! err=$(npx wrangler d1 execute "$DB_NAME" $MODE --file="$f" --config "$CONFIG" 2>&1 >/dev/null); then
+    echo "✗ FAILED on $(basename "$f")" >&2
+    echo "$err" | grep -iE 'error|constraint|sqlite|no such' | tail -6 >&2
+    exit 1
+  fi
 done
 
 echo


### PR DESCRIPTION
Closes #331.

## (1) Fresh migrate now applies cleanly
`npm run d1:migrate:all` (fresh DB) **FK-failed on `0010`** (the 2026 events seed). Root cause: 0010's events reference **9 centers** (`…008/009/015/016/047/057/065/067/088`) that **no migration ever created** — they were orphaned when `seed_centers.sql` switched to the `c1000001` id prefix, leaving 0010's `c0000001` references dangling. (The 'website column' symptom in the issue was already fixed separately — 0003 is now a no-op.)

Fix: recreate those 9 centers in **`0008`** (which runs before 0010), names from 0010's own section comments + a representative geo per center, via **`INSERT OR IGNORE`** so stateful preview/prod D1s (which already have them) are untouched. → all 24 migrations apply on a fresh DB.

## (2) Migrations fail loudly
`migrate-all.sh` printed only `✗ FAILED on X` and swallowed stderr — exactly why this bug was hard to spot. It now surfaces the actual FK/constraint error.

## (3) One-command local stack, discoverable
A full local-stack script already existed (`scripts/dev/setup-local-demo.sh`: migrate + seed + register the 5 Developer-Mode role accounts) but wasn't wired to npm, and the root `setup` was broken (applied only `0001`). Added:
- `npm run setup:local` → the full working local stack
- `npm run local` → `setup:local` + `dev`
- `npm run db:fresh` → reset + migrate
- fixed `setup` to run `d1:migrate:all` (not just 0001); README updated.

## Verification
`npm run db:fresh` applies all 24 migrations cleanly (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)