### PR TITLE
fix(edit-profile): center the form on desktop instead of full-bleed

### DIFF
--- a/packages/frontend/app/edit-profile.tsx
+++ b/packages/frontend/app/edit-profile.tsx
@@ -260,7 +260,7 @@ export default function EditProfileScreen() {
       >
         <ScrollView
           style={{ flex: 1 }}
-          contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 20, paddingBottom: 40 }}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 20, paddingBottom: 40, width: '100%', maxWidth: 680, alignSelf: 'center' }}
           keyboardShouldPersistTaps="handled"
         >
           {/* Photo */}


### PR DESCRIPTION
Found while QA'ing the edit-profile flow (now the canonical editor since Profile's Edit routes here per #330).

On wide web, Edit Profile rendered **edge-to-edge** — fields and section header bars stretched the full viewport, inconsistent with Profile/Settings (which center at a max width). Landing on a stretched form right after the polished Profile redesign was jarring.

Fix: constrain the ScrollView content to `maxWidth: 680`, centered. No-op on mobile (screen < 680). Verified on the preview at desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)