### PR TITLE
feat(settings): surface notification preferences (built but unwired)

### DIFF
--- a/packages/frontend/app/settings/_layout.tsx
+++ b/packages/frontend/app/settings/_layout.tsx
@@ -20,6 +20,7 @@ export default function SettingsLayout() {
       <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
         <Stack.Screen name="index" />
         <Stack.Screen name="invite" />
+        <Stack.Screen name="notifications" />
       </Stack>
     )
   }

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   AlertTriangle,
   UserPlus,
+  Bell,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { Avatar, Text, Section, StackHeader } from '../../components/ui'
@@ -169,6 +170,27 @@ export default function PreferencesNative() {
           </View>
         </Section>
         {/* Connect */}
+        <Section title="NOTIFICATIONS" titleColor={faintColor}>
+          <View
+            style={{
+              borderTopWidth: 1,
+              borderBottomWidth: 1,
+              borderColor,
+              marginHorizontal: -16,
+            }}
+          >
+            <MenuRow onPress={() => {
+              track('settings_notifications_pressed', { source: 'settings' })
+              router.push('/settings/notifications')
+            }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+                <Bell size={20} color={textColor} />
+                <Text style={{ fontSize: 15, color: textColor }}>Notification preferences</Text>
+              </View>
+            </MenuRow>
+          </View>
+        </Section>
+
         <Section title="CONNECT" titleColor={faintColor}>
           <View
             style={{

--- a/packages/frontend/app/settings/index.web.tsx
+++ b/packages/frontend/app/settings/index.web.tsx
@@ -10,7 +10,7 @@ import {
   useWindowDimensions,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { Eye, Shield, Info, ExternalLink, AlertTriangle, UserPlus, LogOut, ChevronRight, User } from 'lucide-react-native'
+import { Eye, Shield, Info, ExternalLink, AlertTriangle, UserPlus, LogOut, ChevronRight, User, Bell } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { useRouter } from 'expo-router'
 import { DestructiveButton, SecondaryButton, Text, Avatar } from '../../components/ui'
@@ -178,6 +178,36 @@ export default function Preferences() {
               <LogOut size={18} color="#DC2626" />
             </Pressable>
           </View>
+        </View>
+
+        {/* Notifications Section */}
+        <View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+            <Bell size={20} color={iconColor} />
+            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Notifications</Text>
+          </View>
+          <Pressable
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: isNarrowWeb ? 20 : 28,
+              backgroundColor: cardBg,
+              borderRadius: 20,
+              borderWidth: 1,
+              borderColor,
+            }}
+            onPress={() => {
+              track('settings_notifications_pressed', { source: 'settings_web' })
+              router.push('/settings/notifications')
+            }}
+          >
+            <View style={{ flex: 1, marginRight: 12 }}>
+              <Text style={{ fontSize: 15, color: textColor }}>Notification preferences</Text>
+              <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>Choose what you're notified about</Text>
+            </View>
+            <ChevronRight size={18} color={iconColor} />
+          </Pressable>
         </View>
 
         {/* Appearance Section */}

--- a/packages/frontend/app/settings/notifications.tsx
+++ b/packages/frontend/app/settings/notifications.tsx
@@ -1,0 +1,18 @@
+// /settings/notifications — manage notification preferences. Surfaces the
+// previously-orphaned NotificationPreferencesPanel (in-app + per-type toggles;
+// push/email are labelled "Coming Soon"). Reached from the Settings page.
+import React from 'react'
+import { View } from 'react-native'
+import { StackHeader } from '../../components/ui'
+import { NotificationPreferencesPanel } from '../../components/notifications/NotificationPreferencesPanel'
+import { useColors } from '../../hooks/useColors'
+
+export default function NotificationSettingsScreen() {
+  const c = useColors()
+  return (
+    <View style={{ flex: 1, backgroundColor: c.bg }}>
+      <StackHeader title="Notifications" />
+      <NotificationPreferencesPanel />
+    </View>
+  )
+}

--- a/packages/frontend/components/notifications/NotificationPreferencesPanel.tsx
+++ b/packages/frontend/components/notifications/NotificationPreferencesPanel.tsx
@@ -72,7 +72,7 @@ export const NotificationPreferencesPanel: React.FC = () => {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: c.card }} contentContainerStyle={{ padding: 16 }}>
+    <ScrollView style={{ flex: 1, backgroundColor: c.card }} contentContainerStyle={{ padding: 16, width: '100%', maxWidth: 680, alignSelf: 'center' }}>
       {/* Main Channels */}
       <View style={{ marginBottom: 24 }}>
         <Text style={{ fontSize: 16, fontWeight: '600', color: c.text, marginBottom: 12, paddingBottom: 8, borderBottomWidth: 1, borderBottomColor: c.border }}>


### PR DESCRIPTION
Found while QA'ing Settings/Notifications for the design pass.

`NotificationPreferencesPanel` was fully built and its backend (`GET/PUT /notifications/preferences`) works — but it was **referenced nowhere**, so users had no way to manage notifications. Wired it up:
- New `/settings/notifications` route rendering the panel (web + native).
- A **Notifications** section in the Settings page (web `index.web.tsx` + native `index.tsx`) → opens it.
- Panel content centered (maxWidth 680) on desktop, matching the other settings surfaces.

Push/email channels stay labelled **"Coming Soon"** and disabled (deferred); **In-App** + the per-type toggles (event reminders/created/cancelled/updated, attendee joined, center announcements) are live and persist via the existing endpoint.

Verified on the preview: the section shows in Settings and the panel loads + toggles. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)