### PR TITLE
feat(native): guest browsing on iOS (web-parity)

### DIFF
--- a/packages/frontend/app/(tabs)/_layout.tsx
+++ b/packages/frontend/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs, usePathname, useRouter } from 'expo-router'
 import { Platform, View, Text, Pressable, Image, StatusBar, useWindowDimensions } from 'react-native'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useUser, useTheme } from '../../components/contexts'
 import { HeaderActionProvider } from '../../components/contexts/HeaderActionContext'
 import { House, Newspaper, Compass, Bell, User } from 'lucide-react-native'
@@ -12,19 +12,13 @@ import { useAnalytics } from '../../utils/analytics'
 export default function TabLayout() {
   const router = useRouter()
   const pathname = usePathname()
-  const { user, loading, logout } = useUser()
+  const { user, logout } = useUser()
   const { isDark } = useTheme()
   const [settingsVisible, setSettingsVisible] = useState(false)
   const { track } = useAnalytics()
   const tabBarShowLabel = Platform.OS === 'web'
   const { width } = useWindowDimensions()
   const isDesktopWeb = Platform.OS === 'web' && width >= 768
-
-  useEffect(() => {
-    if (Platform.OS !== 'web' && !loading && !user) {
-      router.replace('/auth')
-    }
-  }, [user, loading])
 
   const handleLogout = async () => {
     track('nav_logout')

--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { Text } from '../../components/ui'
+import { SignInCallout } from '../../components/boards/SignInCallout'
 import { useAnalytics } from '../../utils/analytics'
 import { LIGHT, DARK } from '../../tokens/colors'
 import { extractCityState } from '../../utils/addressParsing'
@@ -29,7 +30,7 @@ function datePill(dateStr?: string | null): { m: string; d: string } {
 
 export default function Profile() {
   const router = useRouter()
-  const { user } = useUser()
+  const { user, loading } = useUser()
   const { isDark } = useTheme()
   const c = isDark ? DARK : LIGHT
   const { track } = useAnalytics()
@@ -99,6 +100,29 @@ export default function Profile() {
   const SectionLabel = ({ children }: { children: string }) => (
     <Text style={{ fontSize: 12.5, fontWeight: '600', color: c.textMuted, letterSpacing: 0.5, textTransform: 'uppercase', marginBottom: 12, marginTop: 24, marginLeft: 2 }}>{children}</Text>
   )
+
+  // Guest state: a logged-out visitor can browse the read-only tabs, but the
+  // "You" tab has no profile to show — invite them to sign in instead. Returns
+  // early so none of the user.* access below runs for a guest.
+  if (!user && !loading) {
+    return (
+      <ScrollView
+        style={{ flex: 1, backgroundColor: c.bg }}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 18, paddingBottom: 48 }}
+      >
+        <SignInCallout
+          title="Sign in to Janata"
+          subtitle="Sign in to set up your profile, RSVP to events, and join your boards."
+          colors={c}
+          ctaLabel="Sign in"
+          onPress={() => {
+            track('profile_signin_pressed', { source: 'profile_guest' })
+            router.push('/auth')
+          }}
+        />
+      </ScrollView>
+    )
+  }
 
   return (
     <ScrollView

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -98,7 +98,7 @@ export default function AuthScreen() {
       const result = await login(username, password)
       if (result.success) {
         track('login_success', { source: 'auth' })
-        router.replace('/(tabs)')
+        router.replace(params.returnTo ? (params.returnTo as never) : '/(tabs)')
       } else {
         track('login_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Username or password is incorrect.' })

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
 } from 'react-native'
 import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Code, ArrowLeft } from 'lucide-react-native'
 import { useAnalytics } from '../utils/analytics'
 import { AuthInput, Logo, PrimaryButton } from '../components/ui'
@@ -29,6 +30,7 @@ type AuthStep = 'initial' | 'login' | 'invite-code' | 'signup'
 
 export default function AuthScreen() {
   const router = useRouter()
+  const insets = useSafeAreaInsets()
   const { isDark } = useTheme()
   const { checkUserExists, login, signup, loading } = useUser()
   const { track } = useAnalytics()
@@ -238,6 +240,20 @@ export default function AuthScreen() {
         className="flex-1 bg-[#FAFAF7] dark:bg-background-dark"
         keyboardShouldPersistTaps="handled"
       >
+        {/* Discover link, top-right, initial step only. Lets a logged-out
+            user browse the app before signing up (mirrors the web version). */}
+        {authStep === 'initial' && (
+          <Pressable
+            onPress={() => { track('auth_discover_pressed', { source: 'auth' }); router.push('/(tabs)') }}
+            className="absolute right-5"
+            style={{ top: insets.top + 12, paddingHorizontal: 4, paddingVertical: 8 }}
+          >
+            <Text className="font-sans" style={{ fontSize: 14.5, fontWeight: '500', color: '#C2410C' }}>
+              Discover →
+            </Text>
+          </Pressable>
+        )}
+
         {/* Main content */}
         <View
           className="flex-1 justify-center items-center w-full px-6"

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -25,6 +25,7 @@ import { createBoardPost, removeEvent } from '../../utils/api'
 import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
+import AuthPromptModal from '../../components/ui/AuthPromptModal'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
@@ -588,6 +589,7 @@ export default function EventDetailPage() {
   const appColors = useColors()
   const hasTrackedView = useRef(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
+  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
 
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
   const canEdit = isAdmin || isCreator
@@ -633,7 +635,13 @@ export default function EventDetailPage() {
   }
 
   const handleToggleRegistration = async () => {
-    if (!user?.username) return
+    // Guest taps RSVP → prompt to sign in (mirrors the web event detail).
+    if (!user) {
+      track('event_auth_prompt_shown', { eventId: id, source: 'event_detail' })
+      setShowAuthPrompt(true)
+      return
+    }
+    if (!user.username) return
     try {
       track(event?.isRegistered ? 'event_unregistered' : 'event_registered', { eventId: id, source: 'event_detail' })
       await toggleRegistration(user.username)
@@ -840,6 +848,13 @@ export default function EventDetailPage() {
         allowJanataSignup={event.allowJanataSignup}
         onExternalSignup={() => track('event_external_signup_pressed', { eventId: id, signupUrl: event.signupUrl, source: 'event_detail' })}
         colors={colors}
+      />
+
+      <AuthPromptModal
+        visible={showAuthPrompt}
+        onClose={() => setShowAuthPrompt(false)}
+        returnTo={`/events/${id}`}
+        eventTitle={event?.title}
       />
     </SafeAreaView>
   )

--- a/packages/frontend/app/events/form.tsx
+++ b/packages/frontend/app/events/form.tsx
@@ -14,6 +14,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, ChevronDown } from 'lucide-react-native'
 import DateTimePicker from '@react-native-community/datetimepicker'
 import { useAnalytics } from '../../utils/analytics'
+import { useUser } from '../../components/contexts'
 import { PrimaryButton } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import {
@@ -163,7 +164,13 @@ export default function EventFormPage() {
   const router = useRouter()
   const colors = useDetailColors()
   const { track } = useAnalytics()
+  const { user, loading: userLoading } = useUser()
   const today = todayLocalISODate()
+
+  // Creating/editing an event is members-only — bounce guests to sign-in.
+  useEffect(() => {
+    if (Platform.OS !== 'web' && !userLoading && !user) router.replace('/auth')
+  }, [user, userLoading])
 
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)

--- a/packages/frontend/app/notifications.tsx
+++ b/packages/frontend/app/notifications.tsx
@@ -1,14 +1,21 @@
-import React from 'react'
-import { View } from 'react-native'
+import React, { useEffect } from 'react'
+import { View, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
 import StackHeader from '../components/ui/StackHeader'
 import { NotificationCenter } from '../components/notifications/NotificationCenter'
 import { useColors } from '../hooks/useColors'
+import { useUser } from '../components/contexts'
 import type { Notification } from '../utils/notificationService'
 
 export default function NotificationsScreen() {
   const c = useColors()
   const router = useRouter()
+  const { user, loading } = useUser()
+
+  // Account-only screen — bounce guests to sign-in.
+  useEffect(() => {
+    if (Platform.OS !== 'web' && !loading && !user) router.replace('/auth')
+  }, [user, loading])
 
   const handleNotificationPress = (notification: Notification) => {
     // Deep-link to the related resource when the notification carries one.

--- a/packages/frontend/app/notifications.tsx
+++ b/packages/frontend/app/notifications.tsx
@@ -24,6 +24,12 @@ export default function NotificationsScreen() {
     }
   }
 
+  // Guests get redirected by the effect above; render nothing in the meantime so
+  // NotificationCenter doesn't mount and fire an unauthenticated request.
+  if (Platform.OS !== 'web' && !user) {
+    return <View style={{ flex: 1, backgroundColor: c.bg }} />
+  }
+
   return (
     <View style={{ flex: 1, backgroundColor: c.bg }}>
       <StackHeader title="Notifications" />

--- a/packages/frontend/app/onboarding.tsx
+++ b/packages/frontend/app/onboarding.tsx
@@ -1,6 +1,7 @@
-import { View, Text, Animated } from 'react-native'
+import { View, Text, Animated, Platform } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { OnboardingProvider, useOnboarding } from '../components/contexts'
+import { useRouter } from 'expo-router'
+import { OnboardingProvider, useOnboarding, useUser } from '../components/contexts'
 import { useEffect, useRef } from 'react'
 import { Step1, Step2, Step3, Step4, Complete } from '../components/onboarding'
 
@@ -63,6 +64,14 @@ const OnboardingContent = () => {
 }
 
 export default function Onboarding() {
+  const router = useRouter()
+  const { user, loading } = useUser()
+
+  // Onboarding requires an account — bounce guests to sign-in.
+  useEffect(() => {
+    if (Platform.OS !== 'web' && !loading && !user) router.replace('/auth')
+  }, [user, loading])
+
   return (
     <OnboardingProvider>
       <SafeAreaView className="flex-1 bg-white dark:bg-neutral-900">

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { View, Pressable, ScrollView, Modal, Alert } from 'react-native'
+import React, { useState, useEffect } from 'react'
+import { View, Pressable, ScrollView, Modal, Alert, Platform } from 'react-native'
 import { useRouter } from 'expo-router'
 import {
   Shield,
@@ -21,7 +21,13 @@ const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
 
 export default function PreferencesNative() {
   const router = useRouter()
-  const { user, logout } = useUser()
+  const { user, loading, logout } = useUser()
+
+  // Account-only screen — bounce guests to sign-in (a deep link / returnTo
+  // could otherwise land a logged-out visitor here).
+  useEffect(() => {
+    if (Platform.OS !== 'web' && !loading && !user) router.replace('/auth')
+  }, [user, loading])
   const { isDark } = useTheme()
   const { deleteAccount } = useUser()
   const { track } = useAnalytics()

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -149,6 +149,7 @@ export function PostThread({
   }
 
   const handleReact = async (emoji: string) => {
+    if (!user) return
     const prev = reactions
     setReactions(applyOptimisticReaction(prev, emoji))
     track('feed_post_reacted', { post_id: post.postId, emoji, source: 'post_thread' })
@@ -200,6 +201,7 @@ export function PostThread({
   }, [post.postId])
 
   const handleSend = async () => {
+    if (!user) return
     const body = draft.trim()
     if (!body || sending) return
     const tempId = `temp-${Date.now()}`


### PR DESCRIPTION
## Why
On the website a logged-out person can browse Explore, Feed, events, and centers before making an account, with write actions prompting sign-in. On iOS none of that worked: `app/(tabs)/_layout.tsx` redirected every logged-out user to `/auth` the moment they touched a tab, so the app was unreachable without an account. This opens guest browsing on native to match web. It also unblocks the auth-screen Discover link (which previously boomeranged straight back to login — caught by codex).

## What
- **Relax the native tab guard** — remove the blanket logged-out redirect so guests render the read-only tabs (Home/Explore/Feed/Connect). Every per-board write gate (`canAccessBoards = !!user`, etc.) stays intact.
- **Profile/"You" tab** shows a sign-in callout for guests instead of a profile.
- **Account-only routes guarded directly** — settings, notifications, onboarding, event-create now redirect guests to `/auth` (they were only protected by the blanket guard).
- **Event RSVP** opens `AuthPromptModal` for guests (parity with web) instead of silently doing nothing.
- **Defensive `!user` guards** in board write handlers (`PostThread`).
- **Auth welcome screen** gets a top-right `Discover →` link into the app.
- **Two codex P2 fixes:** login now honors `returnTo` (RSVP → sign in → back to the event), and notifications doesn't mount an unauthenticated request for guests.

## Review
- codex review: GATE PASS (no P1; 2 P2 found and fixed).
- Typecheck: no new errors in touched files.
- **Device QA pending** — guest browse flow should be exercised on the simulator before merge (open logged out: lands on Home, no UP NEXT yet until PR2, tabs show no profile content for guest, Explore/Feed/event/center render, RSVP prompts sign-in, Discover link lands on Home).

## Staging
This is the foundation. Follow-ups: **PR2** home not-verified treatment (hide UP NEXT / COMING UP, show Explore + sign-in CTA), and a separate small **profile cleanup** PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)