### PR TITLE
chore: use npm ci in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: rm -rf node_modules package-lock.json && npm install
+        run: npm ci
 
       - name: TypeScript check (backend)
         run: npx tsc --noEmit
@@ -59,7 +59,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: rm -rf node_modules package-lock.json && npm install
+        run: npm ci
 
       - name: TypeScript check (backend)
         run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- use deterministic npm ci installs for staging and production deploy jobs
- keep deploy workflow behavior otherwise unchanged

## Verification
- npm ci --cache .context/npm-cache
- ruby YAML parse for .github/workflows/deploy.yml
- git diff --check

Closes #431