### PR TITLE
feat(home): strip personalized lists for guests + unverified

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -155,6 +155,9 @@ export default function HomeScreen() {
   // still renders below, so Home leads with useful content rather than a
   // redundant feature tour. Self-resolves once they RSVP.
   const isNewUser = !!user && signedUpEvents.length === 0
+  // A signed-in, verified member (vl >= 45). Guests and unverified users get the
+  // stripped home: Explore + sign-in nudge, no personalized event/board lists.
+  const isVerifiedMember = !!user && vl >= 45
 
   if (discoverLoading || (user ? myEventsLoading : false)) {
     return (
@@ -213,7 +216,7 @@ export default function HomeScreen() {
     </Pressable>
   ) : null
 
-  const welcomeBanner = isNewUser ? (
+  const welcomeBanner = !isVerifiedMember || isNewUser ? (
     <WelcomeBanner
       c={c}
       onExplore={() => {
@@ -248,7 +251,7 @@ export default function HomeScreen() {
     />
   ) : null
 
-  const upNextSection = !isNewUser || featured ? (
+  const upNextSection = isVerifiedMember && (!isNewUser || featured) ? (
     <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => {
       track('home_see_all_pressed', { section: 'up_next' })
       router.push('/explore' as never)
@@ -286,7 +289,7 @@ export default function HomeScreen() {
   // Boards peek (#199): the 1-2 latest posts from the user's center board.
   // New users get their center + a feed peek inside the first-run overview,
   // so this section is for returning members only.
-  const boardsSection = user && !isNewUser ? (
+  const boardsSection = isVerifiedMember && !isNewUser ? (
     <SectionHeader
       eyebrow="LATEST ON YOUR BOARDS"
       trailing="Open Feed"
@@ -325,7 +328,7 @@ export default function HomeScreen() {
     </SectionHeader>
   ) : null
 
-  const weekSection = !isNewUser || weekItems.length > 0 ? (
+  const weekSection = isVerifiedMember && (!isNewUser || weekItems.length > 0) ? (
     <SectionHeader
       eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
       trailing="See all"

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -226,7 +226,9 @@ export default function HomeScreen() {
     />
   ) : null
 
-  const firstRunOverview = isNewUser ? (
+  // Only a verified new member gets the first-run overview; it can surface the
+  // user's center + board peek, which the not-verified home must not show.
+  const firstRunOverview = isNewUser && isVerifiedMember ? (
     <FirstRunOverview
       c={c}
       detailColors={detailColors}


### PR DESCRIPTION
Stacked on #396 (native guest mode). Merge #396 first, or retarget this to v2 after.

## Why
When a viewer isn't a verified member (logged out, or signed in with `verificationLevel < 45`), the home screen was still showing UP NEXT FOR YOU and COMING UP — personalized event lists that don't belong to them. This strips the home for that audience and points them at Explore.

## What (`app/(tabs)/index.tsx`)
- `isVerifiedMember = !!user && vl >= 45`.
- UP NEXT FOR YOU, COMING UP, boards peek, and the first-run overview render only for verified members.
- The Explore welcome card shows for not-verified viewers.
- The sign-in CTA still shows only when logged out.
- Verified members: unchanged.

## Review
- codex review: 1 P1 found and fixed (first-run overview was still leaking the user's center + board peek to unverified users) → GATE PASS.
- Typecheck clean.
- **Device QA pending** (verified together with the rest of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)