### PR TITLE
feat(home): strip personalized lists for guests + unverified

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -227,7 +227,9 @@ export default function HomeScreen() {
     />
   ) : null
 
-  const firstRunOverview = isNewUser ? (
+  // Only a verified new member gets the first-run overview; it can surface the
+  // user's center + board peek, which the not-verified home must not show.
+  const firstRunOverview = isNewUser && isVerifiedMember ? (
     <FirstRunOverview
       c={c}
       detailColors={detailColors}

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -155,6 +155,9 @@ export default function HomeScreen() {
   // still renders below, so Home leads with useful content rather than a
   // redundant feature tour. Self-resolves once they RSVP.
   const isNewUser = !!user && signedUpEvents.length === 0
+  // A signed-in, verified member (vl >= 45). Guests and unverified users get the
+  // stripped home: Explore + sign-in nudge, no personalized event/board lists.
+  const isVerifiedMember = !!user && vl >= 45
 
   if (discoverLoading || (user ? myEventsLoading : false)) {
     return (
@@ -213,7 +216,7 @@ export default function HomeScreen() {
     </Pressable>
   ) : null
 
-  const welcomeBanner = isNewUser ? (
+  const welcomeBanner = !isVerifiedMember || isNewUser ? (
     <WelcomeBanner
       c={c}
       centerName={centerName || undefined}
@@ -249,7 +252,7 @@ export default function HomeScreen() {
     />
   ) : null
 
-  const upNextSection = !isNewUser || featured ? (
+  const upNextSection = isVerifiedMember && (!isNewUser || featured) ? (
     <SectionHeader eyebrow="UP NEXT FOR YOU" trailing="See all" accentColor={c.accent} faintColor={c.textFaint} onTrailingPress={() => {
       track('home_see_all_pressed', { section: 'up_next' })
       router.push('/explore' as never)
@@ -287,7 +290,7 @@ export default function HomeScreen() {
   // Boards peek (#199): the 1-2 latest posts from the user's center board.
   // New users get their center + a feed peek inside the first-run overview,
   // so this section is for returning members only.
-  const boardsSection = user && !isNewUser ? (
+  const boardsSection = isVerifiedMember && !isNewUser ? (
     <SectionHeader
       eyebrow="LATEST ON YOUR BOARDS"
       trailing="Open Feed"
@@ -326,7 +329,7 @@ export default function HomeScreen() {
     </SectionHeader>
   ) : null
 
-  const weekSection = !isNewUser || weekItems.length > 0 ? (
+  const weekSection = isVerifiedMember && (!isNewUser || weekItems.length > 0) ? (
     <SectionHeader
       eyebrow={signedUpEvents.length > 0 ? 'THIS WEEK' : 'COMING UP'}
       trailing="See all"


### PR DESCRIPTION
Follow-up to #396 (native guest mode, merged). Independent of the profile-cleanup PR.

## Why
With guest browsing now live on iOS, a not-verified viewer (logged out, or signed in with `verificationLevel < 45`) was still seeing UP NEXT FOR YOU and COMING UP — personalized event lists that aren't theirs. This strips the home for that audience and points them at Explore.

## What (`app/(tabs)/index.tsx`)
- `isVerifiedMember = !!user && vl >= 45`.
- UP NEXT FOR YOU, COMING UP, the boards peek, and the first-run overview render only for verified members.
- The Explore welcome card shows for not-verified viewers; the sign-in CTA shows only when logged out.
- Verified members: unchanged.

## Review
- codex review: 1 P1 found + fixed (first-run overview was leaking the user's center + board peek to unverified users).
- Rebased onto current v2; diff is the 15-line gating only. Typecheck clean.
- Device QA pending.

(Supersedes #397, which auto-closed when its stacked base branch merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)