### PR TITLE
fix: allow v2 preview origin for API CORS

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -131,6 +131,13 @@ describe('GET /api/health', () => {
     expect(allowed.headers.get('Access-Control-Allow-Origin')).toBe('https://main.project-janatha.pages.dev')
     expect(allowed.headers.get('Access-Control-Allow-Credentials')).toBe('true')
 
+    const v2Preview = await fetchApp('/api/health', {
+      headers: { Origin: 'https://v2preview.project-janatha.pages.dev' },
+    })
+    expect(v2Preview.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://v2preview.project-janatha.pages.dev'
+    )
+
     const preview = await fetchApp('/api/health', {
       headers: { Origin: 'https://random-preview.project-janatha.pages.dev' },
     })

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -216,6 +216,7 @@ app.use(
         'https://www.chinmayajanata.org',
         'https://project-janatha.pages.dev',
         'https://main.project-janatha.pages.dev',
+        'https://v2preview.project-janatha.pages.dev',
         'https://chinmaya-janata.pages.dev', // legacy frozen project
         'http://localhost:8081',
         'http://localhost:8787',


### PR DESCRIPTION
## Summary
- explicitly allow https://v2preview.project-janatha.pages.dev in backend CORS
- extend the existing credentialed CORS allowlist test for the preview branch alias

## Verification
- npm run test:backend
- curl/browser smoke test before this fix showed v2preview API calls blocked by missing Access-Control-Allow-Origin

Refs #410