### PR TITLE
Simplify onboarding and auth prompts

### DIFF
--- a/docs/design/auth-home-feed-redesign-20260603/finalized.html
+++ b/docs/design/auth-home-feed-redesign-20260603/finalized.html
@@ -1,0 +1,1358 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Janata Auth, Home, Feed Redesign</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inclusive+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #f5f5f4;
+      --paper: #fbfaf7;
+      --card: #ffffff;
+      --panel: #f7f4ef;
+      --surface: #f0ede8;
+      --border: #e7e5e4;
+      --border-strong: #d6d3d1;
+      --text: #1c1917;
+      --muted: #78716c;
+      --faint: #a8a29e;
+      --accent: #e8862a;
+      --accent-deep: #c2410c;
+      --accent-soft: #fff7ed;
+      --teal: #0f766e;
+      --green: #059669;
+      --blue: #2563eb;
+      --ink: #292524;
+      --shadow: 0 22px 60px rgba(28, 25, 23, 0.16);
+      --radius: 18px;
+      --phone-w: 390px;
+      --phone-h: 844px;
+      color-scheme: light;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1a1a1a;
+        --paper: #171717;
+        --card: #262626;
+        --panel: #1f1f1f;
+        --surface: #171717;
+        --border: #3a3a3a;
+        --border-strong: #525252;
+        --text: #fafafa;
+        --muted: #a8a29e;
+        --faint: #737373;
+        --accent-soft: rgba(232, 134, 42, 0.12);
+        --shadow: 0 22px 60px rgba(0, 0, 0, 0.36);
+        color-scheme: dark;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      min-height: 100%;
+      margin: 0;
+      background:
+        linear-gradient(90deg, rgba(28, 25, 23, 0.035) 1px, transparent 1px),
+        linear-gradient(180deg, rgba(28, 25, 23, 0.035) 1px, transparent 1px),
+        var(--bg);
+      background-size: 96px 96px;
+      color: var(--text);
+      font-family: "Inclusive Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    button,
+    input {
+      font: inherit;
+    }
+
+    button {
+      border: 0;
+      cursor: pointer;
+    }
+
+    button:focus-visible,
+    input:focus-visible,
+    [contenteditable="true"]:focus-visible {
+      outline: 3px solid rgba(232, 134, 42, 0.34);
+      outline-offset: 3px;
+    }
+
+    .page {
+      width: min(1440px, 100%);
+      margin: 0 auto;
+      padding: 32px 28px 56px;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 28px;
+      align-items: end;
+      margin-bottom: 28px;
+    }
+
+    .kicker {
+      color: var(--accent-deep);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0;
+      margin: 0 0 10px;
+    }
+
+    h1 {
+      font-size: clamp(34px, 5vw, 68px);
+      line-height: 0.98;
+      margin: 0;
+      font-weight: 500;
+      letter-spacing: 0;
+      max-width: 900px;
+    }
+
+    .hero p {
+      margin: 14px 0 0;
+      max-width: 720px;
+      color: var(--muted);
+      font-size: 18px;
+      line-height: 1.45;
+    }
+
+    .decision-card {
+      width: min(380px, 100%);
+      border: 1px solid var(--border);
+      background: var(--card);
+      border-radius: var(--radius);
+      padding: 16px;
+      box-shadow: 0 10px 30px rgba(28, 25, 23, 0.08);
+    }
+
+    .decision-card h2 {
+      margin: 0 0 8px;
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .decision-card p {
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .flow-strip {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin: 0 0 32px;
+    }
+
+    .state-pill {
+      border: 1px solid var(--border);
+      background: var(--card);
+      border-radius: 14px;
+      padding: 12px;
+      min-height: 74px;
+    }
+
+    .state-pill strong {
+      display: block;
+      font-size: 14px;
+      margin-bottom: 4px;
+    }
+
+    .state-pill span {
+      display: block;
+      font-size: 12px;
+      line-height: 1.35;
+      color: var(--muted);
+    }
+
+    .screens {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(300px, 1fr));
+      gap: 28px;
+      align-items: start;
+    }
+
+    .screen-card {
+      min-width: 0;
+    }
+
+    .screen-label {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .phone {
+      width: min(var(--phone-w), 100%);
+      height: var(--phone-h);
+      margin: 0 auto;
+      background: var(--paper);
+      border: 1px solid var(--border-strong);
+      border-radius: 44px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .dynamic-island {
+      position: absolute;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 132px;
+      height: 36px;
+      border-radius: 999px;
+      background: #050505;
+      z-index: 5;
+    }
+
+    .phone-top {
+      height: 96px;
+      padding: 56px 22px 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid var(--border);
+      background: var(--card);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 20px;
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    .mark {
+      width: 22px;
+      height: 22px;
+      position: relative;
+      display: inline-block;
+    }
+
+    .mark::before,
+    .mark::after {
+      content: "";
+      position: absolute;
+      inset: 8px 0;
+      border-radius: 999px;
+      background: var(--accent-deep);
+    }
+
+    .mark::after {
+      transform: rotate(90deg);
+    }
+
+    .mark span,
+    .mark i {
+      position: absolute;
+      inset: 8px 0;
+      border-radius: 999px;
+      background: var(--accent-deep);
+      display: block;
+    }
+
+    .mark span {
+      transform: rotate(45deg);
+    }
+
+    .mark i {
+      transform: rotate(-45deg);
+    }
+
+    .top-link {
+      color: var(--accent-deep);
+      background: transparent;
+      font-size: 15px;
+      font-weight: 700;
+      padding: 8px 0;
+    }
+
+    .avatar {
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      background: var(--accent-deep);
+      color: #fff;
+      display: grid;
+      place-items: center;
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .bell {
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+      background: var(--card);
+      border: 1px solid var(--border);
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .content {
+      height: calc(100% - 96px - 76px);
+      overflow: hidden;
+      padding: 20px 22px 18px;
+      position: relative;
+    }
+
+    .content.no-tab {
+      height: calc(100% - 96px);
+    }
+
+    .title {
+      font-size: 31px;
+      line-height: 1.08;
+      margin: 0;
+      font-weight: 500;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.45;
+      margin: 8px 0 24px;
+    }
+
+    .section-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 0 10px;
+      color: var(--faint);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .section-head a {
+      color: var(--accent-deep);
+      text-transform: none;
+      text-decoration: none;
+      font-size: 13px;
+    }
+
+    .event-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .event-tile {
+      height: 154px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--card);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+    }
+
+    .tile-art {
+      flex: 1;
+      background:
+        repeating-linear-gradient(135deg, rgba(232, 134, 42, 0.16), rgba(232, 134, 42, 0.16) 10px, rgba(232, 134, 42, 0.08) 10px, rgba(232, 134, 42, 0.08) 20px);
+      display: grid;
+      place-items: center;
+      color: rgba(120, 113, 108, 0.72);
+      font-size: 11px;
+      text-transform: uppercase;
+    }
+
+    .tile-body {
+      padding: 12px;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), var(--card));
+    }
+
+    .event-title {
+      margin: 0;
+      font-size: 15px;
+      line-height: 1.2;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .event-meta {
+      margin: 4px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .sheet {
+      position: absolute;
+      left: 16px;
+      right: 16px;
+      bottom: 20px;
+      border-radius: 24px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      box-shadow: 0 -12px 42px rgba(28, 25, 23, 0.14);
+      padding: 20px;
+      z-index: 4;
+    }
+
+    .sheet-handle {
+      width: 42px;
+      height: 4px;
+      border-radius: 999px;
+      background: var(--border-strong);
+      margin: -8px auto 16px;
+    }
+
+    .eyebrow {
+      color: var(--accent-deep);
+      font-size: 12px;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0;
+      margin: 0 0 10px;
+    }
+
+    .sheet h3,
+    .panel h3 {
+      margin: 0;
+      font-size: 29px;
+      line-height: 1.06;
+      font-weight: 500;
+    }
+
+    .sheet p,
+    .panel p {
+      margin: 10px 0 16px;
+      color: var(--muted);
+      line-height: 1.4;
+      font-size: 15px;
+    }
+
+    .input {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      height: 52px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--faint);
+      padding: 0 14px;
+      margin-bottom: 12px;
+    }
+
+    .input input {
+      min-width: 0;
+      width: 100%;
+      border: 0;
+      background: transparent;
+      color: var(--text);
+      outline: 0;
+      font-size: 16px;
+    }
+
+    .primary {
+      width: 100%;
+      min-height: 52px;
+      border-radius: 999px;
+      background: var(--accent-deep);
+      color: #fff;
+      font-weight: 700;
+      font-size: 16px;
+      box-shadow: 0 12px 26px rgba(194, 65, 12, 0.22);
+    }
+
+    .secondary-link {
+      display: block;
+      margin: 12px auto 0;
+      color: var(--muted);
+      background: transparent;
+      font-weight: 700;
+      font-size: 14px;
+    }
+
+    .tabbar {
+      height: 76px;
+      border-top: 1px solid var(--border);
+      background: var(--card);
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      align-items: center;
+      padding: 4px 22px 14px;
+    }
+
+    .tab {
+      text-align: center;
+      color: var(--faint);
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .tab .icon {
+      display: block;
+      width: 24px;
+      height: 24px;
+      margin: 0 auto 2px;
+      color: currentColor;
+    }
+
+    .tab.active {
+      color: var(--accent-deep);
+    }
+
+    .search {
+      height: 48px;
+      border-radius: 14px;
+      background: var(--surface);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--faint);
+      padding: 0 14px;
+      margin-bottom: 18px;
+    }
+
+    .post-card {
+      border: 1px solid var(--border);
+      background: var(--card);
+      border-radius: 18px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+
+    .source {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      margin-bottom: 12px;
+    }
+
+    .post-line {
+      display: grid;
+      grid-template-columns: 40px 1fr auto;
+      gap: 12px;
+      align-items: start;
+    }
+
+    .initial {
+      width: 40px;
+      height: 40px;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      color: #fff;
+      font-weight: 700;
+      font-size: 13px;
+    }
+
+    .initial.orange {
+      background: #b45309;
+    }
+
+    .initial.teal {
+      background: var(--teal);
+    }
+
+    .post-author {
+      margin: 0 0 3px;
+      font-weight: 800;
+      font-size: 15px;
+    }
+
+    .post-body {
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+      line-height: 1.35;
+    }
+
+    .post-time {
+      color: var(--faint);
+      font-size: 12px;
+    }
+
+    .reactions {
+      display: flex;
+      gap: 8px;
+      margin: 12px 0 0 52px;
+    }
+
+    .reaction {
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent-deep);
+      padding: 5px 9px;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .lock-note {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      color: var(--faint);
+      font-size: 13px;
+      margin-top: 12px;
+    }
+
+    .center-card,
+    .empty-card,
+    .event-row {
+      border: 1px solid var(--border);
+      background: var(--card);
+      border-radius: 16px;
+      padding: 14px;
+    }
+
+    .map-band {
+      height: 132px;
+      border-radius: 16px 16px 0 0;
+      margin: -14px -14px 14px;
+      display: grid;
+      place-items: center;
+      background:
+        repeating-linear-gradient(135deg, rgba(232, 134, 42, 0.16), rgba(232, 134, 42, 0.16) 10px, rgba(232, 134, 42, 0.08) 10px, rgba(232, 134, 42, 0.08) 20px);
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    .pin {
+      width: 44px;
+      height: 44px;
+      border-radius: 999px 999px 999px 0;
+      background: var(--accent-deep);
+      transform: rotate(-45deg);
+      display: grid;
+      place-items: center;
+      margin-top: 6px;
+    }
+
+    .pin::after {
+      content: "";
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      background: #fff;
+    }
+
+    .center-row {
+      display: grid;
+      grid-template-columns: 46px 1fr auto;
+      gap: 12px;
+      align-items: center;
+      padding: 12px 0;
+      border-top: 1px solid var(--border);
+    }
+
+    .center-row:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    .icon-box {
+      width: 46px;
+      height: 46px;
+      border-radius: 14px;
+      background: var(--surface);
+      display: grid;
+      place-items: center;
+      color: var(--accent-deep);
+      font-size: 12px;
+      font-weight: 800;
+    }
+
+    .row-title {
+      margin: 0 0 3px;
+      color: var(--text);
+      font-size: 15px;
+      font-weight: 800;
+    }
+
+    .row-meta {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .small-button {
+      min-height: 38px;
+      padding: 0 16px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--accent-deep);
+      font-weight: 800;
+    }
+
+    .outline-button {
+      width: 100%;
+      min-height: 44px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--accent-deep);
+      font-weight: 800;
+      margin-top: 10px;
+    }
+
+    .event-row {
+      display: grid;
+      grid-template-columns: 52px 1fr auto;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    .date-pill {
+      width: 52px;
+      height: 52px;
+      border-radius: 14px;
+      background: var(--surface);
+      display: grid;
+      place-items: center;
+      text-align: center;
+    }
+
+    .date-pill span {
+      display: block;
+      color: var(--accent-deep);
+      font-size: 10px;
+      font-weight: 800;
+    }
+
+    .date-pill strong {
+      display: block;
+      font-size: 22px;
+      line-height: 1;
+    }
+
+    .empty-card {
+      text-align: center;
+      padding: 28px 18px;
+    }
+
+    .big-icon {
+      width: 70px;
+      height: 70px;
+      border-radius: 22px;
+      background: var(--accent-soft);
+      color: var(--accent-deep);
+      display: grid;
+      place-items: center;
+      margin: 0 auto 18px;
+      font-size: 18px;
+      font-weight: 800;
+    }
+
+    .empty-card h3 {
+      margin: 0 0 8px;
+      font-size: 24px;
+      font-weight: 500;
+    }
+
+    .empty-card p {
+      color: var(--muted);
+      margin: 0 0 20px;
+      line-height: 1.45;
+    }
+
+    .desktop-demo {
+      grid-column: span 3;
+      border: 1px solid var(--border-strong);
+      background: var(--paper);
+      border-radius: 28px;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+      min-height: 620px;
+      position: relative;
+    }
+
+    .web-header {
+      height: 62px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 22px;
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .web-nav {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .web-nav a {
+      color: var(--muted);
+      text-decoration: none;
+      padding: 10px 12px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .web-nav a.active {
+      color: var(--accent-deep);
+      background: var(--accent-soft);
+    }
+
+    .web-body {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 330px;
+      gap: 24px;
+      padding: 28px;
+      filter: blur(0);
+    }
+
+    .web-main h2 {
+      margin: 0 0 8px;
+      font-size: 38px;
+      font-weight: 500;
+    }
+
+    .web-main p {
+      margin: 0 0 22px;
+      color: var(--muted);
+      font-size: 17px;
+      line-height: 1.45;
+    }
+
+    .web-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .web-event {
+      min-height: 190px;
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--card);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+    }
+
+    .web-rail {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    .modal-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(28, 25, 23, 0.44);
+      display: grid;
+      place-items: center;
+      padding: 28px;
+    }
+
+    .auth-modal {
+      width: min(450px, 100%);
+      border-radius: 22px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      box-shadow: 0 30px 80px rgba(0, 0, 0, 0.32);
+      padding: 24px;
+    }
+
+    .modal-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 22px;
+    }
+
+    .close {
+      width: 36px;
+      height: 36px;
+      border-radius: 999px;
+      background: var(--surface);
+      color: var(--muted);
+      font-size: 20px;
+    }
+
+    .auth-modal h3 {
+      margin: 0;
+      font-size: 30px;
+      font-weight: 500;
+    }
+
+    .auth-modal p {
+      color: var(--muted);
+      margin: 8px 0 18px;
+      line-height: 1.42;
+    }
+
+    .step-list {
+      margin-top: 34px;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+    }
+
+    .plan-card {
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--card);
+      padding: 18px;
+    }
+
+    .plan-card h2 {
+      margin: 0 0 10px;
+      font-size: 20px;
+      font-weight: 600;
+    }
+
+    .plan-card ul {
+      margin: 0;
+      padding: 0 0 0 18px;
+      color: var(--muted);
+      line-height: 1.45;
+      font-size: 14px;
+    }
+
+    @media (max-width: 1120px) {
+      .hero {
+        grid-template-columns: 1fr;
+      }
+
+      .screens {
+        grid-template-columns: repeat(2, minmax(300px, 1fr));
+      }
+
+      .desktop-demo {
+        grid-column: span 2;
+      }
+
+      .step-list {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .page {
+        padding: 22px 14px 42px;
+      }
+
+      .flow-strip,
+      .screens {
+        grid-template-columns: 1fr;
+      }
+
+      .desktop-demo {
+        grid-column: span 1;
+      }
+
+      .web-body {
+        grid-template-columns: 1fr;
+      }
+
+      .web-rail {
+        display: none;
+      }
+    }
+
+    @media (max-width: 430px) {
+      :root {
+        --phone-w: calc(100vw - 24px);
+        --phone-h: 812px;
+      }
+
+      .phone {
+        border-radius: 34px;
+      }
+
+      .content {
+        padding-left: 18px;
+        padding-right: 18px;
+      }
+
+      .sheet {
+        left: 10px;
+        right: 10px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        scroll-behavior: auto !important;
+        transition: none !important;
+        animation: none !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hero" aria-labelledby="page-title">
+      <div>
+        <p class="kicker">Janata UX redesign</p>
+        <h1 id="page-title" contenteditable="true">Browse first. Unlock in context.</h1>
+        <p contenteditable="true">Auth becomes a sheet over Home, Discover, Feed, event detail, and center detail. Setup becomes name plus home center. Everything else moves later.</p>
+      </div>
+      <aside class="decision-card" aria-label="Primary recommendation">
+        <h2 contenteditable="true">Recommendation</h2>
+        <p contenteditable="true">Use one shared auth flow rendered as a native iOS sheet, mobile web sheet, desktop modal, or full-page fallback route.</p>
+      </aside>
+    </section>
+
+    <section class="flow-strip" aria-label="User states">
+      <div class="state-pill"><strong>1. Guest</strong><span>Can browse public events, centers, and feed preview.</span></div>
+      <div class="state-pill"><strong>2. Needs name</strong><span>Has account. Needs enough identity to participate.</span></div>
+      <div class="state-pill"><strong>3. Needs center</strong><span>Signed in. Home and Feed point to center selection.</span></div>
+      <div class="state-pill"><strong>4. Ready</strong><span>Has center. Calendar and boards become personal.</span></div>
+    </section>
+
+    <section class="screens" aria-label="Screen concepts">
+      <article class="screen-card">
+        <p class="screen-label">iOS Home - guest, auth sheet over content</p>
+        <div class="phone">
+          <div class="dynamic-island"></div>
+          <header class="phone-top">
+            <div class="brand"><span class="mark"><span></span><i></i></span>Janata</div>
+            <button class="top-link">Sign in</button>
+          </header>
+          <section class="content no-tab">
+            <h2 class="title" contenteditable="true">Namaste.</h2>
+            <p class="subtitle" contenteditable="true">Here is what is happening across Chinmaya Mission near you.</p>
+            <div class="section-head"><span>Happening near you</span><a href="#">See all</a></div>
+            <div class="event-grid">
+              <div class="event-tile">
+                <div class="tile-art">Camp flyer</div>
+                <div class="tile-body">
+                  <p class="event-title">Mahasamadhi Aradhana Camp</p>
+                  <p class="event-meta">Aug 1 - Parsippany, NJ</p>
+                </div>
+              </div>
+              <div class="event-tile">
+                <div class="tile-art">Class</div>
+                <div class="tile-body">
+                  <p class="event-title">Bhagavad Gita Study</p>
+                  <p class="event-meta">Aug 15 - Andover, MA</p>
+                </div>
+              </div>
+            </div>
+            <div class="sheet" role="dialog" aria-label="Create account">
+              <div class="sheet-handle"></div>
+              <p class="eyebrow">Join the community</p>
+              <h3 contenteditable="true">Find your center. Grow together.</h3>
+              <p contenteditable="true">Discover satsangs, camps, and classes near you, then RSVP in a tap.</p>
+              <label class="input"><span>@</span><input aria-label="Email" placeholder="you@email.com"></label>
+              <button class="primary">Create account -></button>
+              <button class="secondary-link">Browse as guest</button>
+            </div>
+          </section>
+        </div>
+      </article>
+
+      <article class="screen-card">
+        <p class="screen-label">iOS Feed - guest, read-only preview</p>
+        <div class="phone">
+          <div class="dynamic-island"></div>
+          <header class="phone-top">
+            <h2 class="title" style="font-size: 28px;">Feed</h2>
+            <button class="bell" aria-label="Search">S</button>
+          </header>
+          <section class="content no-tab">
+            <div class="post-card">
+              <div class="source">Center board - Chinmaya Vrindavan</div>
+              <div class="post-line">
+                <div class="initial orange">SN</div>
+                <div>
+                  <p class="post-author">Suresh Nair</p>
+                  <p class="post-body">Need two more volunteers for setup before Sunday satsang.</p>
+                </div>
+                <span class="post-time">2h</span>
+              </div>
+              <div class="reactions"><span class="reaction">Pray 8</span><span class="reaction">Tea 3</span></div>
+            </div>
+            <div class="post-card">
+              <div class="source">33rd Aradhana Camp</div>
+              <div class="post-line">
+                <div class="initial teal">AD</div>
+                <div>
+                  <p class="post-author">Anjali Desai</p>
+                  <p class="post-body">Anyone driving in from the Peninsula? Happy to coordinate a carpool.</p>
+                </div>
+                <span class="post-time">4h</span>
+              </div>
+            </div>
+            <div class="sheet" role="dialog" aria-label="Sign in to continue">
+              <div class="sheet-handle"></div>
+              <p class="eyebrow">Your community feed</p>
+              <h3 contenteditable="true">See what your sangha is sharing.</h3>
+              <p contenteditable="true">Posts from your center and events you RSVP to show up here.</p>
+              <button class="primary">Sign in to continue -></button>
+              <div class="lock-note">Lock - Posts are read-only until you sign in</div>
+            </div>
+          </section>
+        </div>
+      </article>
+
+      <article class="screen-card">
+        <p class="screen-label">iOS Home - signed in, no home center</p>
+        <div class="phone">
+          <div class="dynamic-island"></div>
+          <header class="phone-top">
+            <div class="brand"><span class="mark"><span></span><i></i></span>Janata</div>
+            <div style="display:flex; gap:8px; align-items:center;"><button class="bell">N</button><div class="avatar">SD</div></div>
+          </header>
+          <section class="content">
+            <h2 class="title" contenteditable="true">Welcome, Sevak</h2>
+            <div class="center-card" style="margin-top: 22px;">
+              <div class="map-band"><div class="pin"></div></div>
+              <h3 style="font-size: 24px; margin: 0 0 8px;">Pick your home center</h3>
+              <p style="color: var(--muted); line-height: 1.4; margin: 0 0 12px;">Your center's events, board, and people show up once you join.</p>
+              <div class="center-row">
+                <div class="icon-box">Pin</div>
+                <div><p class="row-title">Chinmaya Vrindavan</p><p class="row-meta">Cranbury, NJ - 2.4 mi</p></div>
+                <button class="small-button">Join</button>
+              </div>
+              <div class="center-row">
+                <div class="icon-box">Pin</div>
+                <div><p class="row-title">Chinmaya Badri</p><p class="row-meta">Princeton, NJ - 9 mi</p></div>
+                <button class="small-button">Join</button>
+              </div>
+              <button class="outline-button">Find on map</button>
+            </div>
+            <div class="section-head" style="margin-top: 18px;"><span>While you decide</span></div>
+            <div class="event-row">
+              <div class="date-pill"><div><span>Aug</span><strong>1</strong></div></div>
+              <div><p class="row-title">Mahasamadhi Aradhana Camp</p><p class="row-meta">5:00 PM - Parsippany, NJ</p></div>
+            </div>
+          </section>
+          <nav class="tabbar" aria-label="Tabs">
+            <div class="tab active"><span class="icon">H</span>Home</div>
+            <div class="tab"><span class="icon">D</span>Discover</div>
+            <div class="tab"><span class="icon">F</span>Feed</div>
+          </nav>
+        </div>
+      </article>
+
+      <article class="screen-card">
+        <p class="screen-label">iOS Home - center selected, no RSVPs</p>
+        <div class="phone">
+          <div class="dynamic-island"></div>
+          <header class="phone-top">
+            <div class="brand"><span class="mark"><span></span><i></i></span>Janata</div>
+            <div style="display:flex; gap:8px; align-items:center;"><button class="bell">N</button><div class="avatar">SD</div></div>
+          </header>
+          <section class="content">
+            <h2 class="title" contenteditable="true">Namaste, Sevak</h2>
+            <p class="subtitle" style="margin-bottom: 18px;">Sevak - Chinmaya Vrindavan</p>
+            <div class="empty-card">
+              <div class="big-icon">Cal</div>
+              <h3>Your calendar is open</h3>
+              <p>You are all set at Chinmaya Vrindavan. Find an event to RSVP to and it will land right here.</p>
+              <button class="primary" style="width: 68%; min-width: 210px;">Explore events -></button>
+            </div>
+            <div class="section-head" style="margin-top: 22px;"><span>From your center this week</span><a href="#">See all</a></div>
+            <div class="event-row">
+              <div class="date-pill"><div><span>Aug</span><strong>15</strong></div></div>
+              <div><p class="row-title">Bhagavad Gita Study</p><p class="row-meta">5:00 PM - Union St, Andover</p></div>
+              <button class="small-button">RSVP</button>
+            </div>
+            <div class="event-row">
+              <div class="date-pill"><div><span>Aug</span><strong>17</strong></div></div>
+              <div><p class="row-title">Bala Vihar Children's Class</p><p class="row-meta">5:00 PM - Cranbury, NJ</p></div>
+              <button class="small-button">RSVP</button>
+            </div>
+          </section>
+          <nav class="tabbar" aria-label="Tabs">
+            <div class="tab active"><span class="icon">H</span>Home</div>
+            <div class="tab"><span class="icon">D</span>Discover</div>
+            <div class="tab"><span class="icon">F</span>Feed</div>
+          </nav>
+        </div>
+      </article>
+
+      <article class="screen-card">
+        <p class="screen-label">iOS Feed - signed in, warming up</p>
+        <div class="phone">
+          <div class="dynamic-island"></div>
+          <header class="phone-top">
+            <h2 class="title" style="font-size: 28px;">Feed</h2>
+            <button class="bell" aria-label="Search">S</button>
+          </header>
+          <section class="content">
+            <div class="search">S Search posts and people</div>
+            <div class="empty-card">
+              <div class="big-icon">New</div>
+              <h3>Your feed is warming up</h3>
+              <p>Pick a center or RSVP to an event. Boards you can join will appear here automatically.</p>
+              <button class="primary" style="width: 68%; min-width: 210px;">Pick home center -></button>
+            </div>
+            <div class="section-head" style="margin-top: 22px;"><span>What shows up here</span></div>
+            <div class="center-row" style="background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 12px;">
+              <div class="icon-box">Ctr</div>
+              <div><p class="row-title">Your center</p><p class="row-meta">Posts from your home center.</p></div>
+            </div>
+            <div class="center-row" style="background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 12px; margin-top: 10px;">
+              <div class="icon-box">Evt</div>
+              <div><p class="row-title">Events you RSVP to</p><p class="row-meta">Their boards appear when you join.</p></div>
+            </div>
+          </section>
+          <nav class="tabbar" aria-label="Tabs">
+            <div class="tab"><span class="icon">H</span>Home</div>
+            <div class="tab"><span class="icon">D</span>Discover</div>
+            <div class="tab active"><span class="icon">F</span>Feed</div>
+          </nav>
+        </div>
+      </article>
+
+      <article class="desktop-demo">
+        <header class="web-header">
+          <div style="display:flex; align-items:center; gap:28px;">
+            <div class="brand"><span class="mark"><span></span><i></i></span>Janata</div>
+            <nav class="web-nav" aria-label="Desktop tabs">
+              <a href="#">Home</a>
+              <a href="#" class="active">Discover</a>
+              <a href="#">Feed</a>
+            </nav>
+          </div>
+          <button class="top-link">Sign in</button>
+        </header>
+        <div class="web-body">
+          <section class="web-main">
+            <h2 contenteditable="true">Discover events and centers</h2>
+            <p contenteditable="true">Guests can browse the real app. When they RSVP, join a center, or post, auth opens over this page.</p>
+            <div class="web-grid">
+              <div class="web-event"><div class="tile-art">Camp flyer</div><div class="tile-body"><p class="event-title">Mahasamadhi Aradhana Camp</p><p class="event-meta">Aug 1 - Parsippany, NJ</p></div></div>
+              <div class="web-event"><div class="tile-art">Class</div><div class="tile-body"><p class="event-title">Bhagavad Gita Study</p><p class="event-meta">Aug 15 - Andover, MA</p></div></div>
+              <div class="web-event"><div class="tile-art">Satsang</div><div class="tile-body"><p class="event-title">Sunday Satsang</p><p class="event-meta">Sep 6 - San Jose, CA</p></div></div>
+              <div class="web-event"><div class="tile-art">Youth</div><div class="tile-body"><p class="event-title">CHYK Study Circle</p><p class="event-meta">Sep 10 - Austin, TX</p></div></div>
+            </div>
+          </section>
+          <aside class="web-rail">
+            <div class="center-card"><h3 style="margin:0 0 8px;">Nearby centers</h3><p class="row-meta">Pick one to personalize Home and Feed.</p></div>
+            <div class="post-card"><div class="source">Feed preview</div><p class="post-body">Read-only posts show what a signed-in user unlocks.</p></div>
+          </aside>
+        </div>
+        <div class="modal-backdrop">
+          <div class="auth-modal" role="dialog" aria-label="Desktop auth modal">
+            <div class="modal-head">
+              <div class="brand"><span class="mark"><span></span><i></i></span>Janata</div>
+              <button class="close" aria-label="Close">x</button>
+            </div>
+            <p class="eyebrow">RSVP to continue</p>
+            <h3 contenteditable="true">Sign in to RSVP</h3>
+            <p contenteditable="true">Create an account or sign in. We will bring you back to Bhagavad Gita Study after this step.</p>
+            <label class="input"><span>@</span><input aria-label="Email" placeholder="you@email.com"></label>
+            <button class="primary">Continue</button>
+            <button class="secondary-link">Maybe later</button>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="step-list" aria-label="Implementation steps">
+      <div class="plan-card">
+        <h2>Build order</h2>
+        <ul>
+          <li>Extract shared auth flow from native and web route files.</li>
+          <li>Render the flow as page, iOS sheet, mobile web sheet, and desktop modal.</li>
+          <li>Use intent copy for RSVP, Feed, center, compose, and generic auth.</li>
+        </ul>
+      </div>
+      <div class="plan-card">
+        <h2>Setup order</h2>
+        <ul>
+          <li>Make name the minimum profile requirement.</li>
+          <li>Make center the main setup unlock, with skip allowed.</li>
+          <li>Move birthday and interests into later profile prompts.</li>
+        </ul>
+      </div>
+      <div class="plan-card">
+        <h2>Screen order</h2>
+        <ul>
+          <li>Home gets one primary card per user state.</li>
+          <li>Feed gets guest preview, center setup, empty boards, and active states.</li>
+          <li>Discover remains public and becomes the most common auth entry point.</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <!-- FALLBACK: vendor/pretext.js missing, using CDN -->
+  <script type="module">
+    async function loadPretext() {
+      try {
+        return await import("https://esm.sh/@chenglou/pretext")
+      } catch (error) {
+        return null
+      }
+    }
+
+    const editableNodes = Array.from(document.querySelectorAll('[contenteditable="true"]'))
+    const pretext = await loadPretext()
+
+    function relayoutText() {
+      if (!pretext || typeof pretext.prepare !== 'function' || typeof pretext.layout !== 'function') {
+        return
+      }
+
+      for (const node of editableNodes) {
+        const rect = node.getBoundingClientRect()
+        const text = node.textContent || ''
+        if (!text.trim() || rect.width <= 0) continue
+        try {
+          const prepared = pretext.prepare(text, {
+            fontFamily: '"Inclusive Sans", system-ui, sans-serif',
+            fontSize: Number.parseFloat(getComputedStyle(node).fontSize),
+            lineHeight: Number.parseFloat(getComputedStyle(node).lineHeight),
+          })
+          pretext.layout(prepared, rect.width)
+        } catch (error) {
+          // The board keeps CSS layout as the visual source if CDN Pretext is unavailable.
+        }
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(() => relayoutText())
+    for (const node of editableNodes) {
+      resizeObserver.observe(node)
+      new MutationObserver(() => relayoutText()).observe(node, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+      })
+    }
+
+    if (document.fonts && document.fonts.ready) {
+      await document.fonts.ready
+    }
+    relayoutText()
+  </script>
+</body>
+</html>

--- a/docs/design/auth-home-feed-redesign-20260603/finalized.json
+++ b/docs/design/auth-home-feed-redesign-20260603/finalized.json
@@ -1,0 +1,17 @@
+{
+  "screen": "auth-home-feed-redesign",
+  "date": "2026-06-03",
+  "mode": "plan-driven",
+  "html": "/Users/kishparikh/.gstack/projects/Project-Janatha-Project-Janatha/designs/auth-home-feed-redesign-20260603/finalized.html",
+  "plan": "/Users/kishparikh/conductor/workspaces/Project-Janatha/nairobi/.context/auth-home-feed-redesign-full-plan.md",
+  "source_context": [
+    "packages/frontend/app/auth.tsx",
+    "packages/frontend/app/auth.web.tsx",
+    "packages/frontend/components/ui/AuthPromptModal.tsx",
+    "packages/frontend/components/center/CenterSearch.tsx",
+    "packages/frontend/app/(tabs)/index.tsx",
+    "packages/frontend/app/(tabs)/feed.tsx",
+    "packages/frontend/components/feed/FeedEmptyState.tsx"
+  ],
+  "decision": "Use shared auth flow rendered as sheet/modal/full-page fallback, reduce blocking onboarding to name plus home center, and make Home/Feed state-specific across iOS and web."
+}

--- a/docs/design/auth-home-feed-redesign-20260603/plan.md
+++ b/docs/design/auth-home-feed-redesign-20260603/plan.md
@@ -1,0 +1,456 @@
+# Janata Auth, Home, Feed Redesign Plan
+
+Date: 2026-06-03
+Workspace: `/Users/kishparikh/conductor/workspaces/Project-Janatha/nairobi`
+
+## What Exists Today
+
+The app is already close to the right model:
+
+- Public browsing is allowed from `app/_layout.tsx`: guests can open Home, Explore, Feed, events, and center detail.
+- Auth exists as duplicated screens:
+  - `packages/frontend/app/auth.tsx`
+  - `packages/frontend/app/auth.web.tsx`
+- There is already an event-specific auth modal:
+  - `packages/frontend/components/ui/AuthPromptModal.tsx`
+  - It currently routes to `/auth` instead of completing auth in place.
+- Center search is already shared:
+  - `packages/frontend/components/center/CenterSearch.tsx`
+  - Used in onboarding and feed setup.
+- Feed already has state-aware setup components:
+  - `FeedEmptyState`
+  - `FeedSetupRail`
+  - `GhostFeed`
+- Home already has state-specific pieces:
+  - `SignInCallout`
+  - `WelcomeBanner`
+  - `FirstRunOverview`
+  - board peek and event sections.
+
+The main problem is not missing UI primitives. The problem is that the product model is split across full-page auth, full-page onboarding, center picker, and feed/home empty states.
+
+## Product Thesis
+
+Janata should be browse-first, then unlock-in-context.
+
+Users should first understand:
+
+- There are real events.
+- There are real centers.
+- There are real boards/conversations.
+- Picking a center makes the app personal.
+
+Auth should not feel like a destination. Auth should feel like a sheet that appears when the user tries to do something meaningful.
+
+## User State Model
+
+Use these states everywhere:
+
+1. `guest`
+   - No user.
+   - Can browse public content.
+   - Locked actions open auth sheet.
+
+2. `signedInNeedsName`
+   - Has account, missing `firstName` or `lastName`.
+   - Needs a short setup sheet.
+
+3. `signedInNeedsCenter`
+   - Has name, no `centerID`.
+   - App is usable, but Home and Feed strongly lead to center selection.
+
+4. `signedInReady`
+   - Has name and `centerID`.
+   - Home becomes dashboard.
+   - Feed becomes boards from home center + RSVP events.
+
+Avoid making `profileComplete` mean "finished a long onboarding tour." It should mean "has enough identity to use Janata."
+
+## Auth Design
+
+### Recommendation
+
+Create one shared auth surface:
+
+- `AuthFlowCore` or `useAuthFlow`
+  - owns email check, login, invite-code validation, signup, errors, loading, button labels.
+- `AuthSurface`
+  - renders the shared flow.
+  - supports `mode="sheet" | "page"`.
+  - supports `intent`.
+- `/auth`
+  - remains a full-page wrapper around `AuthSurface`.
+- `AuthPromptModal`
+  - is replaced or upgraded to render `AuthSurface mode="sheet"`.
+
+### Intents
+
+Auth copy should be contextual:
+
+- `generic`: "Sign in to Janata"
+- `rsvp`: "Sign in to RSVP"
+- `feed`: "Sign in to join the conversation"
+- `center`: "Create your account to follow this center"
+- `compose`: "Sign in to post"
+
+Each intent still uses the same underlying flow.
+
+### Platform Behavior
+
+iOS:
+
+- Bottom sheet.
+- Max height about 88% of viewport.
+- Drag/close optional, close button required.
+- Keyboard avoiding behavior.
+
+Mobile web:
+
+- Bottom sheet.
+- Same visual structure as iOS.
+
+Desktop web:
+
+- Centered modal over the current page.
+- Width around 420-460px.
+- Dimmed backdrop.
+
+Fallback:
+
+- Direct `/auth` still full-page on all platforms.
+- Password reset stays route-based.
+
+## Setup / Onboarding Design
+
+### Current
+
+`OnboardingProvider` has four required form steps:
+
+- name
+- birthday
+- center
+- interests
+- complete
+
+### Recommended
+
+Keep the full setup flow, but reduce the feeling of obligation.
+
+Required:
+
+1. Name
+2. Home center
+
+Skippable:
+
+3. Birthday
+4. Interests
+
+Make optional steps extremely simple:
+
+- One screen each.
+- One primary action: `Continue`.
+- One secondary action: `Skip`.
+- No explanatory paragraphs beyond one short sentence.
+- No disabled primary button on optional steps.
+- If skipped, persist null/empty values and continue.
+
+Make center skippable too, but with honest copy:
+
+- Primary: `Pick home center`
+- Secondary: `Skip for now`
+- Consequence: "You can still browse, but your Home and Feed will stay generic."
+
+Use fewer 3D icons than the prototype:
+
+- Use the 3D icon prominently in the intro and lightly in setup headers.
+- Do not place 3D icons on every card, row, or empty state.
+- Use the compass for center selection.
+- Use the diya for welcome/account creation.
+- Avoid adding new 3D imagery to Home/Feed unless it replaces an existing empty-state icon.
+
+### Backend/API
+
+No backend migration is required for the first pass.
+
+Use existing profile update paths:
+
+- `POST /api/auth/complete-onboarding`
+- profile update through `authService.updateProfile`
+
+Set `profileComplete: true` after the user completes or skips the final onboarding step. Also keep the existing derived-complete behavior in mind: `UserContext` already treats a user with first name, last name, and email as effectively onboarded.
+
+## Home Redesign
+
+### Guest Home
+
+Goal: "I understand Janata before I sign up."
+
+Recommended structure:
+
+- Header: logo + `Sign in`.
+- Greeting: `Namaste.`
+- Section: `Happening near you`
+  - show real event cards.
+- Bottom callout/sheet:
+  - eyebrow: `JOIN THE COMMUNITY`
+  - title: `Find your center. Grow together.`
+  - email field or direct `Create account`
+  - secondary: `Browse as guest`
+
+Avoid listing feature-tour bullets if events are visible. Real content does the teaching.
+
+### Signed In, No Center
+
+Goal: "Pick your center so the app makes sense."
+
+Recommended structure:
+
+- Header: logo + notifications + avatar.
+- Greeting: `Welcome, [name]`
+- Primary card: `Pick your home center`
+  - 2-3 nearest centers.
+  - `Join` buttons.
+  - `Find on map`.
+- Section: `While you decide`
+  - one or two real events.
+
+### Signed In, Center, No RSVPs
+
+Goal: "Your account is set up; RSVP to fill your calendar and boards."
+
+Recommended structure:
+
+- Greeting: `Namaste, [name]`
+- Subline: role + center.
+- Primary card: `Your calendar is open`
+- CTA: `Explore events`
+- Section: `From your center this week`
+
+### Returning Member
+
+Goal: "Show me what is next and what changed."
+
+Recommended structure:
+
+- Up Next
+- This Week
+- Latest on your boards
+
+## Feed Redesign
+
+### Guest Feed
+
+Goal: "I understand what Feed is before signing in."
+
+Recommended structure:
+
+- Show one or two read-only sample/real posts when available.
+- Bottom auth callout:
+  - eyebrow: `YOUR COMMUNITY FEED`
+  - title: `See what your sangha is sharing.`
+  - CTA: `Sign in to continue`
+  - lock line: `Posts are read-only until you sign in`
+
+### Signed In, No Center
+
+Goal: "The feed is empty because I have not picked a center."
+
+Recommended structure:
+
+- Title: `Choose your center to start your feed`
+- Inline `CenterSearch`
+- Secondary: `Or RSVP to an event to see its board`
+
+### Signed In, Has Boards, No Posts
+
+Goal: "I have the right boards; now someone needs to post."
+
+Recommended structure:
+
+- Board list visible.
+- Empty post area:
+  - `No posts yet`
+  - `Start the conversation`
+- Compose CTA only if the user has at least one writable board.
+
+### Active Feed
+
+Goal: "Read and respond."
+
+Recommended structure:
+
+- Search.
+- Post list.
+- Context rail on desktop.
+- Thread detail on selection.
+
+## Navigation
+
+Use three tabs:
+
+- Home
+- Explore
+- Feed
+
+Keep the visible label `Explore`. The code and tests already use this label, and the user preference is to keep it.
+
+## Implementation Plan
+
+### Phase 1: Shared Auth Surface
+
+Files:
+
+- Create `packages/frontend/components/auth/AuthSurface.tsx`.
+- Create `packages/frontend/components/auth/useAuthFlow.ts`.
+- Update `packages/frontend/app/auth.tsx`.
+- Update `packages/frontend/app/auth.web.tsx`.
+- Update `packages/frontend/components/ui/AuthPromptModal.tsx`.
+
+Tasks:
+
+- Move auth step state and handlers out of route files.
+- Support `initialEmail`, `initialMode`, `inviteCode`, `returnTo`, and `intent`.
+- Preserve existing analytics names.
+- On success, call optional `onSuccess(user)` for modal use.
+- Full-page `/auth` continues to navigate by `returnTo`.
+
+Tests:
+
+- Existing auth tests should still pass.
+- Add modal flow coverage for existing user login and new user signup.
+
+### Phase 2: Auth Invocation
+
+Files:
+
+- `app/events/[id].tsx`
+- `app/events/[id].web.tsx`
+- `app/(tabs)/feed.tsx`
+- `app/(tabs)/index.tsx`
+- `app/(tabs)/profile.tsx`
+- `app/(tabs)/chat.tsx`
+
+Tasks:
+
+- Replace `router.push('/auth')` for locked actions with `openAuth(intent)`.
+- Keep route fallback for deep links and screens outside the modal provider.
+- For guest center selection, store the intended center and complete it after auth.
+
+### Phase 3: Setup Simplification
+
+Files:
+
+- `components/contexts/OnboardingProvider.tsx`
+- `app/onboarding.tsx`
+- `components/onboarding/step1.tsx`
+- `components/onboarding/step3.tsx`
+- `components/onboarding/step2.tsx`
+- `components/onboarding/step4.tsx`
+
+Tasks:
+
+- Keep four steps: name, birthday, center, interests.
+- Make birthday, center, and interests skippable.
+- Center remains the most important unlock and should still be visually emphasized.
+- Birthday UX: plain date picker, `Continue`, `Skip`.
+- Interests UX: reduce the chip list to clear categories, allow zero selections, `Continue`, `Skip`.
+- Set `profileComplete: true` after final step complete/skip.
+- Allow `centerID` null.
+
+Tests:
+
+- Signup redirects to setup.
+- Skipping birthday/interests gets user into app.
+- Skipping center gets user into generic Home/Feed.
+- Picking center updates Home and Feed.
+
+### Phase 4: Home State Resolver
+
+Files:
+
+- `app/(tabs)/index.tsx`
+- Optional: `components/home/homeState.ts`
+
+Tasks:
+
+- Create a state resolver:
+  - `guest`
+  - `needsName`
+  - `needsCenter`
+  - `emptyCalendar`
+  - `ready`
+- Render one dominant primary card per state.
+- Use real event data in guest and no-center states.
+
+### Phase 5: Feed State Resolver
+
+Files:
+
+- `app/(tabs)/feed.tsx`
+- `components/feed/FeedEmptyState.tsx`
+- `components/feed/FeedSetupRail.tsx`
+- Optional: `components/feed/feedState.ts`
+
+Tasks:
+
+- Create a state resolver:
+  - `guest`
+  - `needsCenter`
+  - `needsBoards`
+  - `emptyBoards`
+  - `active`
+- Guest feed should show read-only content preview before the auth callout.
+- Compose action appears only when there is a writable board.
+
+### Phase 6: Copy and Polish
+
+Tasks:
+
+- Standardize labels:
+  - `Create account`
+  - `Sign in`
+  - `Pick home center`
+  - `Explore events`
+  - `RSVP`
+- Keep `Explore` in UI nav.
+- Remove generic feature-tour copy where real content is already visible.
+- Keep card radius at 8-18 depending on existing component family. Avoid nested cards.
+
+## Gaps Found In Final Check
+
+1. `AuthPromptModal` is already used in event detail and web Explore, but it redirects to `/auth`. Replacing it with the shared auth surface is the cleanest first auth change.
+
+2. Several guest CTAs still push `/auth` directly:
+   - Home sign-in callout.
+   - Feed setup sign-in.
+   - Guest center pick from Feed.
+   - Chat/profile sign-in prompts.
+   These need an `openAuth(intent)` path, with route fallback.
+
+3. `OnboardingProvider` currently makes birthday, center, and interests hard gates in normal signup. The `skipOnboarding` path only appears for `returnTo`, so optional steps need to become first-class for all signup flows.
+
+4. `UserContext` derives onboarding completion from `profileComplete` or name + email. That means the setup changes should be careful not to trap users in `/onboarding` after they skip optional fields.
+
+5. Backend profile update already supports null/empty `centerID`, optional `dateOfBirth`, and optional `interests`. No migration is needed for the UX changes.
+
+## Open Decisions
+
+1. Is Janata invite-only for all new accounts?
+   - If yes, keep invite code in auth flow.
+   - If no, make invite code conditional by center/verification path.
+
+2. Does selecting a center mean `Join` or `Follow`?
+   - Use `Join` only if the user becomes a member.
+   - Use `Follow` if it only personalizes Home/Feed.
+
+3. Is Feed mission-wide or personal?
+   - Current code builds boards from home center and RSVP events.
+   - Screens imply broader mission content may flow in.
+   - Recommendation: personal feed first, with public preview for guests.
+
+## HTML Concept
+
+The accompanying HTML design board is saved under the gstack design artifacts directory:
+
+`~/.gstack/projects/Project-Janatha-Project-Janatha/designs/auth-home-feed-redesign-20260603/finalized.html`

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -19,6 +19,7 @@ import { useHeaderAction } from '../../components/contexts/HeaderActionContext'
 import { useCenterList, useMyEvents } from '../../hooks/useApiData'
 import { extractCityState } from '../../utils/addressParsing'
 import { CreatePostSheet, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import AuthPromptModal from '../../components/ui/AuthPromptModal'
 import { centerPickerStore } from '../../utils/centerPickerStore'
 import { createBoardPost, fetchBoard } from '../../utils/api'
 import {
@@ -174,6 +175,7 @@ export default function FeedScreen() {
   const [query, setQuery] = useState('')
   const [selectedPostId, setSelectedPostId] = useState('')
   const [createPostOpen, setCreatePostOpen] = useState(false)
+  const [authPromptOpen, setAuthPromptOpen] = useState(false)
   const [boardMessagesByGroup, setBoardMessagesByGroup] = useState<Record<string, BoardMessage[]>>({})
   const [boardsLoading, setBoardsLoading] = useState(false)
   const { setCreateHandler } = useHeaderAction()
@@ -197,6 +199,26 @@ export default function FeedScreen() {
 
   const canAccessBoards = !!user
   const userCenter = allCenters.find((item) => item.id === user?.centerID)
+
+  useEffect(() => {
+    if (!user || !centerPickerStore.result) return
+
+    const centerId = centerPickerStore.result
+    centerPickerStore.result = null
+    updateProfile({ centerID: centerId })
+      .then((result) => {
+        if (result.success) {
+          track('feed_setup_center_joined', { center_id: centerId, source: 'feed_empty_auth_return' })
+          refetchCenters()
+        } else {
+          track('feed_setup_center_join_failed', { center_id: centerId, source: 'feed_empty_auth_return' })
+        }
+      })
+      .catch(() => {
+        track('feed_setup_center_join_failed', { center_id: centerId, source: 'feed_empty_auth_return' })
+      })
+  }, [user, updateProfile, track, refetchCenters])
+
   const groups = useMemo<GroupBoard[]>(() => {
     const nextGroups: GroupBoard[] = []
 
@@ -352,8 +374,8 @@ export default function FeedScreen() {
 
   const handleSignIn = useCallback(() => {
     track('connect_signin_pressed', { source: 'feed_setup' })
-    router.push('/auth')
-  }, [router, track])
+    setAuthPromptOpen(true)
+  }, [track])
 
   const handleBrowseEvents = useCallback(() => {
     track('connect_explore_pressed', { source: 'feed_setup' })
@@ -369,7 +391,7 @@ export default function FeedScreen() {
       if (!user) {
         centerPickerStore.result = centerId
         track('feed_setup_center_pick_guest', { center_id: centerId, source: 'feed_empty' })
-        router.push('/auth')
+        setAuthPromptOpen(true)
         return false
       }
       const result = await updateProfile({ centerID: centerId })
@@ -381,7 +403,7 @@ export default function FeedScreen() {
       track('feed_setup_center_join_failed', { center_id: centerId, source: 'feed_empty' })
       return false
     },
-    [user, updateProfile, router, track, refetchCenters]
+    [user, updateProfile, track, refetchCenters]
   )
 
   const closeDetail = () => {
@@ -575,6 +597,19 @@ export default function FeedScreen() {
           setCreatePostOpen(false)
         }}
         onSubmit={handleCreatePost}
+      />
+
+      <AuthPromptModal
+        visible={authPromptOpen}
+        onClose={() => setAuthPromptOpen(false)}
+        returnTo="/feed"
+        title="Join the conversation."
+        subtitle="Sign in or create an account to follow your center, RSVP to events, and join your boards."
+        bullets={[
+          'Follow your center board and stay in the loop',
+          'Join event boards after you RSVP',
+          'Post updates, questions, and reflections with your sangha',
+        ]}
       />
     </View>
   )

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ActivityIndicator, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
 import { ChevronRight, Compass, MapPin, Shield } from 'lucide-react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
@@ -14,6 +14,7 @@ import { FeaturedEventCard, type FeaturedSource } from '../../components/home/Fe
 import { MiniEventRow, type WeekItem } from '../../components/home/MiniEventRow'
 import { BoardPostCard, SignInCallout, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { DesktopColumns, desktopScrollContent, useDesktopLayout } from '../../components/layout/DesktopColumns'
+import AuthPromptModal from '../../components/ui/AuthPromptModal'
 import type { AppColors } from '../../tokens'
 
 function formatDatePill(dateStr: string): { month: string; day: string } {
@@ -60,6 +61,7 @@ export default function HomeScreen() {
   const { width } = useWindowDimensions()
   const { track } = useAnalytics()
   const { user } = useUser()
+  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
   const c = useColors()
   const detailColors = useDetailColors()
   const { events: myEvents, loading: myEventsLoading, refetch: refetchMyEvents } = useMyEvents(user?.username)
@@ -190,10 +192,25 @@ export default function HomeScreen() {
       colors={c}
       onPress={() => {
         track('home_signin_pressed', { source: 'home_nudge' })
-        router.push('/auth' as never)
+        setShowAuthPrompt(true)
       }}
     />
   ) : null
+
+  const authPrompt = (
+    <AuthPromptModal
+      visible={showAuthPrompt}
+      onClose={() => setShowAuthPrompt(false)}
+      returnTo="/"
+      title="Make Janata yours."
+      subtitle="Sign in or create an account to follow your center, RSVP to events, and join your boards."
+      bullets={[
+        'Follow your local center and see what is coming up',
+        'RSVP to events and keep details handy',
+        'Join boards for your center and gatherings',
+      ]}
+    />
+  )
 
   // Role-aware: admins get a quick path to the dashboard from Home.
   const adminShortcut = isSuperAdmin(user) ? (
@@ -368,57 +385,63 @@ export default function HomeScreen() {
       <View style={{ gap: 22 }}>{boardsSection}</View>
     )
     return (
-      <ScrollView
-        style={{ flex: 1, backgroundColor: c.bg }}
-        contentContainerStyle={desktopScrollContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <DesktopColumns
-          header={
-            <>
-              {greeting}
-              {guestNudge}
-              {adminShortcut}
-              {welcomeBanner}
-            </>
-          }
-          main={
-            <>
-              {upNextSection}
-              {weekSection}
-            </>
-          }
-          rail={rail}
-        />
-      </ScrollView>
+      <>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: c.bg }}
+          contentContainerStyle={desktopScrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <DesktopColumns
+            header={
+              <>
+                {greeting}
+                {guestNudge}
+                {adminShortcut}
+                {welcomeBanner}
+              </>
+            }
+            main={
+              <>
+                {upNextSection}
+                {weekSection}
+              </>
+            }
+            rail={rail}
+          />
+        </ScrollView>
+        {authPrompt}
+      </>
     )
   }
 
   // ── Mobile web + native + narrow web: original single centered column ────
   return (
-    <ScrollView
-      style={{ flex: 1, backgroundColor: c.bg }}
-      contentContainerStyle={{
-        paddingHorizontal: isDesktop ? 24 : 16,
-        paddingTop: Platform.OS === 'web' ? 20 : 8,
-        paddingBottom: Platform.OS === 'web' ? 40 : 112,
-      }}
-      showsVerticalScrollIndicator={false}
-    >
-      {/* Mobile single column: lead with the schedule (the desktop "main"
-          column — Up Next + Coming Up), then wrap the center/boards content
-          (the desktop right rail) below it, so the order matches desktop. */}
-      <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center', gap: 22 }}>
-        {greeting}
-        {guestNudge}
-        {adminShortcut}
-        {welcomeBanner}
-        {upNextSection}
-        {weekSection}
-        {firstRunOverview}
-        {boardsSection}
-      </View>
-    </ScrollView>
+    <>
+      <ScrollView
+        style={{ flex: 1, backgroundColor: c.bg }}
+        contentContainerStyle={{
+          paddingHorizontal: isDesktop ? 24 : 16,
+          paddingTop: Platform.OS === 'web' ? 20 : 8,
+          paddingBottom: Platform.OS === 'web' ? 40 : 112,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Mobile single column: lead with the schedule (the desktop "main"
+            column — Up Next + Coming Up), then wrap the center/boards content
+            (the desktop right rail) below it, so the order matches desktop. */}
+        <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center', gap: 22 }}>
+          {greeting}
+          {guestNudge}
+          {adminShortcut}
+          {welcomeBanner}
+          {upNextSection}
+          {weekSection}
+          {firstRunOverview}
+          {boardsSection}
+        </View>
+      </ScrollView>
+      {authPrompt}
+    </>
   )
 }
 

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
   View,
   Text,
@@ -41,9 +41,8 @@ export default function AuthScreen() {
   const urlInviteCode = params.inviteCode
   const urlEmail = typeof params.email === 'string' ? params.email : ''
 
-  // mode=login is meaningful only when we also have an email — otherwise we'd
-  // render a login screen with a disabled empty email field that the user
-  // can't edit, which is a dead-end. Fall back to the initial step instead.
+  // mode=login needs a prefilled email. mode=signup can work with only an
+  // invite code because the email field stays editable in that flow.
   const [authStep, setAuthStep] = useState<AuthStep>(
     params.mode === 'login' && urlEmail ? 'login'
       : params.mode === 'signup' && urlInviteCode ? 'signup'
@@ -54,8 +53,23 @@ export default function AuthScreen() {
   const [confirmPassword, setConfirmPassword] = useState('')
   const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
 
   const [showDevPanel, setShowDevPanel] = useState(false)
+
+  useEffect(() => {
+    const nextStep =
+      params.mode === 'login' && urlEmail ? 'login'
+        : params.mode === 'signup' && urlInviteCode ? 'signup'
+        : 'initial'
+
+    setAuthStep(nextStep)
+    setUsername(urlEmail)
+    setInviteCode(urlInviteCode || '')
+    setPassword('')
+    setConfirmPassword('')
+    setErrors({})
+  }, [params.mode, urlEmail, urlInviteCode])
 
   const handleContinue = useCallback(async () => {
     setErrors({})
@@ -354,7 +368,7 @@ export default function AuthScreen() {
                   onChangeText={handleUsernameChange}
                   value={username}
                   secureTextEntry={false}
-                  editable={authStep === 'initial'}
+                  editable={emailEditable}
                 />
               </View>
               {authStep === 'login' && (

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react'
-import { useRouter } from 'expo-router'
+import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useUser } from '../components/contexts'
 import { useAnalytics } from '../utils/analytics'
 import { validateEmail, validatePassword } from '../utils'
@@ -53,18 +53,17 @@ export default function AuthScreen() {
   const { checkUserExists, login, signup, loading } = useUser()
   const { track } = useAnalytics()
 
-  // Read mode, returnTo, inviteCode, and email from URL params
-  const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null
-  const initialMode = urlParams?.get('mode')
-  const returnTo = urlParams?.get('returnTo')
-  const urlInviteCode = urlParams?.get('inviteCode')
-  const urlEmail = urlParams?.get('email') ?? ''
+  // Read mode, returnTo, inviteCode, and email from URL params.
+  // useLocalSearchParams stays reactive during Expo Router SPA navigation.
+  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string }>()
+  const initialMode = typeof params.mode === 'string' ? params.mode : ''
+  const returnTo = typeof params.returnTo === 'string' ? params.returnTo : null
+  const urlInviteCode = typeof params.inviteCode === 'string' ? params.inviteCode : ''
+  const urlEmail = typeof params.email === 'string' ? params.email : ''
 
-  // When inviteCode is provided via URL (e.g. from public explore flow),
-  // skip the invite-code step and go straight to signup.
-  // mode=login is meaningful only when we also have an email — otherwise we'd
-  // render a login screen with a disabled empty email field that the user
-  // can't edit, which is a dead-end. Fall back to the initial step instead.
+  // When inviteCode is provided via URL (e.g. from public explore flow), skip
+  // the invite-code step and go straight to signup. mode=login still needs a
+  // prefilled email, while signup without an email keeps the email field editable.
   const [authStep, setAuthStep] = useState<AuthStep>(
     initialMode === 'login' && urlEmail ? 'login'
       : initialMode === 'signup' && urlInviteCode ? 'signup'
@@ -76,6 +75,7 @@ export default function AuthScreen() {
   const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const [showDevPanel, setShowDevPanel] = useState(false)
+  const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
   // Focus state for input styling
   const [emailFocused, setEmailFocused] = useState(false)
   const [passwordFocused, setPasswordFocused] = useState(false)
@@ -84,6 +84,20 @@ export default function AuthScreen() {
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth : 1280
   )
+
+  useEffect(() => {
+    const nextStep =
+      initialMode === 'login' && urlEmail ? 'login'
+        : initialMode === 'signup' && urlInviteCode ? 'signup'
+        : 'initial'
+
+    setAuthStep(nextStep)
+    setUsername(urlEmail)
+    setInviteCode(urlInviteCode || '')
+    setPassword('')
+    setConfirmPassword('')
+    setErrors({})
+  }, [initialMode, urlEmail, urlInviteCode])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -135,7 +149,7 @@ export default function AuthScreen() {
       const result = await login(username, password)
       if (result.success) {
         track('login_success', { source: 'auth' })
-        router.replace(returnTo || '/(tabs)')
+        router.replace(returnTo ? (returnTo as never) : '/(tabs)')
       } else {
         track('login_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Username or password is incorrect.' })
@@ -144,7 +158,7 @@ export default function AuthScreen() {
       track('login_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, login, router, track])
+  }, [username, password, returnTo, login, router, track])
 
   const handleSignup = useCallback(async () => {
     setErrors({})
@@ -177,7 +191,7 @@ export default function AuthScreen() {
       track('signup_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, confirmPassword, inviteCode, signup, router, track])
+  }, [username, password, confirmPassword, inviteCode, returnTo, signup, router, track])
 
   const handleInviteCodeContinue = useCallback(async () => {
     setErrors({})
@@ -531,7 +545,7 @@ export default function AuthScreen() {
               placeholder="Email"
               value={username}
               onChange={handleUsernameChange}
-              disabled={authStep !== 'initial'}
+              disabled={!emailEditable}
               onFocus={() => setEmailFocused(true)}
               onBlur={() => setEmailFocused(false)}
               style={getInputStyle(emailFocused)}

--- a/packages/frontend/components/onboarding/step2.tsx
+++ b/packages/frontend/components/onboarding/step2.tsx
@@ -6,10 +6,7 @@ import BirthdatePicker from '../profile/BirthdatePicker'
 import { PrimaryButton } from '../ui'
 
 export default function Step2() {
-  const { goToNextStep, birthdate, setBirthdate, skipOnboarding, returnTo, isSubmitting } = useOnboarding()
-
-  // Only true if birthdate is not null
-  const isDateSelected = !!birthdate
+  const { goToNextStep, birthdate, setBirthdate } = useOnboarding()
 
   return (
     <SafeAreaView className="flex-1 bg-background dark:bg-background-dark">
@@ -24,6 +21,9 @@ export default function Step2() {
               <Text className="text-lg font-sans text-stone-500 dark:text-stone-400 text-center">
                 We'll use this to personalize your experience.
               </Text>
+              <Text className="text-sm font-sans text-stone-400 dark:text-stone-500 text-center">
+                Optional. You can add this later.
+              </Text>
             </View>
             <View className="mt-8 w-full flex items-center justify-center" style={Platform.OS === 'web' ? { overflow: 'visible', zIndex: 20 } : undefined}>
               <BirthdatePicker value={birthdate ?? undefined} onChange={setBirthdate} />
@@ -34,14 +34,13 @@ export default function Step2() {
         {/* --- Continue Button --- */}
         <View className="pb-6">
           <PrimaryButton
-            disabled={!isDateSelected}
             onPress={goToNextStep}
             style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
             Continue
           </PrimaryButton>
-          {returnTo && (
-            <Pressable onPress={skipOnboarding} disabled={isSubmitting} style={{ alignSelf: 'center', marginTop: 12 }}>
+          {!birthdate && (
+            <Pressable onPress={goToNextStep} style={{ alignSelf: 'center', marginTop: 12 }}>
               <Text className="text-sm font-sans text-stone-400 dark:text-stone-500">
                 Skip for now
               </Text>

--- a/packages/frontend/components/onboarding/step3.tsx
+++ b/packages/frontend/components/onboarding/step3.tsx
@@ -1,21 +1,11 @@
 import { View, Text, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useOnboarding } from '../contexts'
-import { useState } from 'react'
 import { PrimaryButton } from '../ui'
 import { CenterSearch } from '../center/CenterSearch'
 
 export default function Step3() {
-  const { goToNextStep, centerID, setCenterID, skipOnboarding, returnTo, isSubmitting } = useOnboarding()
-  const [error, setError] = useState('')
-
-  const handleContinue = () => {
-    if (!centerID) {
-      setError('Please search and select a center')
-      return
-    }
-    goToNextStep()
-  }
+  const { goToNextStep, centerID, setCenterID } = useOnboarding()
 
   return (
     <SafeAreaView className="flex-1 bg-white dark:bg-neutral-900">
@@ -30,6 +20,9 @@ export default function Step3() {
               <Text className="text-lg font-sans text-stone-500 dark:text-stone-400 text-center">
                 Enter your city or town to see nearby centers.
               </Text>
+              <Text className="text-sm font-sans text-stone-400 dark:text-stone-500 text-center">
+                Optional. You can choose one later.
+              </Text>
             </View>
 
             {/* Shared center search — same behavior as the feed's "join your
@@ -41,31 +34,22 @@ export default function Step3() {
                 placeholder="City or town name"
                 onSelect={(center) => {
                   setCenterID(center.id)
-                  setError('')
                 }}
               />
             </View>
-
-            {/* Error Message */}
-            {error ? (
-              <View className="w-full max-w-md self-center mt-4 bg-red-50 dark:bg-red-900/20 rounded-xl p-4">
-                <Text className="text-red-600 dark:text-red-400 font-sans text-center">{error}</Text>
-              </View>
-            ) : null}
           </View>
         </View>
 
         {/* Button */}
         <View className="pb-6">
           <PrimaryButton
-            onPress={handleContinue}
-            disabled={!centerID}
+            onPress={goToNextStep}
             style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
             Continue
           </PrimaryButton>
-          {returnTo && (
-            <Pressable onPress={skipOnboarding} disabled={isSubmitting} style={{ alignSelf: 'center', marginTop: 12 }}>
+          {!centerID && (
+            <Pressable onPress={goToNextStep} style={{ alignSelf: 'center', marginTop: 12 }}>
               <Text className="text-sm font-sans text-stone-400 dark:text-stone-500">Skip for now</Text>
             </Pressable>
           )}

--- a/packages/frontend/components/onboarding/step4.tsx
+++ b/packages/frontend/components/onboarding/step4.tsx
@@ -1,12 +1,11 @@
 import { View, Text, Pressable } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import React, { useState } from 'react'
+import React from 'react'
 import { useOnboarding } from '../contexts'
 import { PrimaryButton } from '../ui'
 
 export default function Step4() {
-  const { goToNextStep, interests, setInterests, skipOnboarding, returnTo, isSubmitting } = useOnboarding()
-  const [error, setError] = useState<string | null>(null)
+  const { goToNextStep, interests, setInterests } = useOnboarding()
   const interestOptions = [
     'Satsangs',
     'Bhiksha',
@@ -24,14 +23,6 @@ export default function Step4() {
     }
   }
 
-  const handleContinue = () => {
-    if (interests.length === 0) {
-      setError('Please select at least one interest')
-      return
-    }
-    goToNextStep()
-  }
-
   return (
     <SafeAreaView className="flex-1 bg-white dark:bg-neutral-900">
       <View className="max-w-[720px] w-full flex-1 self-center px-6">
@@ -44,6 +35,9 @@ export default function Step4() {
               </Text>
               <Text className="text-lg font-sans text-stone-500 dark:text-stone-400 text-center">
                 Select topics that interest you to personalize your experience.
+              </Text>
+              <Text className="text-sm font-sans text-stone-400 dark:text-stone-500 text-center">
+                Optional. You can update these later.
               </Text>
             </View>
 
@@ -72,29 +66,19 @@ export default function Step4() {
                 )
               })}
             </View>
-
-            {/* Error Message */}
-            {error && (
-              <View className="w-full max-w-md self-center mt-4 bg-red-50 dark:bg-red-900/20 rounded-xl p-4">
-                <Text className="text-red-600 dark:text-red-400 font-sans text-center">
-                  {error}
-                </Text>
-              </View>
-            )}
           </View>
         </View>
 
         {/* Button */}
         <View className="pb-6">
           <PrimaryButton
-            onPress={handleContinue}
-            disabled={interests.length === 0}
+            onPress={goToNextStep}
             style={{ width: '100%', maxWidth: 448, alignSelf: 'center' }}
           >
             Continue
           </PrimaryButton>
-          {returnTo && (
-            <Pressable onPress={skipOnboarding} disabled={isSubmitting} style={{ alignSelf: 'center', marginTop: 12 }}>
+          {interests.length === 0 && (
+            <Pressable onPress={goToNextStep} style={{ alignSelf: 'center', marginTop: 12 }}>
               <Text className="text-sm font-sans text-stone-400 dark:text-stone-500">
                 Skip for now
               </Text>

--- a/packages/frontend/components/ui/AuthPromptModal.tsx
+++ b/packages/frontend/components/ui/AuthPromptModal.tsx
@@ -1,47 +1,210 @@
-import { useEffect } from 'react'
-import { View, Text, Pressable, Modal, Platform } from 'react-native'
+import { useCallback, useEffect, useState } from 'react'
+import { View, Text, Pressable, Modal, Platform, Image, TextInput } from 'react-native'
 import { useRouter } from 'expo-router'
+import { useUser } from '../contexts'
+import { useAnalytics } from '../../utils/analytics'
+import { validateEmail, validatePassword } from '../../utils'
+import { extractInviteCode } from '../../utils/validation'
+import PasswordStrength from '../auth/PasswordStrength'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import PrimaryButton from './buttons/PrimaryButton'
 import SecondaryButton from './buttons/SecondaryButton'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const swamiChinmayanandaJpg = require('../../assets/images/landing/Swami Chinmayananda.jpg')
+const swamiChinmayanandaAlt = require('../../assets/images/landing/Swami Chinmayananda (1).jpg')
+const swamiChinmayanandaOption2 = require('../../assets/images/landing/Swami Chinmayananda Option 2.jpeg')
+
+const AUTH_CAROUSEL_IMAGES = [
+  swamiChinmayanandaJpg,
+  swamiChinmayanandaAlt,
+  swamiChinmayanandaOption2,
+]
+
+type AuthStep = 'initial' | 'login' | 'signup'
 
 interface AuthPromptModalProps {
   visible: boolean
   onClose: () => void
   returnTo: string
   eventTitle?: string
+  title?: string
+  subtitle?: string
+  bullets?: string[]
 }
 
-export default function AuthPromptModal({ visible, onClose, returnTo, eventTitle }: AuthPromptModalProps) {
+export default function AuthPromptModal({
+  visible,
+  onClose,
+  returnTo,
+  eventTitle,
+  title,
+  subtitle,
+  bullets,
+}: AuthPromptModalProps) {
   const router = useRouter()
+  const { login, signup, loading } = useUser()
+  const { track } = useAnalytics()
   const colors = useDetailColors()
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    Platform.OS === 'web' && typeof window !== 'undefined' ? window.innerWidth : 1024
+  )
+  const [authStep, setAuthStep] = useState<AuthStep>('initial')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
 
-  const encoded = encodeURIComponent(returnTo)
+  const trimmedEmail = email.trim()
 
-  const handleSignUp = () => {
+  const resetAuthState = useCallback(() => {
+    setAuthStep('initial')
+    setEmail('')
+    setPassword('')
+    setConfirmPassword('')
+    setErrors({})
+  }, [])
+
+  const closePrompt = useCallback(() => {
+    resetAuthState()
     onClose()
-    router.push(`/auth?mode=signup&returnTo=${encoded}&inviteCode=PUBLIC-EXPLORE`)
-  }
+  }, [onClose, resetAuthState])
 
-  const handleLogIn = () => {
-    onClose()
-    router.push(`/auth?mode=login&returnTo=${encoded}`)
-  }
+  const validateEmailStep = useCallback(() => {
+    setErrors({})
+    if (!trimmedEmail) {
+      setErrors({ email: 'Please enter your email.' })
+      return false
+    }
+    if (!validateEmail(trimmedEmail)) {
+      setErrors({ email: 'Enter a valid email address.' })
+      return false
+    }
+    return true
+  }, [trimmedEmail])
+
+  const handleStartSignup = useCallback(() => {
+    if (!validateEmailStep()) return
+    track('auth_signup_started', { source: 'auth_modal' })
+    setAuthStep('signup')
+  }, [track, validateEmailStep])
+
+  const handleStartLogin = useCallback(() => {
+    if (!validateEmailStep()) return
+    track('auth_login_started', { source: 'auth_modal' })
+    setAuthStep('login')
+  }, [track, validateEmailStep])
+
+  const handleBack = useCallback(() => {
+    track('auth_back_pressed', { source: 'auth_modal', from_step: authStep })
+    setAuthStep('initial')
+    setPassword('')
+    setConfirmPassword('')
+    setErrors({})
+  }, [authStep, track])
+
+  const handleLogin = useCallback(async () => {
+    setErrors({})
+    if (!password) {
+      setErrors({ password: 'Please enter your password.' })
+      return
+    }
+
+    try {
+      const result = await login(trimmedEmail, password)
+      if (result.success) {
+        track('login_success', { source: 'auth_modal' })
+        closePrompt()
+        router.replace(returnTo ? (returnTo as never) : '/')
+      } else {
+        track('login_failed', { source: 'auth_modal', reason: result.message })
+        setErrors({ form: result.message || 'Username or password is incorrect.' })
+      }
+    } catch {
+      track('login_failed', { source: 'auth_modal', reason: 'network_error' })
+      setErrors({ form: 'Failed to connect to server. Please try again.' })
+    }
+  }, [closePrompt, login, password, returnTo, router, track, trimmedEmail])
+
+  const handleSignup = useCallback(async () => {
+    setErrors({})
+    if (!password) {
+      setErrors({ password: 'Please enter a password.' })
+      return
+    }
+    if (!validatePassword(password).isValid) {
+      setErrors({ password: 'Password does not meet complexity requirements.' })
+      return
+    }
+    if (password !== confirmPassword) {
+      setErrors({ confirmPassword: 'Passwords do not match.' })
+      return
+    }
+
+    try {
+      const result = await signup(trimmedEmail, password, extractInviteCode('PUBLIC-EXPLORE'))
+      if (result.success) {
+        track('signup_success', { source: 'auth_modal' })
+        closePrompt()
+        router.replace(returnTo ? (`/onboarding?returnTo=${encodeURIComponent(returnTo)}` as never) : '/onboarding')
+      } else {
+        track('signup_failed', { source: 'auth_modal', reason: result.message })
+        setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
+      }
+    } catch {
+      track('signup_failed', { source: 'auth_modal', reason: 'network_error' })
+      setErrors({ form: 'Failed to connect to server. Please try again.' })
+    }
+  }, [closePrompt, confirmPassword, password, returnTo, router, signup, track, trimmedEmail])
 
   // Web: close on Escape key
   useEffect(() => {
     if (Platform.OS !== 'web' || !visible) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') closePrompt()
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [visible, onClose])
+  }, [visible, closePrompt])
+
+  useEffect(() => {
+    if (!visible) resetAuthState()
+  }, [resetAuthState, visible])
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return
+
+    const onResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   if (!visible) return null
 
   // Use a portal-style overlay on web for better z-index handling
   if (Platform.OS === 'web') {
+    const isDesktop = viewportWidth >= 820
+    const modalWidth = isDesktop ? 860 : 380
+    const promptTitle = title ?? 'Sign up to attend.'
+    const promptCopy = subtitle ?? (eventTitle
+      ? `Create a free account to register for ${eventTitle}`
+      : 'Create a free account to register for events')
+    const promptBullets = bullets ?? [
+      'RSVP in a tap and keep event details handy',
+      'See updates from your center and community',
+      'Discover more satsangs, camps, and classes nearby',
+    ]
+    const stepTitle = authStep === 'login'
+      ? 'Welcome back.'
+      : authStep === 'signup'
+        ? 'Create your account.'
+        : promptTitle
+    const stepCopy = authStep === 'login'
+      ? 'Enter your password to continue.'
+      : authStep === 'signup'
+        ? 'Set a password to continue to onboarding.'
+        : promptCopy
+
     return (
       <View
         style={{
@@ -54,59 +217,270 @@ export default function AuthPromptModal({ visible, onClose, returnTo, eventTitle
           justifyContent: 'center',
           alignItems: 'center',
           zIndex: 9999,
+          padding: isDesktop ? 24 : 16,
         }}
       >
         <Pressable
           style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-          onPress={onClose}
+          onPress={closePrompt}
         />
         <View
           style={{
             backgroundColor: colors.panelBg,
-            borderRadius: 16,
-            padding: 28,
-            width: 360,
-            maxWidth: '90%',
-            gap: 16,
+            borderRadius: isDesktop ? 22 : 18,
+            width: modalWidth,
+            maxWidth: '100%',
+            minHeight: isDesktop ? 520 : undefined,
+            overflow: 'hidden',
+            flexDirection: isDesktop ? 'row' : 'column',
             shadowColor: '#000',
-            shadowOpacity: 0.15,
-            shadowRadius: 20,
-            shadowOffset: { width: 0, height: 8 },
+            shadowOpacity: 0.2,
+            shadowRadius: 30,
+            shadowOffset: { width: 0, height: 14 },
           }}
         >
-          <Text style={{ fontSize: 20, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
-            Sign up to attend
-          </Text>
-          <Text style={{ fontSize: 15, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 22 }}>
-            {eventTitle
-              ? `Create a free account to register for ${eventTitle}`
-              : 'Create a free account to register for events'}
-          </Text>
-          <View style={{ gap: 10, marginTop: 4 }}>
-            <PrimaryButton onPress={handleSignUp}>
-              Sign Up
-            </PrimaryButton>
-            <SecondaryButton onPress={handleLogIn}>
-              Log In
-            </SecondaryButton>
-          </View>
-          <Pressable onPress={onClose} style={{ alignSelf: 'center', paddingTop: 4 }}>
-            <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textMuted }}>
-              Maybe later
+          {isDesktop && (
+            <View style={{ width: '48%', position: 'relative', backgroundColor: '#E7D5CC' }}>
+              <Image
+                source={AUTH_CAROUSEL_IMAGES[0]}
+                style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, width: '100%', height: '100%' }}
+                resizeMode="cover"
+              />
+              <View
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  height: '58%',
+                  backgroundImage: 'linear-gradient(to top, rgba(28,25,23,0.74), rgba(28,25,23,0.38), rgba(28,25,23,0))' as any,
+                }}
+              />
+              <View style={{ position: 'absolute', left: 28, right: 28, bottom: 28, gap: 8 }}>
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 24, lineHeight: 30, color: '#FFFFFF' }}>
+                  Janata
+                </Text>
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, lineHeight: 21, color: '#F5F5F4' }}>
+                  Community events, satsangs, and local gatherings in one place.
+                </Text>
+              </View>
+            </View>
+          )}
+
+          <Pressable
+            onPress={closePrompt}
+            accessibilityRole="button"
+            accessibilityLabel="Close sign up prompt"
+            style={({ pressed }) => ({
+              position: 'absolute',
+              top: 14,
+              right: 14,
+              width: 36,
+              height: 36,
+              borderRadius: 18,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: pressed ? 'rgba(28,25,23,0.10)' : isDesktop ? 'rgba(255,255,255,0.86)' : 'transparent',
+              zIndex: 2,
+            })}
+          >
+            <Text style={{ fontSize: 24, lineHeight: 26, fontFamily: 'Inclusive Sans', color: '#1C1917' }}>
+              {'\u00d7'}
             </Text>
           </Pressable>
+
+          <View
+            style={{
+              flex: 1,
+              backgroundColor: '#FAFAF7',
+              paddingHorizontal: isDesktop ? 48 : 28,
+              paddingTop: isDesktop ? 64 : 58,
+              paddingBottom: isDesktop ? 44 : 28,
+              justifyContent: 'center',
+            }}
+          >
+            <View style={{ gap: 20 }}>
+              <View style={{ gap: 10 }}>
+                <Text
+                  style={{
+                    fontSize: isDesktop ? 36 : 24,
+                    lineHeight: isDesktop ? 42 : 30,
+                    fontFamily: 'Inclusive Sans',
+                    fontWeight: '400',
+                    color: '#1C1917',
+                  }}
+                >
+                  {stepTitle}
+                </Text>
+                <Text
+                  style={{
+                    fontSize: 16,
+                    fontFamily: 'Inclusive Sans',
+                    color: '#78716C',
+                    lineHeight: 24,
+                  }}
+                >
+                  {stepCopy}
+                </Text>
+              </View>
+
+              {isDesktop && authStep === 'initial' && (
+                <View style={{ gap: 9 }}>
+                  {promptBullets.map((line) => (
+                    <View key={line} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
+                      <Text style={{ color: '#C2410C', fontSize: 15, lineHeight: 22 }}>{'\u2713'}</Text>
+                      <Text style={{ flex: 1, fontFamily: 'Inclusive Sans', fontSize: 14.5, lineHeight: 22, color: '#57534E' }}>
+                        {line}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+
+              <View style={{ gap: 12, marginTop: 4 }}>
+                {authStep !== 'initial' && (
+                  <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#C2410C' }}>
+                      Back
+                    </Text>
+                  </Pressable>
+                )}
+                <TextInput
+                  value={email}
+                  onChangeText={(value) => {
+                    setEmail(value)
+                    setErrors((prev) => ({ ...prev, email: '', form: '' }))
+                  }}
+                  placeholder="Email"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  editable={authStep === 'initial'}
+                  placeholderTextColor="#9CA3AF"
+                  style={{
+                    width: '100%',
+                    height: 48,
+                    borderWidth: 1,
+                    borderColor: '#D6D3D1',
+                    borderRadius: 8,
+                    paddingHorizontal: 16,
+                    fontSize: 16,
+                    fontFamily: 'Inclusive Sans',
+                    color: authStep === 'initial' ? '#1C1917' : '#57534E',
+                    backgroundColor: '#FFFFFF',
+                  }}
+                />
+                {errors.email ? <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#B91C1C' }}>{errors.email}</Text> : null}
+
+                {authStep !== 'initial' && (
+                  <>
+                    <TextInput
+                      value={password}
+                      onChangeText={(value) => {
+                        setPassword(value)
+                        setErrors((prev) => ({ ...prev, password: '', form: '' }))
+                      }}
+                      placeholder="Password"
+                      secureTextEntry
+                      placeholderTextColor="#9CA3AF"
+                      style={{
+                        width: '100%',
+                        height: 48,
+                        borderWidth: 1,
+                        borderColor: '#D6D3D1',
+                        borderRadius: 8,
+                        paddingHorizontal: 16,
+                        fontSize: 16,
+                        fontFamily: 'Inclusive Sans',
+                        color: '#1C1917',
+                        backgroundColor: '#FFFFFF',
+                      }}
+                    />
+                    {errors.password ? <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#B91C1C' }}>{errors.password}</Text> : null}
+                  </>
+                )}
+
+                {authStep === 'signup' && (
+                  <>
+                    <PasswordStrength password={password} show={password.length > 0} />
+                    <TextInput
+                      value={confirmPassword}
+                      onChangeText={(value) => {
+                        setConfirmPassword(value)
+                        setErrors((prev) => ({ ...prev, confirmPassword: '', form: '' }))
+                      }}
+                      placeholder="Confirm password"
+                      secureTextEntry
+                      placeholderTextColor="#9CA3AF"
+                      style={{
+                        width: '100%',
+                        height: 48,
+                        borderWidth: 1,
+                        borderColor: '#D6D3D1',
+                        borderRadius: 8,
+                        paddingHorizontal: 16,
+                        fontSize: 16,
+                        fontFamily: 'Inclusive Sans',
+                        color: '#1C1917',
+                        backgroundColor: '#FFFFFF',
+                      }}
+                    />
+                    {errors.confirmPassword ? <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#B91C1C' }}>{errors.confirmPassword}</Text> : null}
+                  </>
+                )}
+
+                {errors.form ? <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#B91C1C', lineHeight: 18 }}>{errors.form}</Text> : null}
+
+                {authStep === 'initial' ? (
+                  <>
+                    <PrimaryButton onPress={handleStartSignup} disabled={!trimmedEmail || loading} style={{ borderRadius: 8 }}>
+                      Sign Up
+                    </PrimaryButton>
+                    <SecondaryButton
+                      onPress={handleStartLogin}
+                      disabled={!trimmedEmail || loading}
+                      style={{ borderRadius: 8, backgroundColor: '#FFFFFF' }}
+                    >
+                      Log In
+                    </SecondaryButton>
+                  </>
+                ) : authStep === 'login' ? (
+                  <PrimaryButton onPress={handleLogin} disabled={!password || loading} style={{ borderRadius: 8 }}>
+                    Log In
+                  </PrimaryButton>
+                ) : (
+                  <PrimaryButton onPress={handleSignup} disabled={!password || !confirmPassword || loading} style={{ borderRadius: 8 }}>
+                    Create Account
+                  </PrimaryButton>
+                )}
+              </View>
+            </View>
+          </View>
         </View>
       </View>
     )
   }
 
   // Native fallback using Modal
+  const nativeTitle = authStep === 'login'
+    ? 'Welcome back'
+    : authStep === 'signup'
+      ? 'Create your account'
+      : title ?? 'Sign up to attend'
+  const nativeCopy = authStep === 'login'
+    ? 'Enter your password to continue.'
+    : authStep === 'signup'
+      ? 'Set a password to continue to onboarding.'
+      : subtitle ?? (eventTitle
+        ? `Create a free account to register for ${eventTitle}`
+        : 'Create a free account to register for events')
+
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={closePrompt}>
       <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' }}>
         <Pressable
           style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-          onPress={onClose}
+          onPress={closePrompt}
         />
         <View
           style={{
@@ -119,22 +493,125 @@ export default function AuthPromptModal({ visible, onClose, returnTo, eventTitle
           }}
         >
           <Text style={{ fontSize: 20, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
-            Sign up to attend
+            {nativeTitle}
           </Text>
           <Text style={{ fontSize: 15, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 22 }}>
-            {eventTitle
-              ? `Create a free account to register for ${eventTitle}`
-              : 'Create a free account to register for events'}
+            {nativeCopy}
           </Text>
           <View style={{ gap: 10, marginTop: 4 }}>
-            <PrimaryButton onPress={handleSignUp}>
-              Sign Up
-            </PrimaryButton>
-            <SecondaryButton onPress={handleLogIn}>
-              Log In
-            </SecondaryButton>
+            {authStep !== 'initial' && (
+              <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
+                <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: '#C2410C' }}>
+                  Back
+                </Text>
+              </Pressable>
+            )}
+            <TextInput
+              value={email}
+              onChangeText={(value) => {
+                setEmail(value)
+                setErrors((prev) => ({ ...prev, email: '', form: '' }))
+              }}
+              placeholder="Email"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={authStep === 'initial'}
+              placeholderTextColor={colors.textMuted}
+              style={{
+                width: '100%',
+                height: 48,
+                borderWidth: 1,
+                borderColor: colors.border,
+                borderRadius: 8,
+                paddingHorizontal: 16,
+                fontSize: 16,
+                fontFamily: 'Inclusive Sans',
+                color: authStep === 'initial' ? colors.text : colors.textSecondary,
+                backgroundColor: colors.cardBg,
+              }}
+            />
+            {errors.email ? <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C' }}>{errors.email}</Text> : null}
+
+            {authStep !== 'initial' && (
+              <>
+                <TextInput
+                  value={password}
+                  onChangeText={(value) => {
+                    setPassword(value)
+                    setErrors((prev) => ({ ...prev, password: '', form: '' }))
+                  }}
+                  placeholder="Password"
+                  secureTextEntry
+                  placeholderTextColor={colors.textMuted}
+                  style={{
+                    width: '100%',
+                    height: 48,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    borderRadius: 8,
+                    paddingHorizontal: 16,
+                    fontSize: 16,
+                    fontFamily: 'Inclusive Sans',
+                    color: colors.text,
+                    backgroundColor: colors.cardBg,
+                  }}
+                />
+                {errors.password ? <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C' }}>{errors.password}</Text> : null}
+              </>
+            )}
+
+            {authStep === 'signup' && (
+              <>
+                <PasswordStrength password={password} show={password.length > 0} />
+                <TextInput
+                  value={confirmPassword}
+                  onChangeText={(value) => {
+                    setConfirmPassword(value)
+                    setErrors((prev) => ({ ...prev, confirmPassword: '', form: '' }))
+                  }}
+                  placeholder="Confirm password"
+                  secureTextEntry
+                  placeholderTextColor={colors.textMuted}
+                  style={{
+                    width: '100%',
+                    height: 48,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    borderRadius: 8,
+                    paddingHorizontal: 16,
+                    fontSize: 16,
+                    fontFamily: 'Inclusive Sans',
+                    color: colors.text,
+                    backgroundColor: colors.cardBg,
+                  }}
+                />
+                {errors.confirmPassword ? <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C' }}>{errors.confirmPassword}</Text> : null}
+              </>
+            )}
+
+            {errors.form ? <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C', lineHeight: 18 }}>{errors.form}</Text> : null}
+
+            {authStep === 'initial' ? (
+              <>
+                <PrimaryButton onPress={handleStartSignup} disabled={!trimmedEmail || loading}>
+                  Sign Up
+                </PrimaryButton>
+                <SecondaryButton onPress={handleStartLogin} disabled={!trimmedEmail || loading}>
+                  Log In
+                </SecondaryButton>
+              </>
+            ) : authStep === 'login' ? (
+              <PrimaryButton onPress={handleLogin} disabled={!password || loading}>
+                Log In
+              </PrimaryButton>
+            ) : (
+              <PrimaryButton onPress={handleSignup} disabled={!password || !confirmPassword || loading}>
+                Create Account
+              </PrimaryButton>
+            )}
           </View>
-          <Pressable onPress={onClose} style={{ alignSelf: 'center', paddingTop: 4 }}>
+          <Pressable onPress={closePrompt} style={{ alignSelf: 'center', paddingTop: 4 }}>
             <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textMuted }}>
               Maybe later
             </Text>


### PR DESCRIPTION
## Summary
- make birthday, center, and interests onboarding steps optional with explicit skip affordances
- upgrade the auth prompt modal to a split desktop form and email-first native/web prompt
- preserve invite-code signup links while keeping email editable when it is not prefilled

## Verification
- npm run test:frontend
- npm run build:frontend
- git diff --check

Note: npx tsc --noEmit -p packages/frontend/tsconfig.json still fails on existing unrelated type errors in explore.web.tsx, _layout.tsx, notifications.tsx, EventCard.tsx, and WebBottomNav.test.tsx.