### PR TITLE
chore(release): v0.3.0 + EAS TestFlight setup

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -7,3 +7,5 @@ expo-env.d.ts
 
 # Build output
 dist/
+# Local-only release helper (references ASC key outside the repo)
+*.local.sh

--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
     "name": "Janata",
-    "slug": "janata",
-    "version": "0.2.0",
+    "slug": "chinmaya-janata",
+    "version": "0.3.0",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "janata",

--- a/packages/frontend/eas.json
+++ b/packages/frontend/eas.json
@@ -43,7 +43,10 @@
     "production": {
       "ios": {
         "appleId": "kishparikh18@gmail.com",
-        "ascAppId": "6761746513"
+        "ascAppId": "6761746513",
+        "ascApiKeyPath": "$EXPO_ASC_API_KEY_PATH",
+        "ascApiKeyId": "9LGHH7UKJV",
+        "ascApiKeyIssuerId": "1027ee60-03e2-42ff-8b82-c10d9870cc90"
       }
     }
   }

--- a/packages/frontend/eas.json
+++ b/packages/frontend/eas.json
@@ -34,7 +34,8 @@
         "resourceClass": "m-medium"
       },
       "env": {
-        "EXPO_NO_TELEMETRY": "1"
+        "EXPO_NO_TELEMETRY": "1",
+        "EXPO_PUBLIC_POSTHOG_KEY": "phc_5o67MgFjj113GN0QKduyyIs0BmEQkpWc8D2eDi6ju7Q"
       }
     }
   },


### PR DESCRIPTION
Release prep so we can ship a v0.3.0 build to TestFlight off v2. No app code changes, config only.

## What's here
- **Version 0.2.0 to 0.3.0** for the next TestFlight iteration.
- **Slug reverted to `chinmaya-janata`.** The v2 rebrand had set it to `janata`, which mismatches the registered Expo project and made every `eas` command error out. Slug is an internal Expo id only, so this does not touch the App Store app, bundle id, or the "Janata" display name.
- **App Store Connect API key wired into `eas.json`** (submit profile) so EAS can authenticate to Apple non-interactively. This is what fixes the build failure where the provisioning profile was missing the Associated Domains capability (our universal links). Key ID and Issuer ID are non-secret identifiers; the `.p8` lives outside the repo and is referenced via env var.
- **PostHog key added to the production build env** so analytics work in the cloud build (the local `.env` is gitignored and never reaches EAS). It is a publishable client key, so safe to commit.

## How to build + submit
A local, gitignored helper sets the three env vars EAS needs and runs the build:
`cd packages/frontend && ./scripts/testflight.local.sh all`

## Still manual
Reviewing the finished build and assigning it to a TestFlight tester group in App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)