### PR TITLE
feat(feed): post images fit the card + lightbox on tap (#382)

### DIFF
--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
-import { Avatar } from '../ui'
+import { Avatar, ImageLightbox } from '../ui'
 import type { BoardMessage } from './__mocks__/mockData'
 
 export type ComposerState = 'open' | 'locked'
@@ -310,6 +310,7 @@ export function BoardPostCard({
   const reactions = message.reactions ?? []
   const accent = colors.accent ?? '#E8862A'
   const accentSoft = colors.accentSoft ?? '#FFF7ED'
+  const [lightboxOpen, setLightboxOpen] = useState(false)
   const isFeedCard = showSource || asCard
   const sourceIcon =
     message.sourceKind === 'event' ? (
@@ -443,11 +444,17 @@ export function BoardPostCard({
           </Text>
 
           {message.imageUrl ? (
-            <Image
-              source={{ uri: message.imageUrl }}
-              style={{ marginTop: 8, width: '100%', maxWidth: 360, height: 220, borderRadius: 16, backgroundColor: colors.iconBoxBg }}
-              resizeMode="cover"
-            />
+            <>
+              <Pressable
+                onPress={() => setLightboxOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel="View image full screen"
+                style={{ marginTop: 8, width: '100%', maxWidth: 360, height: 220, borderRadius: 16, overflow: 'hidden', backgroundColor: colors.iconBoxBg }}
+              >
+                <Image source={{ uri: message.imageUrl }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+              </Pressable>
+              <ImageLightbox uri={message.imageUrl} visible={lightboxOpen} onClose={() => setLightboxOpen(false)} />
+            </>
           ) : null}
 
           <View

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Image, Pressable, Text, View } from 'react-native'
 import { Building2, CalendarDays, MessageCircle } from 'lucide-react-native'
-import { Avatar } from '../ui'
+import { Avatar, ImageLightbox } from '../ui'
 import type { AppColors } from '../../tokens'
 import type { FeedPost } from './types'
 
@@ -16,6 +16,7 @@ export function FeedPostCard({
 }) {
   const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
   const replies = post.replyCount ?? 2
+  const [lightboxOpen, setLightboxOpen] = useState(false)
 
   return (
     <Pressable
@@ -76,11 +77,17 @@ export function FeedPostCard({
           <Text style={{ fontSize: 14, lineHeight: 20, color: colors.text }}>{post.body}</Text>
 
           {post.imageUrl ? (
-            <Image
-              source={{ uri: post.imageUrl }}
-              style={{ marginTop: 8, width: '100%', height: 200, borderRadius: 14, backgroundColor: colors.panel }}
-              resizeMode="cover"
-            />
+            <>
+              <Pressable
+                onPress={() => setLightboxOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel="View image full screen"
+                style={{ marginTop: 8, width: '100%', height: 200, borderRadius: 14, overflow: 'hidden', backgroundColor: colors.panel }}
+              >
+                <Image source={{ uri: post.imageUrl }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+              </Pressable>
+              <ImageLightbox uri={post.imageUrl} visible={lightboxOpen} onClose={() => setLightboxOpen(false)} />
+            </>
           ) : null}
 
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16, marginTop: 6 }}>

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -12,7 +12,7 @@ import {
   SmilePlus,
   Trash2,
 } from 'lucide-react-native'
-import { Avatar } from '../ui'
+import { Avatar, ImageLightbox } from '../ui'
 import { useUser } from '../contexts'
 import type { AppColors } from '../../tokens'
 import { boardPostToMessage, type BoardMessage } from '../boards'
@@ -598,6 +598,7 @@ function OriginalPost({
 }) {
   const { track } = useAnalytics()
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
   return (
     <View style={{ flexDirection: 'row', gap: 12 }}>
       <Avatar
@@ -654,11 +655,17 @@ function OriginalPost({
         </Text>
 
         {post.imageUrl ? (
-          <Image
-            source={{ uri: post.imageUrl }}
-            style={{ marginTop: 12, width: '100%', maxWidth: 420, height: 280, borderRadius: 16, backgroundColor: colors.surface }}
-            resizeMode="cover"
-          />
+          <>
+            <Pressable
+              onPress={() => setLightboxOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="View image full screen"
+              style={{ marginTop: 12, width: '100%', maxWidth: 420, height: 280, borderRadius: 16, overflow: 'hidden', backgroundColor: colors.surface }}
+            >
+              <Image source={{ uri: post.imageUrl }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+            </Pressable>
+            <ImageLightbox uri={post.imageUrl} visible={lightboxOpen} onClose={() => setLightboxOpen(false)} />
+          </>
         ) : null}
 
         <View

--- a/packages/frontend/components/ui/ImageLightbox.tsx
+++ b/packages/frontend/components/ui/ImageLightbox.tsx
@@ -1,0 +1,41 @@
+// ImageLightbox — full-screen viewer for a single image (#382). RN Modal with a
+// dark backdrop; dismiss by tapping anywhere, the X button, or Escape (web).
+import React, { useEffect } from 'react'
+import { Modal, Pressable, Image, View, Platform } from 'react-native'
+import { X } from 'lucide-react-native'
+
+export function ImageLightbox({
+  uri,
+  visible,
+  onClose,
+}: {
+  uri: string
+  visible: boolean
+  onClose: () => void
+}) {
+  useEffect(() => {
+    if (!visible || Platform.OS !== 'web' || typeof window === 'undefined') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [visible, onClose])
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable
+        onPress={onClose}
+        accessibilityLabel="Close image"
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.92)', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Image source={{ uri }} style={{ width: '92%', height: '85%' }} resizeMode="contain" />
+        <View style={{ position: 'absolute', top: 0, right: 0 }} pointerEvents="box-none">
+          <Pressable onPress={onClose} accessibilityLabel="Close" hitSlop={12} style={{ padding: 20 }}>
+            <X size={28} color="#fff" />
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  )
+}

--- a/packages/frontend/components/ui/index.ts
+++ b/packages/frontend/components/ui/index.ts
@@ -10,6 +10,7 @@
 import PrimaryButton from './buttons/PrimaryButton'
 import AuthInput from './AuthInput'
 import SecondaryButton from './buttons/SecondaryButton'
+export { ImageLightbox } from './ImageLightbox'
 import GhostButton from './buttons/GhostButton'
 import IconButton from './buttons/IconButton'
 import DestructiveButton from './buttons/DestructiveButton'


### PR DESCRIPTION
Closes #382 (follow-up to the board-image fix).

- **Fit within card:** the image now sits in a Pressable with `overflow: hidden` + `width: '100%'`, so it respects the card padding and can't overflow.
- **Lightbox:** a new reusable `ImageLightbox` (RN `Modal`, dark backdrop, dismiss on tap / X button / **Escape** on web — no new dependency). Tapping a post image opens it full-screen (`resizeMode: contain`).
- Wired into all three image surfaces: board post card (`ThreadPanel`), expanded thread (`PostThread` — which now renders the image since #377), and `FeedPostCard`.

`tsc` clean. (The note in the issue about PostThread not rendering the image is already resolved by #377.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)