### PR TITLE
fix(boards): composer uses the real user avatar (not hardcoded 'YO')

### DIFF
--- a/packages/frontend/components/boards/CreatePostSheet.tsx
+++ b/packages/frontend/components/boards/CreatePostSheet.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { ActivityIndicator, Image, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, ChevronDown, ImagePlus, X } from 'lucide-react-native'
 import { Avatar } from '../ui'
+import { useUser } from '../contexts'
 import type { AppColors } from '../../tokens'
 import { useAnalytics } from '../../utils/analytics'
 import { uploadBoardImage } from '../../utils/api'
@@ -32,6 +33,10 @@ export function CreatePostSheet({
   onSubmit?: (group: GroupOption, body: string, imageUrl?: string | null) => Promise<void> | void
 }) {
   const { track } = useAnalytics()
+  const { user } = useUser()
+  const composerName =
+    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
   const [body, setBody] = useState('')
   const [groupId, setGroupId] = useState<string | undefined>()
   const [groupPickerOpen, setGroupPickerOpen] = useState(false)
@@ -208,7 +213,7 @@ export function CreatePostSheet({
 
           {/* Composer */}
           <View style={{ flexDirection: 'row', gap: 12, marginTop: 4 }}>
-            <Avatar name="You" initials="YO" size={38} backgroundColor={colors.accent} />
+            <Avatar image={user?.profileImage || undefined} name={composerName} size={38} backgroundColor={colors.accent} />
             <TextInput
               autoFocus
               multiline

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar, ImageLightbox } from '../ui'
+import { useUser } from '../contexts'
 import type { BoardMessage } from './__mocks__/mockData'
 
 export type ComposerState = 'open' | 'locked'
@@ -137,6 +138,10 @@ function BoardComposer({
   visibleLabel?: string
   onSubmit?: (body: string) => Promise<void> | void
 }) {
+  const { user } = useUser()
+  const composerName =
+    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
   const [body, setBody] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -175,7 +180,7 @@ function BoardComposer({
         }}
       >
         <View style={{ alignSelf: 'flex-start' }}>
-          <Avatar name="You" initials="YO" size={36} backgroundColor="#0478A5" />
+          <Avatar image={user?.profileImage || undefined} name={composerName} size={36} backgroundColor={accent} />
         </View>
         <TextInput
           editable={!!onSubmit && !submitting}


### PR DESCRIPTION
QA finding: both board composers — the inline 'Write to the board…' (ThreadPanel, used on center detail + feed) and the 'New post' sheet (CreatePostSheet) — rendered a hardcoded `name="You" initials="YO"` avatar, inconsistent with the user's real initials/photo shown elsewhere.

Now both pull the signed-in user's name + `profileImage` (the `Avatar` component derives initials from the name). Verified live on the center board composer (shows 'MD' for Member Demo, no more 'YO'). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)