### PR TITLE
feat(settings): logged-out account menu is a login CTA + appearance only (#381)

### DIFF
--- a/packages/frontend/components/SettingsPanel.tsx
+++ b/packages/frontend/components/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import { router, usePathname } from 'expo-router'
 import ThemeSelector from './ThemeSelector'
 import { Avatar } from './ui'
 import { isSuperAdmin } from '../utils/admin'
+import { usePostHog } from 'posthog-react-native'
 
 function SettingsPanel({ visible, onClose, onLogout }) {
   const opacityAnim = useRef(new Animated.Value(0)).current
@@ -13,6 +14,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
   const { user } = useUser()
   const { preference: themePreference, setPreference: setThemePreference, isDark } = useTheme()
   const pathname = usePathname()
+  const posthog = usePostHog()
   const themeOptions = ['light', 'dark', 'system']
   const optionWidth = 70
   const indicatorPadding = 8
@@ -91,9 +93,10 @@ function SettingsPanel({ visible, onClose, onLogout }) {
 
   if (!visible) return null
 
-  const displayName =
-    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}` : user?.username || 'User'
-
+  // Logged-in state: compute display values only when user exists
+  const displayName = user
+    ? (user.firstName && user.lastName ? `${user.firstName} ${user.lastName}` : user.username || 'User')
+    : null
   const profileImage = user?.profileImage
   const getInitials = () => {
     if (user?.firstName && user?.lastName) return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
@@ -138,98 +141,143 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           transform: [{ translateY: translateYAnim }],
         }}
       >
-        {/* Profile Info */}
-        <View className="flex-row items-center mb-3">
-          <Avatar
-            image={profileImage || undefined}
-            name={displayName}
-            size={32}
-            style={{ marginRight: 12 }}
-          />
-          <View className="flex-col flex-1">
-            <Text className="text-lg font-inter-semibold text-content dark:text-content-dark -mb-0.5">
-              {displayName}
+        {!user ? (
+          // Logged-out state: login CTA + appearance only
+          <>
+            {/* Prompt */}
+            <Text className="text-sm font-inter text-content dark:text-content-dark mb-3">
+              Sign in to your account
             </Text>
-            <Text
-              className="text-sm font-inter text-contentStrong dark:text-contentStrong-dark"
-              numberOfLines={1}
-              ellipsizeMode="tail"
+
+            {/* Log In CTA */}
+            <Pressable
+              onPress={() => {
+                posthog?.capture('settings_panel_login_pressed', { source: 'settings_panel' })
+                onClose()
+                router.push(`/auth?returnTo=${encodeURIComponent(pathname)}`)
+              }}
+              style={{
+                backgroundColor: '#E8862A',
+                borderRadius: 10,
+                paddingVertical: 10,
+                alignItems: 'center',
+                marginBottom: 16,
+              }}
             >
-              {user?.username}
-            </Text>
-          </View>
-        </View>
+              <Text style={{ color: '#fff', fontFamily: 'Inter-SemiBold', fontSize: 15 }}>Log in</Text>
+            </Pressable>
 
-        {/* Separator Line */}
-        <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-3" />
+            {/* Separator Line */}
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-3" />
 
-        {/* Profile Button */}
-        <Pressable
-          className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings/profile' ? 'bg-primary' : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
-          }`}
-          onPress={() => {
-            onClose()
-            router.push('/settings/profile')
-          }}
-        >
-          <User size={16} color={pathname === '/settings/profile' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
-          <Text className={`font-inter ${
-            pathname === '/settings/profile' ? 'text-white font-inter-semibold' : 'text-content dark:text-content-dark'
-          }`}>Profile</Text>
-        </Pressable>
-        <Pressable
-          className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings/preferences' ? 'bg-primary' : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
-          }`}
-          onPress={() => {
-            onClose()
-            router.push('/settings/preferences')
-          }}
-        >
-          <Settings size={16} color={pathname === '/settings/preferences' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
-          <Text className={`font-inter ${
-            pathname === '/settings/preferences' ? 'text-white font-inter-semibold' : 'text-content dark:text-content-dark'
-          }`}>Preferences</Text>
-        </Pressable>
-        {isSuperAdmin(user) && (
-          <Pressable
-            className="flex-row items-center mb-2 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-800"
-            onPress={() => {
-              onClose()
-              router.push('/admin' as any)
-            }}
-          >
-            <Shield size={16} color="#E8862A" className="mr-3" />
-            <Text style={{ fontFamily: 'Inter-Regular', color: '#E8862A' }}>Admin Dashboard</Text>
-          </Pressable>
+            {/* Appearance Slider */}
+            <View className="mb-1">
+              <Text className="text-sm font-inter-medium text-content dark:text-content-dark mb-2">
+                Appearance
+              </Text>
+              <ThemeSelector
+                className="relative flex-row bg-gray-100 dark:bg-neutral-800 rounded-lg p-1"
+                style={{ width: 218 }}
+              />
+            </View>
+          </>
+        ) : (
+          // Logged-in state: full menu
+          <>
+            {/* Profile Info */}
+            <View className="flex-row items-center mb-3">
+              <Avatar
+                image={profileImage || undefined}
+                name={displayName!}
+                size={32}
+                style={{ marginRight: 12 }}
+              />
+              <View className="flex-col flex-1">
+                <Text className="text-lg font-inter-semibold text-content dark:text-content-dark -mb-0.5">
+                  {displayName}
+                </Text>
+                <Text
+                  className="text-sm font-inter text-contentStrong dark:text-contentStrong-dark"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {user.username}
+                </Text>
+              </View>
+            </View>
+
+            {/* Separator Line */}
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-3" />
+
+            {/* Profile Button */}
+            <Pressable
+              className={`flex-row items-center mb-2 p-2 rounded-lg ${
+                pathname === '/settings/profile' ? 'bg-primary' : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
+              }`}
+              onPress={() => {
+                onClose()
+                router.push('/settings/profile')
+              }}
+            >
+              <User size={16} color={pathname === '/settings/profile' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
+              <Text className={`font-inter ${
+                pathname === '/settings/profile' ? 'text-white font-inter-semibold' : 'text-content dark:text-content-dark'
+              }`}>Profile</Text>
+            </Pressable>
+            <Pressable
+              className={`flex-row items-center mb-2 p-2 rounded-lg ${
+                pathname === '/settings/preferences' ? 'bg-primary' : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
+              }`}
+              onPress={() => {
+                onClose()
+                router.push('/settings/preferences')
+              }}
+            >
+              <Settings size={16} color={pathname === '/settings/preferences' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
+              <Text className={`font-inter ${
+                pathname === '/settings/preferences' ? 'text-white font-inter-semibold' : 'text-content dark:text-content-dark'
+              }`}>Preferences</Text>
+            </Pressable>
+            {isSuperAdmin(user) && (
+              <Pressable
+                className="flex-row items-center mb-2 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-800"
+                onPress={() => {
+                  onClose()
+                  router.push('/admin' as any)
+                }}
+              >
+                <Shield size={16} color="#E8862A" className="mr-3" />
+                <Text style={{ fontFamily: 'Inter-Regular', color: '#E8862A' }}>Admin Dashboard</Text>
+              </Pressable>
+            )}
+
+            {/* Separator Line */}
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
+
+            {/* Appearance Slider */}
+            <View className="mb-3">
+              <Text className="text-sm font-inter-medium text-content dark:text-content-dark mb-2">
+                Appearance
+              </Text>
+              <ThemeSelector
+                className="relative flex-row bg-gray-100 dark:bg-neutral-800 rounded-lg p-1"
+                style={{ width: 218 }}
+              />
+            </View>
+
+            {/* Separator Line */}
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
+
+            {/* Log Out Button */}
+            <Pressable
+              onPress={onLogout}
+              className="flex-row items-center p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              <LogOut size={16} color={isDark ? '#ef4444' : '#dc2626'} className="mr-3" />
+              <Text className="text-red-600 dark:text-red-400 font-inter">Log Out</Text>
+            </Pressable>
+          </>
         )}
-
-        {/* Separator Line */}
-        <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
-
-        {/* Appearance Slider */}
-        <View className="mb-3">
-          <Text className="text-sm font-inter-medium text-content dark:text-content-dark mb-2">
-            Appearance
-          </Text>
-          <ThemeSelector
-            className="relative flex-row bg-gray-100 dark:bg-neutral-800 rounded-lg p-1"
-            style={{ width: 218 }}
-          />
-        </View>
-
-        {/* Separator Line */}
-        <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
-
-        {/* Log Out Button */}
-        <Pressable
-          onPress={onLogout}
-          className="flex-row items-center p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20"
-        >
-          <LogOut size={16} color={isDark ? '#ef4444' : '#dc2626'} className="mr-3" />
-          <Text className="text-red-600 dark:text-red-400 font-inter">Log Out</Text>
-        </Pressable>
       </Animated.View>
     </>
   )


### PR DESCRIPTION
## Summary

- When no user session exists, the settings panel now shows only: a short "Sign in to your account" prompt, a primary orange Log In CTA, a separator, and the Appearance toggle.
- Profile, Preferences, Admin Dashboard, and Log Out are hidden for logged-out users.
- Log In button fires a PostHog event (`settings_panel_login_pressed`), calls `onClose()`, then routes to `/auth?returnTo=<current-path>`.
- Logged-in path is unchanged.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)