### PR TITLE
fix(backend): isolate staging from prod DB + drop committed preview JWT secrets

### DIFF
--- a/packages/backend/wrangler.preview.toml
+++ b/packages/backend/wrangler.preview.toml
@@ -1,8 +1,8 @@
 # Chinmaya Janata API — v2 PREVIEW worker
 #
-# Fully isolated test environment for the v2 sprint. Unlike wrangler.staging.toml
-# (which shares the prod D1!), this binds to its OWN database so test writes
-# never touch production data.
+# Fully isolated test environment for the v2 sprint. Binds its OWN database so
+# test writes never touch production data. (wrangler.staging.toml is likewise
+# isolated now, its own chinmaya-janata-db-staging, see issue #406.)
 #
 # Deploy: npx wrangler deploy --config packages/backend/wrangler.preview.toml
 # URL:    https://chinmaya-janata-api-v2preview.<account>.workers.dev
@@ -28,10 +28,13 @@ binding = "AVATARS"
 # want total isolation here too.
 bucket_name = "chinmaya-janata-avatars"
 
+# Non-secret vars only. JWT_SECRET / JWT_REFRESH_SECRET come from
+# `wrangler secret put` (see below). Never commit signing secrets: anyone who
+# can read the repo could otherwise mint valid preview tokens.
 [vars]
-JWT_SECRET = "dev-secret-key-change-in-production"
-JWT_REFRESH_SECRET = "dev-refresh-secret-key-change-in-production"
 RESEND_FROM_EMAIL = "noreply@chinmayajanata.org"
 
-# Secrets (optional — email verification only):
-#   npx wrangler secret put RESEND_API_KEY --config packages/backend/wrangler.preview.toml
+# Secrets (set once per worker, NOT in this file):
+#   npx wrangler secret put JWT_SECRET         --config packages/backend/wrangler.preview.toml
+#   npx wrangler secret put JWT_REFRESH_SECRET --config packages/backend/wrangler.preview.toml
+#   npx wrangler secret put RESEND_API_KEY     --config packages/backend/wrangler.preview.toml  (email verification only)

--- a/packages/backend/wrangler.staging.toml
+++ b/packages/backend/wrangler.staging.toml
@@ -1,5 +1,8 @@
 # Chinmaya Janata API - Staging Worker
 # Auto-deployed on every push to main.
+#
+# Binds its OWN D1 (chinmaya-janata-db-staging), isolated from production.
+# Provision/seed it with: bash scripts/db/setup-staging-db.sh
 
 name = "chinmaya-janata-api-staging"
 main = "src/worker.ts"
@@ -7,8 +10,8 @@ compatibility_date = "2026-02-26"
 
 [[d1_databases]]
 binding = "DB"
-database_name = "chinmaya-janata-db"
-database_id = "d38b4cd2-963b-45eb-9f83-1e72f9d3aa5d"
+database_name = "chinmaya-janata-db-staging"
+database_id = "e8ab870b-2f2b-42f0-94b7-5b631e314676"
 
 [[r2_buckets]]
 binding = "AVATARS"

--- a/scripts/db/setup-staging-db.sh
+++ b/scripts/db/setup-staging-db.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/db/setup-staging-db.sh: provision the isolated staging D1.
+#
+# The staging worker (wrangler.staging.toml) auto-deploys on every push to main.
+# It binds chinmaya-janata-db-staging, which is SEPARATE from the production
+# database, so staging writes never touch real user data (see issue #406).
+#
+# Applies every schema migration (0001 → latest) against the staging database,
+# then loads real centers + demo data so the staging API has something to serve.
+#
+# Safe to re-run only on a FRESH `wrangler d1 create chinmaya-janata-db-staging`.
+# To start over: delete + recreate the D1, then run this once.
+#
+# Prereq: wrangler authed (npx wrangler login) and the database_id in
+# packages/backend/wrangler.staging.toml pointing at the staging D1.
+#
+# Usage: bash scripts/db/setup-staging-db.sh
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+CONFIG="packages/backend/wrangler.staging.toml"
+DB_NAME="chinmaya-janata-db-staging"
+
+if grep -q 'database_id = "d38b4cd2-963b-45eb-9f83-1e72f9d3aa5d"' "$CONFIG"; then
+  echo "✗ wrangler.staging.toml still points at the PRODUCTION database_id." >&2
+  echo "  Rebind it to the staging D1 before running this script." >&2
+  exit 1
+fi
+
+# Data-only migrations are SKIPPED: they seed real Chinmaya data and several
+# assume column orderings that only held mid-history (e.g. 0002 inserts a
+# `website` value before 0003 adds the column). On a clean replay they fail,
+# and staging replaces their data with the seed files below anyway. We apply
+# only the schema-defining migrations (CREATE/ALTER), in order.
+SKIP_DATA_ONLY="0002 0007 0008 0010 0012 0013"
+
+echo "▶ Applying SCHEMA migrations to $DB_NAME (fresh staging DB)"
+for f in migrations/0[0-9][0-9][0-9]_*.sql; do
+  base="$(basename "$f")"
+  num="${base%%_*}"
+  if echo " $SKIP_DATA_ONLY " | grep -q " $num "; then
+    echo "  ↳ skip $base (data-only)"
+    continue
+  fi
+  echo "  → $base"
+  npx wrangler d1 execute "$DB_NAME" --remote --file="$f" --config "$CONFIG" >/dev/null 2>&1 \
+    || { echo "✗ FAILED on $base" >&2; exit 1; }
+done
+
+echo "▶ Loading real centers (packages/backend/src/seed/centers.sql)"
+npx wrangler d1 execute "$DB_NAME" --remote --file=packages/backend/src/seed/centers.sql --config "$CONFIG" >/dev/null 2>&1 \
+  || { echo "✗ FAILED seeding real centers" >&2; exit 1; }
+echo "▶ Loading demo events (on top of real centers)"
+npx wrangler d1 execute "$DB_NAME" --remote --file=migrations/seed_preview_data.sql --config "$CONFIG" >/dev/null 2>&1 \
+  || { echo "✗ FAILED seeding demo data" >&2; exit 1; }
+
+echo
+echo "✓ Staging DB ready. Centers + events seeded."
+echo "  Remember to set the staging worker secrets (once):"
+echo "    npx wrangler secret put JWT_SECRET         --config $CONFIG"
+echo "    npx wrangler secret put JWT_REFRESH_SECRET --config $CONFIG"
+echo "    npx wrangler secret put RESEND_API_KEY     --config $CONFIG"


### PR DESCRIPTION
Closes #406. Closes #407.

## #406 — Staging worker wrote to the production database

`wrangler.staging.toml` bound the **same** D1 as prod (`d38b4cd2…`), and `deploy.yml` auto-deploys the staging worker on every push to `main`. Any staging seed, migration, or test write landed directly in production data.

**Fix:**
- Created a dedicated staging D1: `chinmaya-janata-db-staging` (`e8ab870b-2f2b-42f0-94b7-5b631e314676`)
- Rebound `wrangler.staging.toml` to it
- Applied the full schema (migrations `0001`–`0026`) to the new DB plus a smoke dataset (3 real centers + 4 demo events), verified: 19 tables, isolated uuid, board_posts rebuild clean
- Added `scripts/db/setup-staging-db.sh` (mirrors the preview setup) to reproduce provisioning on a fresh staging D1

The staging worker now reads/writes its own database. Production data is untouched by staging deploys.

## #407 — Forgeable JWT secrets committed in wrangler.preview.toml

`JWT_SECRET` / `JWT_REFRESH_SECRET` were hardcoded in the committed preview config, so anyone with repo read access could mint valid preview tokens (and the preview worker reuses the prod avatars R2 bucket).

**Fix:** Removed both vars from `wrangler.preview.toml`. They now come from `wrangler secret put`, the same way prod and staging already handle them. Also corrected the stale comment that said staging shares the prod D1.

## Required follow-up before relying on these workers (one-time, needs wrangler auth)

Both the **staging** and **preview** workers now need their JWT secrets set, or auth will break on them:

```
npx wrangler secret put JWT_SECRET         --config packages/backend/wrangler.staging.toml
npx wrangler secret put JWT_REFRESH_SECRET --config packages/backend/wrangler.staging.toml
npx wrangler secret put JWT_SECRET         --config packages/backend/wrangler.preview.toml
npx wrangler secret put JWT_REFRESH_SECRET --config packages/backend/wrangler.preview.toml
```

Optional: layer the full 91-center catalog onto staging (idempotent upsert):

```
npx wrangler d1 execute chinmaya-janata-db-staging --remote \
  --file=packages/backend/src/seed/centers.sql --config packages/backend/wrangler.staging.toml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)