### PR TITLE
[codex] Polish detail panel spacing

### DIFF
--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -143,6 +143,7 @@ function BoardComposer({
     user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}`
       : user?.firstName || user?.username || 'You'
   const [body, setBody] = useState('')
+  const [focused, setFocused] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const canSubmit = !!onSubmit && body.trim().length > 0 && !submitting
@@ -164,62 +165,65 @@ function BoardComposer({
   }
 
   return (
-    <View style={{ paddingHorizontal: 20, paddingTop: 18, paddingBottom: visibleLabel ? 16 : 10 }}>
-      <View
-        style={{
-          minHeight: 58,
-          borderRadius: 16,
-          backgroundColor: colors.iconBoxBg,
-          flexDirection: 'row',
-          // Send button sits at the bottom; the avatar is pinned to the top so
-          // the row reads top-to-bottom as the input grows vertically.
-          alignItems: 'flex-end',
-          paddingHorizontal: 16,
-          paddingVertical: 10,
-          gap: 12,
-        }}
-      >
-        <View style={{ alignSelf: 'flex-start' }}>
-          <Avatar image={user?.profileImage || undefined} name={composerName} size={36} backgroundColor={accent} />
-        </View>
-        <TextInput
-          editable={!!onSubmit && !submitting}
-          multiline
-          value={body}
-          onChangeText={setBody}
-          placeholder={placeholder}
-          placeholderTextColor={colors.textMuted}
+    <View style={{ paddingHorizontal: 20, paddingTop: 12, paddingBottom: visibleLabel ? 14 : 10 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+        <Avatar image={user?.profileImage || undefined} name={composerName} size={30} backgroundColor={accent} />
+        <View
           style={{
             flex: 1,
-            minHeight: 38,
-            maxHeight: 120,
-            paddingTop: 8,
-            paddingBottom: 8,
-            fontFamily: 'Inclusive Sans',
-            fontSize: 16,
-            lineHeight: 22,
-            color: colors.text,
-            textAlignVertical: 'top',
-          }}
-        />
-        <Pressable
-          accessibilityLabel="Post to board"
-          disabled={!canSubmit}
-          onPress={handleSubmit}
-          style={{
-            width: 38,
-            height: 38,
-            borderRadius: 19,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: canSubmit ? accent : colors.cardBg ?? colors.panelBg,
-            borderWidth: canSubmit ? 0 : 1,
-            borderColor: colors.border,
-            opacity: submitting ? 0.7 : 1,
+            minHeight: 46,
+            borderRadius: 12,
+            backgroundColor: colors.cardBg ?? colors.panelBg,
+            borderWidth: 1,
+            borderColor: focused || body.length > 0 ? colors.border : 'transparent',
+            flexDirection: 'row',
+            alignItems: 'flex-end',
+            paddingLeft: 12,
+            paddingRight: 6,
+            paddingVertical: 5,
+            gap: 8,
           }}
         >
-          <Send size={17} color={canSubmit ? '#FFFFFF' : colors.textMuted} strokeWidth={2.3} />
-        </Pressable>
+          <TextInput
+            editable={!!onSubmit && !submitting}
+            multiline
+            value={body}
+            onChangeText={setBody}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            placeholder={placeholder}
+            placeholderTextColor={colors.textMuted}
+            style={{
+              flex: 1,
+              minHeight: 34,
+              maxHeight: 120,
+              paddingTop: 7,
+              paddingBottom: 6,
+              fontFamily: 'Inclusive Sans',
+              fontSize: 15,
+              lineHeight: 21,
+              color: colors.text,
+              textAlignVertical: 'top',
+              outlineStyle: 'none',
+            } as any}
+          />
+          <Pressable
+            accessibilityLabel="Post to board"
+            disabled={!canSubmit}
+            onPress={handleSubmit}
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 16,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: canSubmit ? accent : 'transparent',
+              opacity: submitting ? 0.7 : 1,
+            }}
+          >
+            <Send size={15} color={canSubmit ? '#FFFFFF' : colors.textMuted} strokeWidth={2.3} />
+          </Pressable>
+        </View>
       </View>
       {visibleLabel ? (
         <Text

--- a/packages/frontend/components/center/CenterDetailPanel.web.tsx
+++ b/packages/frontend/components/center/CenterDetailPanel.web.tsx
@@ -354,92 +354,88 @@ export default function CenterDetailPanel({
         </DetailSection>
 
         {/* ── UPCOMING EVENTS ──────────────────────────────────────── */}
-        <DetailSection title="Upcoming Events" count={events.length} contentStyle={{ gap: 8 }}>
+        <DetailSection title="Upcoming Events" count={events.length} contentStyle={{ gap: 10 }}>
           {events.length > 0 ? (
-                <View style={{ gap: 8 }}>
-                  {events.map((event) => {
-                    const { month, day } = formatDateCallout(event.date)
-                    return (
-                      <Pressable
-                        key={event.id}
-                        onPress={() => onEventPress(event.id)}
+            <View style={{ gap: 10 }}>
+              {events.map((event) => {
+                const { month, day } = formatDateCallout(event.date)
+                return (
+                  <Pressable
+                    key={event.id}
+                    onPress={() => onEventPress(event.id)}
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      backgroundColor: colors.cardBg,
+                      borderRadius: 10,
+                      paddingVertical: 10,
+                      paddingHorizontal: 12,
+                      gap: 12,
+                      minHeight: 44,
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 48,
+                        minHeight: 50,
+                        borderRadius: 10,
+                        backgroundColor: colors.iconBoxBg,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Text
                         style={{
-                          flexDirection: 'row',
-                          alignItems: 'center',
-                          backgroundColor: colors.cardBg,
-                          borderRadius: 8,
-                          paddingVertical: 12,
-                          paddingHorizontal: 14,
-                          minHeight: 44,
+                          fontFamily: 'Inclusive Sans',
+                          fontSize: 11,
+                          color: '#E8862A',
+                          textTransform: 'uppercase',
+                          lineHeight: 14,
                         }}
                       >
-                        <View
-                          style={{
-                            width: 52,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0,
-                          }}
-                        >
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 11,
-                              color: '#E8862A',
-                              textTransform: 'uppercase',
-                              lineHeight: 14,
-                            }}
-                          >
-                            {month}
-                          </Text>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 22,
-                              color: colors.text,
-                              lineHeight: 28,
-                            }}
-                          >
-                            {day}
-                          </Text>
-                        </View>
-                        <View
-                          style={{
-                            width: 1,
-                            backgroundColor: colors.border,
-                            alignSelf: 'stretch',
-                            marginHorizontal: 12,
-                          }}
-                        />
-                        <View style={{ flex: 1 }}>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 14,
-                              color: colors.text,
-                              lineHeight: 20,
-                            }}
-                            numberOfLines={2}
-                          >
-                            {event.title}
-                          </Text>
-                          <Text
-                            style={{
-                              fontFamily: 'Inclusive Sans',
-                              fontSize: 12,
-                              color: colors.textSecondary,
-                              lineHeight: 16,
-                              marginTop: 2,
-                            }}
-                          >
-                            {event.time} {event.attendees > 0 ? `\u00B7 ${event.attendees} attending` : ''}
-                          </Text>
-                        </View>
-                      </Pressable>
-                    )
-                  })}
-                </View>
-              ) : (
+                        {month}
+                      </Text>
+                      <Text
+                        style={{
+                          fontFamily: 'Inclusive Sans',
+                          fontSize: 22,
+                          color: colors.text,
+                          lineHeight: 28,
+                        }}
+                      >
+                        {day}
+                      </Text>
+                    </View>
+                    <View style={{ flex: 1 }}>
+                      <Text
+                        style={{
+                          fontFamily: 'Inclusive Sans',
+                          fontSize: 14,
+                          color: colors.text,
+                          lineHeight: 20,
+                        }}
+                        numberOfLines={2}
+                      >
+                        {event.title}
+                      </Text>
+                      <Text
+                        style={{
+                          fontFamily: 'Inclusive Sans',
+                          fontSize: 12,
+                          color: colors.textSecondary,
+                          lineHeight: 16,
+                          marginTop: 2,
+                        }}
+                      >
+                        {event.time} {event.attendees > 0 ? `\u00B7 ${event.attendees} attending` : ''}
+                      </Text>
+                    </View>
+                  </Pressable>
+                )
+              })}
+            </View>
+          ) : (
                 <View style={{ alignItems: 'center', paddingVertical: 32 }}>
                   <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textSecondary }}>
                     No upcoming events yet

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -6,7 +6,6 @@ import Badge from '../ui/Badge'
 import { DetailSection } from '../ui'
 import Avatar from '../ui/Avatar'
 import PrimaryButton from '../ui/buttons/PrimaryButton'
-import DestructiveButton from '../ui/buttons/DestructiveButton'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useBoard } from '../../hooks/useApiData'
 import { createBoardPost } from '../../utils/api'
@@ -787,6 +786,55 @@ function googleCalendarUrl(e: {
   return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${text}&dates=${dates}&details=${details}&location=${location}`
 }
 
+function QuietCancelButton({
+  onPress,
+  disabled,
+  loading,
+  colors,
+}: {
+  onPress: () => void
+  disabled?: boolean
+  loading?: boolean
+  colors: DetailColors
+}) {
+  const isDisabled = disabled || loading
+  return (
+    <Pressable
+      onPress={!isDisabled ? onPress : undefined}
+      disabled={isDisabled}
+      accessibilityRole="button"
+      accessibilityLabel="Cancel registration"
+      style={({ pressed }) => ({
+        borderWidth: 1,
+        borderColor: pressed ? '#FCA5A5' : colors.border,
+        backgroundColor: pressed ? '#FEF2F2' : 'transparent',
+        paddingHorizontal: 16,
+        paddingVertical: 11,
+        borderRadius: 999,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity: isDisabled ? 0.55 : 1,
+      })}
+    >
+      {loading ? (
+        <ActivityIndicator size="small" color={colors.textMuted} />
+      ) : (
+        <Text
+          style={{
+            fontFamily: 'Inclusive Sans',
+            fontSize: 14,
+            lineHeight: 20,
+            color: '#B91C1C',
+            textAlign: 'center',
+          }}
+        >
+          Cancel Registration
+        </Text>
+      )}
+    </Pressable>
+  )
+}
+
 function ActionBar({
   isRegistered,
   isPast,
@@ -820,13 +868,12 @@ function ActionBar({
         }}
       >
         {isRegistered ? (
-          <DestructiveButton
+          <QuietCancelButton
             onPress={onToggleRegistration}
             disabled={isToggling}
             loading={isToggling}
-          >
-            Cancel Registration
-          </DestructiveButton>
+            colors={colors}
+          />
         ) : (
           <PrimaryButton
             onPress={onToggleRegistration}
@@ -898,13 +945,12 @@ function ActionBar({
           backgroundColor: colors.panelBg,
         }}
       >
-        <DestructiveButton
+        <QuietCancelButton
           onPress={onToggleRegistration}
           disabled={isToggling}
           loading={isToggling}
-        >
-          Cancel Registration
-        </DestructiveButton>
+          colors={colors}
+        />
       </View>
     )
   }

--- a/packages/frontend/components/ui/DetailSection.tsx
+++ b/packages/frontend/components/ui/DetailSection.tsx
@@ -5,8 +5,7 @@ import { useColors } from '../../hooks/useColors'
 /**
  * DetailSection — the editorial "on-surface" section used across the center
  * and event detail screens. A small-caps muted label, an optional count and
- * trailing action, and a thin hairline divider above (skipped for the first
- * section). Content sits directly on the page background — no cards.
+ * trailing action. Content sits directly on the page background — no cards.
  *
  * Replaces the old tabbed layout (Details / Thread / People|Events) with one
  * ordered scroll so the detail screens read like the Connect feed.
@@ -31,10 +30,7 @@ export function DetailSection({
   const c = useColors()
   return (
     <View>
-      {!first ? (
-        <View style={{ height: 1, backgroundColor: c.border, marginHorizontal: 20, marginTop: 24 }} />
-      ) : null}
-      <View style={{ paddingHorizontal: 20, paddingTop: first ? 4 : 18, paddingBottom: 8 }}>
+      <View style={{ paddingHorizontal: 20, paddingTop: first ? 12 : 28, paddingBottom: 10 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
           <Text style={{ flex: 1, fontSize: 11, letterSpacing: 0.9, color: c.textFaint }}>
             {title.toUpperCase()}


### PR DESCRIPTION
## Summary

- Removes hard section divider lines from center/event detail sections and uses whitespace for separation.
- Tightens center upcoming-event cards and removes their internal vertical divider.
- Reworks the board/comment composer into a cleaner inline input row with the avatar outside the input, muted empty send state, and no browser-blue focus outline.
- Makes registered event cancellation a quieter outline action instead of a prominent destructive red button.

## Validation

- Passed: `npx biome check packages/frontend/components/ui/DetailSection.tsx packages/frontend/components/boards/ThreadPanel.tsx packages/frontend/components/center/CenterDetailPanel.web.tsx packages/frontend/components/events/EventDetailPanel.web.tsx`
- Passed: `git diff --check`
- Manual: ran Expo web locally and verified center/event detail panels at `localhost` with the local backend.
- Not passing before/after this change: `cd packages/frontend && npx jest --runTestsByPath 'src/__tests__/app/events/[id].web.test.tsx' 'src/__tests__/app/events/index.test.tsx' 'src/__tests__/app/(tabs)/explore.test.tsx' --runInBand` reports the selected suites contain no tests.
- Not passing before/after this change: `npx tsc --noEmit -p packages/frontend/tsconfig.json` reports existing unrelated errors in explore route counts, router typed paths, notification props, lucide accessibility props, and test mocks.
