### PR TITLE
feat(auth): value-prop on the sign-in screen (insight into the feature)

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -289,6 +289,23 @@ export default function AuthScreen() {
                   : 'Welcome.'}
               </Text>
 
+              {/* What Janata is — first step only, so a new member knows what
+                  they're signing into before entering an email. */}
+              {authStep === 'initial' && (
+                <View style={{ marginTop: 12, gap: 9 }}>
+                  {[
+                    'Discover satsangs, camps, and classes near you',
+                    'RSVP in a tap and see who else is going',
+                    'Stay connected with your center and sangha',
+                  ].map((line) => (
+                    <View key={line} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
+                      <Text style={{ color: '#C2410C', fontSize: 14, lineHeight: 22 }}>✓</Text>
+                      <Text className="font-sans" style={{ flex: 1, fontSize: 14.5, lineHeight: 22, color: '#57534E' }}>{line}</Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+
               <Text
                 className="text-base font-sans mt-2"
                 style={{ color: '#78716C' }}

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -462,6 +462,24 @@ export default function AuthScreen() {
             {heading}
           </h1>
 
+          {/* What Janata is — only on the first step, so a new beta tester knows
+              what they're signing into before entering an email. On mobile the
+              brand carousel is hidden, making this the only context shown. */}
+          {authStep === 'initial' && (
+            <div style={{ marginTop: 4, marginBottom: 24 }}>
+              {[
+                'Discover satsangs, camps, and classes near you',
+                'RSVP in a tap and see who else is going',
+                'Stay connected with your center and sangha',
+              ].map((line) => (
+                <div key={line} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', marginBottom: 9 }}>
+                  <span style={{ color: '#C2410C', fontSize: 14, lineHeight: '22px' }}>✓</span>
+                  <span style={{ fontFamily: 'Inclusive Sans, sans-serif', fontSize: 14.5, lineHeight: '22px', color: '#57534E' }}>{line}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
           {/* Subtitle */}
           <p
             style={{


### PR DESCRIPTION
Serves the goal's 'sign-in / give insight into the feature, more user-friendly.'

The **initial** auth step showed only **'Welcome.'** + an email field. A new beta tester arriving cold had no idea what Janata is — and on mobile the brand carousel is hidden, so there was *zero* context. Now the first step leads with a concise 3-item value list:
- ✓ Discover satsangs, camps, and classes near you
- ✓ RSVP in a tap and see who else is going
- ✓ Stay connected with your center and sangha

Shown on the **initial** step only (not login/password/signup, to keep those focused). **Web verified** on the preview at desktop + mobile; **native parity** added to `app/auth.tsx` (not sim-verified). `tsc` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)