### PR TITLE
chore: add dependency hygiene checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: v2
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: v2
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,32 @@
+name: Dependency Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies
+        run: |
+          npm audit --audit-level=moderate || {
+            echo "::warning::npm audit found vulnerabilities at moderate or higher. See the audit output for details."
+            exit 0
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'npm'
 
       - name: Clean install
-        run: rm -rf node_modules package-lock.json && npm install
+        run: npm ci
 
       - name: TypeScript check (backend)
         run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- switch CI installs from deleting the lockfile plus npm install to npm ci
- add weekly Dependabot updates for npm workspaces and GitHub Actions targeting v2
- add a scheduled/manual dependency audit workflow that warns without blocking while current audit findings are unresolved

## Verification
- npm ci --cache .context/npm-cache
- ruby YAML parse check for .github/dependabot.yml, .github/workflows/dependency-audit.yml, and .github/workflows/test.yml
- git diff --check
- npm audit --audit-level=moderate warning path exits 0 and currently reports 21 vulnerabilities: 1 low, 19 moderate, 1 high

Refs #410