### PR TITLE
fix: board image 404 + expanded-post image + dark-mode email

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2093,7 +2093,9 @@ app.post('/profile/uploadImage', authMiddleware, async (c) => {
     },
   })
 
-  const baseUrl = 'https://avatars.chinmayajanata.org/avatars'
+  // R2 custom domain is bound at the bucket root → public URL is domain + key
+  // (key already includes the avatars/ folder). No extra "/avatars" segment.
+  const baseUrl = 'https://avatars.chinmayajanata.org'
   const url = `${baseUrl}/${key}`
 
   // Update user profile with new image URL
@@ -2134,7 +2136,10 @@ app.post('/board/uploadImage', authMiddleware, async (c) => {
     customMetadata: { userId: user.id, originalFileName: file.name },
   })
 
-  const url = `https://avatars.chinmayajanata.org/avatars/${key}`
+  // The R2 custom domain is bound at the bucket root, so the public URL is
+  // domain + object key (the key already namespaces under boards/). A previous
+  // extra "/avatars" segment 404'd — board photos showed as a grey box.
+  const url = `https://avatars.chinmayajanata.org/${key}`
   return c.json({ message: 'Image uploaded', imageUrl: url })
 })
 

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { ActivityIndicator, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { ActivityIndicator, Image, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import {
   Building2,
   CalendarDays,
@@ -652,6 +652,14 @@ function OriginalPost({
         >
           {body}
         </Text>
+
+        {post.imageUrl ? (
+          <Image
+            source={{ uri: post.imageUrl }}
+            style={{ marginTop: 12, width: '100%', maxWidth: 420, height: 280, borderRadius: 16, backgroundColor: colors.surface }}
+            resizeMode="cover"
+          />
+        ) : null}
 
         <View
           style={{

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -162,7 +162,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
               {displayName}
             </Text>
             <Text
-              className="text-sm font-sans text-contentStrong dark:text-contentStrong-dark"
+              className="text-sm font-sans text-stone-500 dark:text-stone-400"
               numberOfLines={1}
               ellipsizeMode="tail"
             >


### PR DESCRIPTION
Three fixes from testing feedback:

**1. Uploaded post images showed as a grey box (404).** The R2 custom domain `avatars.chinmayajanata.org` is bound at the **bucket root**, but `/board/uploadImage` returned `domain + /avatars/ + key` — an extra path segment. Verified live against the preview bucket:
- `…/avatars/boards/<key>` → **404**
- `…/boards/<key>` → **200**

Now returns `domain + key`. The same latent bug existed in `/profile/uploadImage` (`/avatars/avatars/…`) — fixed too.

**2. Expanding a post hid its image.** `PostThread`'s `OriginalPost` rendered the body but never `post.imageUrl`. Now renders it (matching the feed card).

**3. Dark-mode email in the profile dropdown** was near-invisible (`text-contentStrong-dark`) → `text-stone-500/400`.

⚠️ Posts uploaded **before** this fix keep their old 404 URL (the broken path is stored on the row); re-posting produces a working image.

backend + frontend `tsc` clean. Needs deploy for the URL fix to take effect on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)