### PR TITLE
chore: update Hono audit baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7982,7 +7982,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.14",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary
- update locked Hono from 4.12.14 to 4.12.23
- removes the Hono advisory from the npm audit baseline
- leaves larger Expo/Cloudflare audit work for separate PRs

## Verification
- npm ci --cache .context/npm-cache
- npm run typecheck
- npm run test:backend
- npm audit --audit-level=moderate --json: total findings reduced from 21 to 20; Hono finding removed

Part of #425