### PR TITLE
chore(seed): seed one board post with a photo

### DIFF
--- a/scripts/ci/seed-preview-roles.sh
+++ b/scripts/ci/seed-preview-roles.sh
@@ -45,6 +45,11 @@ if [ -n "$MT" ]; then
   curl -fsS -X POST "$API/boards/center/$CENTER/posts" -H "Authorization: Bearer $MT" \
     -H 'Content-Type: application/json' \
     -d '{"body":"Anyone driving up from the South Bay on Aug 1? 🚗"}' >/dev/null 2>&1 || true
+  # One post with a photo so the board/feed image rendering is visible out of the
+  # box (and guards the image-URL fix). Unsplash CDN, same source as the event seed.
+  curl -fsS -X POST "$API/boards/center/$CENTER/posts" -H "Authorization: Bearer $MT" \
+    -H 'Content-Type: application/json' \
+    -d '{"body":"Beautiful turnout at last week'"'"'s satsang 🪔 grateful for this sangha.","imageUrl":"https://images.unsplash.com/photo-1511795409834-ef04bbd61622?w=800&q=80"}' >/dev/null 2>&1 || true
 fi
 # Populate the moderation queue so admin/sevak have something to action.
 if [ -n "$PID" ] && [ -n "$UT" ]; then


### PR DESCRIPTION
The preview's seeded board content had no image posts, so testers never saw the board/feed image rendering (just fixed in #377) out of the box. This seeds one center post with a known-good Unsplash photo — showcases the feature for beta testers and acts as a live regression guard for the image-URL fix.

Seed-script only (no app code). Best-effort like the other seed posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)