### PR TITLE
fix(seed): demo users + board content on a real center (Vrindavan)

### DIFF
--- a/scripts/ci/seed-preview-roles.sh
+++ b/scripts/ci/seed-preview-roles.sh
@@ -7,7 +7,11 @@
 set -uo pipefail
 
 API="$1"; DB="$2"; CONFIG="$3"; PW="$4"
-CENTER="c1000001-0000-0000-0000-000000000001"   # Chinmaya Mission Boston (seeded)
+# Real seeded center (matches the official Chinmaya center list, c0000001- prefix).
+# Chinmaya Vrindavan also has seeded events, so the demo users' home center shows
+# both a populated board AND upcoming events. The old c1000001- Boston id was
+# orphaned by the center-list id-prefix change, so all board seeding 404'd.
+CENTER="c0000001-0000-0000-0000-000000000081"   # Chinmaya Vrindavan (real, has events)
 
 reg() {
   curl -fsS -X POST "$API/auth/register" -H 'Content-Type: application/json' \
@@ -40,7 +44,7 @@ PID=""
 if [ -n "$MT" ]; then
   RESP="$(curl -fsS -X POST "$API/boards/center/$CENTER/posts" -H "Authorization: Bearer $MT" \
     -H 'Content-Type: application/json' \
-    -d '{"body":"Welcome to the Boston CHYK board! 🙏 Carpools for MSC are forming here."}' 2>/dev/null || true)"
+    -d '{"body":"Welcome to the Chinmaya Vrindavan board! 🙏 Carpools for MSC are forming here."}' 2>/dev/null || true)"
   PID="$(echo "$RESP" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("post",{}).get("id",""))' 2>/dev/null || true)"
   curl -fsS -X POST "$API/boards/center/$CENTER/posts" -H "Authorization: Bearer $MT" \
     -H 'Content-Type: application/json' \


### PR DESCRIPTION
While verifying the board-image fix I found the preview's **entire sample social layer was empty** — testers saw no board posts, no feed content, and demo users had a broken home center.

**Root cause:** the seed used `center_id='c1000001-…001'` (Chinmaya Mission Boston), but that id was **orphaned** when the official Chinmaya center list landed (centers are now `c0000001-…`). So:
- Every demo user had a **dangling `center_id`** → broken 'your center' on Home/Profile, empty Feed.
- All sample board posts **404'd** ('Center not found'), so the board/feed/moderation-queue seed silently did nothing.

**Fix:** repoint to `c0000001-…081` = **Chinmaya Vrindavan**, a real seeded center that also has 2 seeded events. Board access requires `user.center_id === centerId` (verified in code), so demo users can now post to + read their board, and their home center shows **events + posts** out of the box (including the sample photo post for the image feature).

Seed-script only. Verified the target center exists + has events via the live preview API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)