### PR TITLE
fix(boards/feed): fit post images in the card + lightbox on tap (#382)

### DIFF
--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar } from '../ui'
+import ImageLightbox from '../ui/ImageLightbox'
 import type { BoardMessage } from './__mocks__/mockData'
 
 export type ComposerState = 'open' | 'locked'
@@ -311,6 +312,7 @@ export function BoardPostCard({
   const accent = colors.accent ?? '#E8862A'
   const accentSoft = colors.accentSoft ?? '#FFF7ED'
   const isFeedCard = showSource || asCard
+  const [lightboxOpen, setLightboxOpen] = useState(false)
   const sourceIcon =
     message.sourceKind === 'event' ? (
       <CalendarDays size={11} color={accent} strokeWidth={2.4} />
@@ -443,11 +445,31 @@ export function BoardPostCard({
           </Text>
 
           {message.imageUrl ? (
-            <Image
-              source={{ uri: message.imageUrl }}
-              style={{ marginTop: 8, width: '100%', maxWidth: 360, height: 220, borderRadius: 16, backgroundColor: colors.iconBoxBg }}
-              resizeMode="cover"
-            />
+            <>
+              <View
+                style={{
+                  marginTop: 8,
+                  width: '100%',
+                  maxWidth: 480,
+                  borderRadius: 16,
+                  overflow: 'hidden',
+                  minWidth: 0,
+                }}
+              >
+                <Pressable onPress={() => setLightboxOpen(true)} accessibilityRole="button" accessibilityLabel="View image">
+                  <Image
+                    source={{ uri: message.imageUrl }}
+                    style={{ width: '100%', aspectRatio: 16 / 9, maxHeight: 360, backgroundColor: colors.iconBoxBg }}
+                    resizeMode="cover"
+                  />
+                </Pressable>
+              </View>
+              <ImageLightbox
+                visible={lightboxOpen}
+                imageUrl={message.imageUrl}
+                onClose={() => setLightboxOpen(false)}
+              />
+            </>
           ) : null}
 
           <View

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Image, Pressable, Text, View } from 'react-native'
 import { Building2, CalendarDays, MessageCircle } from 'lucide-react-native'
 import { Avatar } from '../ui'
+import ImageLightbox from '../ui/ImageLightbox'
 import type { AppColors } from '../../tokens'
 import type { FeedPost } from './types'
 
@@ -16,6 +17,7 @@ export function FeedPostCard({
 }) {
   const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
   const replies = post.replyCount ?? 2
+  const [lightboxOpen, setLightboxOpen] = useState(false)
 
   return (
     <Pressable
@@ -76,11 +78,31 @@ export function FeedPostCard({
           <Text style={{ fontSize: 14, lineHeight: 20, color: colors.text }}>{post.body}</Text>
 
           {post.imageUrl ? (
-            <Image
-              source={{ uri: post.imageUrl }}
-              style={{ marginTop: 8, width: '100%', height: 200, borderRadius: 14, backgroundColor: colors.panel }}
-              resizeMode="cover"
-            />
+            <>
+              <View
+                style={{
+                  marginTop: 8,
+                  width: '100%',
+                  maxWidth: 480,
+                  borderRadius: 14,
+                  overflow: 'hidden',
+                  minWidth: 0,
+                }}
+              >
+                <Pressable onPress={() => setLightboxOpen(true)} accessibilityRole="button" accessibilityLabel="View image">
+                  <Image
+                    source={{ uri: post.imageUrl }}
+                    style={{ width: '100%', aspectRatio: 16 / 9, maxHeight: 360, backgroundColor: colors.panel }}
+                    resizeMode="cover"
+                  />
+                </Pressable>
+              </View>
+              <ImageLightbox
+                visible={lightboxOpen}
+                imageUrl={post.imageUrl}
+                onClose={() => setLightboxOpen(false)}
+              />
+            </>
           ) : null}
 
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16, marginTop: 6 }}>

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -13,6 +13,7 @@ import {
   Trash2,
 } from 'lucide-react-native'
 import { Avatar } from '../ui'
+import ImageLightbox from '../ui/ImageLightbox'
 import { useUser } from '../contexts'
 import type { AppColors } from '../../tokens'
 import { boardPostToMessage, type BoardMessage } from '../boards'
@@ -463,6 +464,7 @@ function PostMessageBlock({
   original?: boolean
 }) {
   const reactions = message.reactions ?? []
+  const [lightboxOpen, setLightboxOpen] = useState(false)
 
   return (
     <View style={{ flexDirection: 'row', gap: original ? 12 : 10 }}>
@@ -513,6 +515,34 @@ function PostMessageBlock({
         >
           {message.body}
         </Text>
+
+        {message.imageUrl ? (
+          <>
+            <View
+              style={{
+                marginTop: 8,
+                width: '100%',
+                maxWidth: 480,
+                borderRadius: 14,
+                overflow: 'hidden',
+                minWidth: 0,
+              }}
+            >
+              <Pressable onPress={() => setLightboxOpen(true)} accessibilityRole="button" accessibilityLabel="View image">
+                <Image
+                  source={{ uri: message.imageUrl }}
+                  style={{ width: '100%', aspectRatio: 16 / 9, maxHeight: 360 }}
+                  resizeMode="cover"
+                />
+              </Pressable>
+            </View>
+            <ImageLightbox
+              visible={lightboxOpen}
+              imageUrl={message.imageUrl}
+              onClose={() => setLightboxOpen(false)}
+            />
+          </>
+        ) : null}
 
         {reactions.length > 0 ? (
           <View
@@ -598,6 +628,7 @@ function OriginalPost({
 }) {
   const { track } = useAnalytics()
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
   return (
     <View style={{ flexDirection: 'row', gap: 12 }}>
       <Avatar
@@ -654,11 +685,31 @@ function OriginalPost({
         </Text>
 
         {post.imageUrl ? (
-          <Image
-            source={{ uri: post.imageUrl }}
-            style={{ marginTop: 12, width: '100%', maxWidth: 420, height: 280, borderRadius: 16, backgroundColor: colors.surface }}
-            resizeMode="cover"
-          />
+          <>
+            <View
+              style={{
+                marginTop: 10,
+                width: '100%',
+                maxWidth: 480,
+                borderRadius: 16,
+                overflow: 'hidden',
+                minWidth: 0,
+              }}
+            >
+              <Pressable onPress={() => setLightboxOpen(true)} accessibilityRole="button" accessibilityLabel="View image">
+                <Image
+                  source={{ uri: post.imageUrl }}
+                  style={{ width: '100%', aspectRatio: 16 / 9, maxHeight: 360 }}
+                  resizeMode="cover"
+                />
+              </Pressable>
+            </View>
+            <ImageLightbox
+              visible={lightboxOpen}
+              imageUrl={post.imageUrl}
+              onClose={() => setLightboxOpen(false)}
+            />
+          </>
         ) : null}
 
         <View

--- a/packages/frontend/components/ui/ImageLightbox.tsx
+++ b/packages/frontend/components/ui/ImageLightbox.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react'
+import { Image, Modal, Platform, Pressable, useWindowDimensions, View } from 'react-native'
+import { X } from 'lucide-react-native'
+
+interface ImageLightboxProps {
+  visible: boolean
+  imageUrl: string | null
+  onClose: () => void
+}
+
+export default function ImageLightbox({ visible, imageUrl, onClose }: ImageLightboxProps) {
+  const { width, height } = useWindowDimensions()
+
+  // Web: dismiss on Escape key
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !visible) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [visible, onClose])
+
+  if (!visible || !imageUrl) return null
+
+  const content = (
+    <>
+      {/* Backdrop tap closes */}
+      <Pressable
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Close image"
+      />
+
+      {/* Tapping the image itself does NOT close the lightbox */}
+      <Pressable onPress={(e) => e.stopPropagation()} style={{ alignItems: 'center', justifyContent: 'center' }}>
+        <Image
+          source={{ uri: imageUrl }}
+          style={{ width: width * 0.9, height: height * 0.9 }}
+          resizeMode="contain"
+        />
+      </Pressable>
+
+      {/* Close button top-right */}
+      <Pressable
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Close"
+        style={{
+          position: 'absolute',
+          top: 16,
+          right: 16,
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          backgroundColor: 'rgba(0,0,0,0.6)',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <X size={20} color="#fff" />
+      </Pressable>
+    </>
+  )
+
+  // Web: fixed overlay at high z-index (no raw Modal, which doesn't work well on web)
+  if (Platform.OS === 'web') {
+    return (
+      <View
+        style={{
+          position: 'fixed' as any,
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.9)',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 9999,
+        }}
+      >
+        {content}
+      </View>
+    )
+  }
+
+  // Native: Modal handles Android back button via onRequestClose
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(0,0,0,0.9)',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        {content}
+      </View>
+    </Modal>
+  )
+}

--- a/packages/frontend/components/ui/index.ts
+++ b/packages/frontend/components/ui/index.ts
@@ -21,6 +21,7 @@ import Logo from './Logo'
 import UnderlineTabBar from './UnderlineTabBar'
 import Avatar from './Avatar'
 import AuthPromptModal from './AuthPromptModal'
+import ImageLightbox from './ImageLightbox'
 import CopyLinkButton from './CopyLinkButton'
 import TabHeader from './TabHeader'
 import StackHeader from './StackHeader'
@@ -45,6 +46,7 @@ export {
   UnderlineTabBar,
   Avatar,
   AuthPromptModal,
+  ImageLightbox,
   CopyLinkButton,
   TabHeader,
   StackHeader,


### PR DESCRIPTION
## Summary

- New `ImageLightbox` component (`components/ui/ImageLightbox.tsx`): cross-platform full-screen image viewer. Web uses a `position: fixed` overlay at `zIndex 9999` (matches `AuthPromptModal` pattern). Native uses RN `Modal` with `onRequestClose`. Dismisses on backdrop press, X button, and Escape key; tapping the image itself does not close it.
- **ThreadPanel / BoardPostCard**: replaced `maxWidth: 360, height: 220` fixed-size Image with a clipping wrapper (`overflow: hidden`, `borderRadius: 16`) + `aspectRatio: 16/9` + `maxHeight: 360` + tap-to-lightbox Pressable.
- **FeedPostCard**: replaced `width: '100%', height: 200` (no maxWidth, no clipping) with the same wrapper pattern.
- **PostThread — OriginalPost**: existing bare Image (no lightbox, no overflow clip) upgraded to wrapper + lightbox.
- **PostThread — PostMessageBlock**: reply messages had no image rendering at all; added the same wrapper + lightbox block.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)