### PR TITLE
feat(profile): iOS cleanup (drop Account & Settings row, hide handle, add Invite Friends)

### DIFF
--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -7,7 +7,7 @@ import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share } from 'react-native'
 import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  Pencil, Share2, ChevronRight, BadgeCheck, MapPin,
+  Pencil, Share2, ChevronRight, BadgeCheck, MapPin, UserPlus,
   Megaphone, CalendarDays, Building2,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
@@ -84,7 +84,7 @@ export default function Profile() {
       track('profile_shared', { source: 'profile', username: user?.username })
     } catch { /* dismissed */ }
   }
-  const onSettings = () => { track('nav_settings_opened', { source: 'profile', destination: 'preferences' }); router.push('/settings') }
+  const onInvite = () => { track('settings_invite_pressed', { source: 'profile' }); router.push('/settings/invite') }
   const onExplore = () => { track('profile_explore_cta', { source: 'profile' }); router.push('/explore') }
 
   const card = { backgroundColor: c.card, borderWidth: 1, borderColor: c.border, borderRadius: 20 } as const
@@ -140,7 +140,6 @@ export default function Profile() {
             </View>
           )}
           <Text style={{ fontSize: 21, fontWeight: '700', color: c.text, marginTop: 14, textAlign: 'center' }}>{displayName}</Text>
-          {user?.username ? <Text style={{ fontSize: 14, color: c.textMuted, marginTop: 1 }}>@{user.username}</Text> : null}
           {roleLabel ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10, backgroundColor: c.accentSoft, paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999 }}>
               <BadgeCheck size={14} color="#C2410C" />
@@ -185,10 +184,13 @@ export default function Profile() {
         ) : null}
 
         <Pressable
-          onPress={onSettings}
+          onPress={onInvite}
           style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
         >
-          <Text style={{ fontSize: 14, color: c.textSecondary }}>Account &amp; Settings</Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            <UserPlus size={16} color={c.textSecondary} />
+            <Text style={{ fontSize: 14, color: c.textSecondary }}>Invite Friends</Text>
+          </View>
           <ChevronRight size={18} color={c.iconMuted} />
         </Pressable>
       </View>


### PR DESCRIPTION
Top of the stack: #396 (guest mode) ← #397 (home) ← this. Merge in order, or retarget to v2 after the parents land.

iOS-only changes to `app/(tabs)/profile.tsx`:
- **Remove the "Account & Settings" row.** The header gear icon already opens Settings, so the in-card row was redundant.
- **Add an "Invite Friends" row** in its place → `/settings/invite` (was reachable only from Settings).
- **Drop the @handle line**, which rendered the email as `@member@chinmayajanata.org`.

Web keeps its Account & Settings row (it's web's path to Settings). codex review: clean, no findings. Typecheck clean. Device QA pending with the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)