### PR TITLE
fix(verification): don't promise messaging (deferred post-MSC)

### DIFF
--- a/packages/frontend/app/verification.tsx
+++ b/packages/frontend/app/verification.tsx
@@ -27,7 +27,8 @@ export default function VerificationScreen() {
   const unlocks = [
     'Post and reply on your center and event boards',
     'RSVP to events and see who else is going',
-    'Message other members',
+    // Messaging/DMs are deferred post-MSC (PRD §5.4) — don't promise them here.
+    'View member profiles across your community',
   ]
 
   return (


### PR DESCRIPTION
Found QA'ing the verification explainer (/verification).

"What verification unlocks" listed **"Message other members"** — but messaging/DMs are **deferred post-MSC** (PRD §5.4; Chat is cut from v2). A new member would verify expecting a feature that doesn't exist. Replaced with **"View member profiles across your community"** — accurate, since Verified users *can* view others' profiles (PRD §5.5).

Checked the rest of the app — no other user-facing copy promises messaging. Verified on the preview. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)