### PR TITLE
feat(ui): person-icon avatar fallback instead of "?" (#380)

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Tabs, useRouter } from 'expo-router'
-import { Platform, View, Text, Pressable, Image, StatusBar } from 'react-native'
+import { Platform, View, Text, Pressable, StatusBar } from 'react-native'
 import { useState, useEffect } from 'react'
 import { useUser, useTheme } from '../../components/contexts'
 import { Plus, User } from 'lucide-react-native'
@@ -80,14 +80,9 @@ export default function TabLayout() {
       )
     }
     if (Platform.OS === 'web') {
-      const webProfileImage = user?.profileImage
-      const getInitials = () => {
-        if (user?.firstName && user?.lastName)
-          return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
-        if (user?.firstName) return user.firstName[0].toUpperCase()
-        if (user?.username) return user.username[0].toUpperCase()
-        return '?'
-      }
+      const displayName = user?.firstName
+        ? `${user.firstName} ${user.lastName ?? ''}`.trim()
+        : user?.username
 
       return (
         <View className="flex-row items-center" style={{ gap: 8 }}>
@@ -119,31 +114,13 @@ export default function TabLayout() {
             </Pressable>
           )}
           <Pressable
-            className="mr-4 rounded-full overflow-hidden"
-            style={{ width: 36, height: 36 }}
+            className="mr-4"
             onPress={() => {
               posthog?.capture('nav_menu_opened')
               setSettingsVisible(true)
             }}
           >
-            {webProfileImage ? (
-              <Image source={{ uri: webProfileImage }} style={{ width: 36, height: 36 }} />
-            ) : (
-              <View
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: 18,
-                  backgroundColor: '#C2410C',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Text style={{ color: '#fff', fontSize: 14, fontWeight: '600' }}>
-                  {getInitials()}
-                </Text>
-              </View>
-            )}
+            <Avatar image={user?.profileImage ?? undefined} name={displayName} size={36} />
           </Pressable>
           <SettingsPanel
             visible={settingsVisible}

--- a/packages/frontend/components/ui/Avatar.tsx
+++ b/packages/frontend/components/ui/Avatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { View, Text, Image } from 'react-native'
+import { User } from 'lucide-react-native'
 
 interface AvatarProps {
   image?: string
@@ -13,16 +14,18 @@ interface AvatarProps {
 export default function Avatar({ image, initials, name, size = 40, style, backgroundColor }: AvatarProps) {
   const [imageError, setImageError] = React.useState(false)
 
-  const getInitials = () => {
+  // Returns initials text, or null when there is nothing usable (show icon instead).
+  const getInitials = (): string | null => {
     if (initials) return initials
-    if (name) {
-      const parts = name.split(' ')
+    const trimmed = name?.trim()
+    if (trimmed) {
+      const parts = trimmed.split(' ')
       if (parts.length >= 2) {
         return `${parts[0][0]}${parts[1][0]}`.toUpperCase()
       }
-      return name.slice(0, 2).toUpperCase()
+      return trimmed.slice(0, 2).toUpperCase()
     }
-    return '?'
+    return null
   }
 
   const fontSize = size * 0.4
@@ -54,6 +57,8 @@ export default function Avatar({ image, initials, name, size = 40, style, backgr
     )
   }
 
+  const text = getInitials()
+
   return (
     <View
       style={[
@@ -68,15 +73,19 @@ export default function Avatar({ image, initials, name, size = 40, style, backgr
         style,
       ]}
     >
-      <Text
-        style={{
-          color: 'white',
-          fontSize,
-          fontWeight: '600',
-        }}
-      >
-        {getInitials()}
-      </Text>
+      {text ? (
+        <Text
+          style={{
+            color: 'white',
+            fontSize,
+            fontWeight: '600',
+          }}
+        >
+          {text}
+        </Text>
+      ) : (
+        <User color="#FFFFFF" size={Math.round(size * 0.55)} />
+      )}
     </View>
   )
 }


### PR DESCRIPTION
## Summary

- Replaces the `'?'` text fallback in the shared `Avatar` component with a centered lucide `User` icon when there are no usable initials or name.
- Trims whitespace-only names so they are treated the same as no name.
- Replaces the WebHeader's inline avatar block with the shared `Avatar` component, removing the duplicate local `getInitials()` and the `webProfileImage` variable. One source of truth now.
- When logged out on web, the avatar area shows the person icon instead of `'?'`.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)