### PR TITLE
fix: lock linux rolldown binding for ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4085,6 +4085,24 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
       "dev": true,


### PR DESCRIPTION
## Summary
- add the Linux x64 glibc Rolldown optional native binding entry to package-lock.json
- fix v2preview deploy gate under npm ci, where Vitest/Rolldown could not find @rolldown/binding-linux-x64-gnu

## Verification
- node JSON parse for package-lock.json
- npm ci --cache .context/npm-cache
- npm run test:backend
- git diff --check

Follow-up to #427