### PR TITLE
fix(ci): set preview JWT secrets at deploy time (follow-up to #407)

### DIFF
--- a/scripts/ci/deploy-v2preview.sh
+++ b/scripts/ci/deploy-v2preview.sh
@@ -77,6 +77,20 @@ WR d1 execute "$DB_NAME" --remote --config "$CONFIG" --file=migrations/seed_prev
 echo "▶ (3/7) Deploy preview worker"
 WR deploy --config "$CONFIG"
 
+echo "▶ (3b/7) Set JWT signing secrets (never committed, see #407)"
+# JWT_SECRET / JWT_REFRESH_SECRET used to be plaintext [vars] in
+# wrangler.preview.toml. They were removed (anyone with repo read could forge
+# preview tokens), so the worker now needs them as real secrets. Preview is
+# ephemeral, the D1 is reset and role users reseeded every run, so a fresh
+# random secret per deploy is fine and keeps this pipeline self-contained (no
+# extra CI secret to manage). Set PREVIEW_JWT_SECRET / PREVIEW_JWT_REFRESH_SECRET
+# in the env to pin stable values instead. Runs AFTER deploy so the old plaintext
+# var is gone first (a name can't be both a var and a secret).
+JWT_SECRET_VAL="${PREVIEW_JWT_SECRET:-$(openssl rand -hex 32)}"
+JWT_REFRESH_VAL="${PREVIEW_JWT_REFRESH_SECRET:-$(openssl rand -hex 32)}"
+printf '%s' "$JWT_SECRET_VAL"  | WR secret put JWT_SECRET         --config "$CONFIG"
+printf '%s' "$JWT_REFRESH_VAL" | WR secret put JWT_REFRESH_SECRET --config "$CONFIG"
+
 echo "▶ (4/7) Wait for worker health"
 ok=""
 for i in $(seq 1 20); do


### PR DESCRIPTION
Follow-up to #411 (#407).

## Why
#407 removed the committed `JWT_SECRET` / `JWT_REFRESH_SECRET` from `wrangler.preview.toml`. But the v2preview deploy pipeline (`deploy-v2preview.yml` → `scripts/ci/deploy-v2preview.sh`) never set those as real secrets — it relied entirely on the committed plaintext vars. So after #411, a preview deploy would produce a worker with **no signing secret**: login/signup 500s, and the role-user seeding step (5/7) fails the whole run.

This was the gap between "secret removed from the file" and "preview still deployable."

## Fix
`deploy-v2preview.sh` now sets the secrets via `wrangler secret put` right after deploy:
- Generates a fresh random secret per run by default. Preview is ephemeral — the D1 is reset and role users are reseeded on every deploy — so per-run secrets are correct and keep the pipeline self-contained (no new GitHub secret to manage).
- Override with `PREVIEW_JWT_SECRET` / `PREVIEW_JWT_REFRESH_SECRET` env vars if you want stable preview tokens across deploys.
- Runs after `wrangler deploy` so the old plaintext var is gone first (a name can't be both a var and a secret).

No secret is ever committed. `bash -n` clean.

## Testing the preview after this merges
Trigger **Deploy v2 Preview** (Actions → workflow_dispatch, or push to `deploy/v2preview`). The run deploys an isolated worker + fresh D1 + seeded logins at `https://v2preview.project-janatha.pages.dev`, with the signing secret set from `secret put` instead of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)