### PR TITLE
chore: use npm ci for v2 preview deploy

### DIFF
--- a/.github/workflows/deploy-v2preview.yml
+++ b/.github/workflows/deploy-v2preview.yml
@@ -40,7 +40,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: rm -rf node_modules package-lock.json && npm install
+        run: npm ci
 
       - name: Gate — typecheck + backend tests
         run: npm run typecheck && npm run test:backend


### PR DESCRIPTION
## Summary
- switch v2preview deploy dependency install to npm ci
- stop deleting package-lock.json in the preview deploy workflow

## Verification
- ruby YAML parse check for .github/workflows/deploy-v2preview.yml
- git diff --check
- npm ci --cache .context/npm-cache

Refs #410