### PR TITLE
fix: harden credentialed auth surfaces

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -123,6 +123,21 @@ describe('GET /api/health', () => {
     expect(res.headers.get('X-Frame-Options')).toBe('DENY')
     expect(res.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin')
   })
+
+  it('only allows explicit credentialed CORS origins', async () => {
+    const allowed = await fetchApp('/api/health', {
+      headers: { Origin: 'https://main.project-janatha.pages.dev' },
+    })
+    expect(allowed.headers.get('Access-Control-Allow-Origin')).toBe('https://main.project-janatha.pages.dev')
+    expect(allowed.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+
+    const preview = await fetchApp('/api/health', {
+      headers: { Origin: 'https://random-preview.project-janatha.pages.dev' },
+    })
+    expect(preview.headers.get('Access-Control-Allow-Origin')).not.toBe(
+      'https://random-preview.project-janatha.pages.dev'
+    )
+  })
 })
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -223,8 +223,6 @@ app.use(
       ]
       if (allowed.includes(origin)) return origin
       if (origin.startsWith('http://localhost:')) return origin
-      if (origin.endsWith('.project-janatha.pages.dev')) return origin
-      if (origin.endsWith('.chinmaya-janata.pages.dev')) return origin // legacy
       return ''
     },
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],

--- a/packages/frontend/src/__tests__/tokenStorage.web.test.ts
+++ b/packages/frontend/src/__tests__/tokenStorage.web.test.ts
@@ -19,6 +19,7 @@ const localStorageMock = {
 
 // ── document.cookie mock ───────────────────────────────────────────────
 let cookieStore = ''
+let lastCookieWrite = ''
 
 // Save originals
 const origWindow = (globalThis as any).window
@@ -34,6 +35,7 @@ beforeEach(() => {
   localStorageMock.setItem.mockClear()
   localStorageMock.removeItem.mockClear()
   cookieStore = ''
+  lastCookieWrite = ''
 
   // Define window so typeof window !== 'undefined' passes
   ;(globalThis as any).window = globalThis
@@ -50,6 +52,7 @@ beforeEach(() => {
         return cookieStore
       },
       set cookie(val: string) {
+        lastCookieWrite = val
         const parts = val.split(';')
         const nameValue = parts[0].trim()
         const eqIdx = nameValue.indexOf('=')
@@ -133,6 +136,8 @@ describe('setStoredToken', () => {
 
     expect(localStorageMock.setItem).toHaveBeenCalledWith(TOKEN_KEY, 'my-token')
     expect(cookieStore).toContain(`${TOKEN_KEY}=my-token`)
+    expect(lastCookieWrite).toContain('Secure')
+    expect(lastCookieWrite).toContain('SameSite=Lax')
   })
 })
 
@@ -170,6 +175,8 @@ describe('removeStoredToken', () => {
     await removeStoredToken()
     expect(localStorageMock.removeItem).toHaveBeenCalledWith(TOKEN_KEY)
     expect(cookieStore).not.toContain(`${TOKEN_KEY}=to-remove`)
+    expect(lastCookieWrite).toContain('Secure')
+    expect(lastCookieWrite).toContain('SameSite=Lax')
   })
 })
 
@@ -207,6 +214,8 @@ describe('cookie fallback when localStorage throws', () => {
 
     await setStoredToken('fallback-token')
     expect(cookieStore).toContain(`${TOKEN_KEY}=fallback-token`)
+    expect(lastCookieWrite).toContain('Secure')
+    expect(lastCookieWrite).toContain('SameSite=Lax')
   })
 
   it('getStoredToken falls back to cookie when localStorage.getItem throws', async () => {

--- a/packages/frontend/src/storage/tokenStorage.web.ts
+++ b/packages/frontend/src/storage/tokenStorage.web.ts
@@ -17,7 +17,7 @@ const setCookie = (name: string, value: string, days: number) => {
     date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
     expires = '; expires=' + date.toUTCString()
   }
-  document.cookie = name + '=' + (value || '') + expires + '; path=/'
+  document.cookie = name + '=' + (value || '') + expires + '; path=/; Secure; SameSite=Lax'
 }
 
 // Helper to get cookie
@@ -36,7 +36,7 @@ const getCookie = (name: string) => {
 // Helper to erase cookie
 const eraseCookie = (name: string) => {
   if (typeof document === 'undefined') return
-  document.cookie = name + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;'
+  document.cookie = name + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Secure; SameSite=Lax'
 }
 
 export const setStoredToken = async (token: string): Promise<void> => {


### PR DESCRIPTION
## Summary
- remove wildcard Pages preview origins from credentialed backend CORS
- add Secure and SameSite=Lax to web auth fallback cookies
- add focused regression coverage for both hardening changes

## Validation
- npm run typecheck
- npm run test:cloudflare:app -- --runInBand
- cd packages/frontend && npx vitest run src/__tests__/tokenStorage.web.test.ts
- git diff --check

Closes #408
Closes #409