### PR TITLE
fix: clean up the logged-out web header (#379/#380/#381)

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -3,7 +3,7 @@ import { Platform, View, Text, Pressable, Image, StatusBar, useWindowDimensions 
 import { useState, useEffect } from 'react'
 import { useUser, useTheme } from '../../components/contexts'
 import { HeaderActionProvider } from '../../components/contexts/HeaderActionContext'
-import { House, Newspaper, Compass, Bell } from 'lucide-react-native'
+import { House, Newspaper, Compass, Bell, User } from 'lucide-react-native'
 import SettingsPanel from '../../components/settings/SettingsPanel'
 import Logo from '../../components/ui/Logo'
 import TabHeader from '../../components/ui/TabHeader'
@@ -50,7 +50,7 @@ export default function TabLayout() {
         return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
       if (user?.firstName) return user.firstName[0].toUpperCase()
       if (user?.username) return user.username[0].toUpperCase()
-      return '?'
+      return ''
     }
 
     return (
@@ -151,9 +151,13 @@ export default function TabLayout() {
                   justifyContent: 'center',
                 }}
               >
-                <Text style={{ color: '#fff', fontSize: 14, fontWeight: '600' }}>
-                  {getInitials()}
-                </Text>
+                {getInitials() ? (
+                  <Text style={{ color: '#fff', fontSize: 14, fontWeight: '600' }}>
+                    {getInitials()}
+                  </Text>
+                ) : (
+                  <User size={18} color="#fff" strokeWidth={2} />
+                )}
               </View>
             )}
           </Pressable>

--- a/packages/frontend/components/landing/NavBar.tsx
+++ b/packages/frontend/components/landing/NavBar.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react'
 import { View, Text, Pressable, useWindowDimensions, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
 import { usePostHog } from 'posthog-react-native'
-import { User } from 'lucide-react-native'
 import Logo from '../ui/Logo'
+import { Avatar } from '../ui'
+import { useUser } from '../contexts'
 
 // Inject hamburger animation CSS (web only)
 if (Platform.OS === 'web' && typeof document !== 'undefined') {
@@ -26,6 +27,9 @@ const NAV_LINKS: string[] = []
 export function NavBar() {
   const router = useRouter()
   const posthog = usePostHog()
+  const { user } = useUser()
+  const displayName =
+    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}` : user?.firstName || user?.username || ''
   const { width } = useWindowDimensions()
   const isMobile = width < 768
   const isTablet = width >= 768 && width < 1024
@@ -76,24 +80,21 @@ export function NavBar() {
               </Pressable>
             ))}
 
-          <Pressable
-            accessibilityLabel="Sign in or sign up"
-            onPress={() => {
-              posthog?.capture('landing_signin_pressed', { source: 'navbar' })
-              router.push('/auth')
-            }}
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: 18,
-              borderWidth: 1,
-              borderColor: '#D6D3D1',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <User size={18} color="#1C1917" />
-          </Pressable>
+          {/* Landing is the logged-out experience (the "Start Exploring" CTA covers
+              sign-in), so show no avatar for guests. A signed-in visitor gets their
+              avatar, routing into the app. (#379) */}
+          {user ? (
+            <Pressable
+              accessibilityLabel="Open the app"
+              onPress={() => {
+                posthog?.capture('landing_avatar_pressed', { source: 'navbar' })
+                router.push('/')
+              }}
+              style={{ width: 36, height: 36, borderRadius: 18, overflow: 'hidden' }}
+            >
+              <Avatar image={user.profileImage || undefined} name={displayName} size={36} />
+            </Pressable>
+          ) : null}
 
         </View>
       </View>

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -149,6 +149,21 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           transform: [{ translateY: translateYAnim }],
         }}
       >
+        {/* Logged out: just a Log in CTA — none of the account items apply (#381). */}
+        {!user ? (
+          <Pressable
+            className="flex-row items-center justify-center mb-3 py-2.5 rounded-lg"
+            style={{ backgroundColor: '#E8862A' }}
+            onPress={() => {
+              track('nav_login_pressed', { source: 'settings_panel' })
+              onClose()
+              router.push('/auth')
+            }}
+          >
+            <Text className="font-sans text-white" style={{ fontWeight: '600' }}>Log in</Text>
+          </Pressable>
+        ) : (
+          <>
         {/* Profile Info */}
         <View className="flex-row items-center mb-3">
           <Avatar
@@ -245,6 +260,8 @@ function SettingsPanel({ visible, onClose, onLogout }) {
 
         {/* Separator Line */}
         <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
+          </>
+        )}
 
         {/* Appearance Slider */}
         <View className="mb-3">
@@ -257,20 +274,24 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           />
         </View>
 
-        {/* Separator Line */}
-        <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
+        {user && (
+          <>
+            {/* Separator Line */}
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2 mt-2" />
 
-        {/* Log Out Button */}
-        <Pressable
-          onPress={() => {
-            track('logout', { source: 'settings_panel' })
-            onLogout()
-          }}
-          className="flex-row items-center p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20"
-        >
-          <LogOut size={16} color={isDark ? '#ef4444' : '#dc2626'} className="mr-3" />
-          <Text className="text-red-600 dark:text-red-400 font-sans">Log Out</Text>
-        </Pressable>
+            {/* Log Out Button */}
+            <Pressable
+              onPress={() => {
+                track('logout', { source: 'settings_panel' })
+                onLogout()
+              }}
+              className="flex-row items-center p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              <LogOut size={16} color={isDark ? '#ef4444' : '#dc2626'} className="mr-3" />
+              <Text className="text-red-600 dark:text-red-400 font-sans">Log Out</Text>
+            </Pressable>
+          </>
+        )}
       </Animated.View>
     </>
   )

--- a/packages/frontend/components/ui/Avatar.tsx
+++ b/packages/frontend/components/ui/Avatar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Image, Text, View } from 'react-native'
+import { User } from 'lucide-react-native'
 
 interface AvatarProps {
   image?: string
@@ -15,6 +16,8 @@ export default function Avatar({ image, initials, name, size = 40, style, backgr
   const fontSize = size * 0.38
   const bgColor = backgroundColor || '#C2410C'
 
+  // Empty string (not "?") when there's nothing to show — the render falls back
+  // to a person icon instead (#380).
   const getInitials = () => {
     if (initials) return initials
     if (name) {
@@ -23,7 +26,7 @@ export default function Avatar({ image, initials, name, size = 40, style, backgr
         ? `${parts[0][0]}${parts[1][0]}`.toUpperCase()
         : name.slice(0, 2).toUpperCase()
     }
-    return '?'
+    return ''
   }
 
   if (image && !imageError) {
@@ -34,11 +37,16 @@ export default function Avatar({ image, initials, name, size = 40, style, backgr
     )
   }
 
+  const label = getInitials()
   return (
     <View style={[{ width: size, height: size, borderRadius: size / 2, backgroundColor: bgColor, alignItems: 'center', justifyContent: 'center' }, style]}>
-      <Text style={{ fontWeight: '600', fontSize, color: '#FFFFFF' }}>
-        {getInitials()}
-      </Text>
+      {label ? (
+        <Text style={{ fontWeight: '600', fontSize, color: '#FFFFFF' }}>
+          {label}
+        </Text>
+      ) : (
+        <User size={size * 0.5} color="#FFFFFF" strokeWidth={2} />
+      )}
     </View>
   )
 }


### PR DESCRIPTION
Three coupled frontend issues from testing, all about the logged-out web experience:

- **#380** — the app-header avatar showed a **"?"** fallback. Now renders a person icon (lucide `User`) when there's no image/name; the inline WebHeader fallback matches.
- **#381** — the header dropdown showed the full account menu (name, Profile, Preferences, Log Out) even when logged out. Now logged-out users see only a **"Log in" CTA + the appearance toggle**; logged-in keeps the full menu.
- **#379** — the **landing** NavBar showed a redundant person icon for guests (the 'Start Exploring' CTA already covers sign-in). Removed for logged-out; a signed-in visitor gets their avatar → app.

Verified on the preview (desktop): app header now shows a person icon (not ?), and the landing top-right is clean for guests. `tsc` clean.

Closes #379, #380, #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)