### PR TITLE
chore: update Cloudflare Vitest pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,207 +1288,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.16.0",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.13.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cjs-module-lexer": "^1.2.3",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260317.3",
-        "wrangler": "4.78.0",
-        "zod": "^3.25.76"
-      },
-      "peerDependencies": {
-        "@vitest/runner": "^4.1.0",
-        "@vitest/snapshot": "^4.1.0",
-        "vitest": "^4.1.0"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
-      "integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260317.1",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
-      "integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
-      "integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260317.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
-      "integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
-      "version": "4.20260317.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260317.1",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
-      "version": "7.24.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
-      "version": "1.20260317.1",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260317.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260317.1",
-        "@cloudflare/workerd-linux-64": "1.20260317.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260317.1",
-        "@cloudflare/workerd-windows-64": "1.20260317.1"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-      "version": "4.78.0",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.16.0",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260317.3",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260317.1"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=20.3.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260317.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20260603.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260603.1.tgz",
@@ -15531,11 +15330,37 @@
         "jose": "^6.0.0"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.13.0",
+        "@cloudflare/vitest-pool-workers": "^0.16.13",
         "@cloudflare/workers-types": "^4.20260101.0",
         "typescript": "~5.9.2",
         "vitest": "^4.1.0"
       }
+    },
+    "packages/backend/node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.13.tgz",
+      "integrity": "sha512-nTuEiuLv+YoLrGfftdlBJB3nJJELT/9VVuBlF2JDpnv3uAOCXaZcniP+K5C9Mcg0xSopvFLAL45Q7Hco1hHOLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260603.0",
+        "wrangler": "4.98.0",
+        "zod": "3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "packages/backend/node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/frontend": {
       "name": "@janata/frontend",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.0.0"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.13.0",
+    "@cloudflare/vitest-pool-workers": "^0.16.13",
     "@cloudflare/workers-types": "^4.20260101.0",
     "typescript": "~5.9.2",
     "vitest": "^4.1.0"


### PR DESCRIPTION
## Summary
- update @cloudflare/vitest-pool-workers from ^0.13.0 to ^0.16.13
- removes the old nested Wrangler/Miniflare/ws audit cluster
- reduces npm audit baseline from 20 to 17 findings after #433

## Verification
- npm ci --cache .context/npm-cache
- npm run typecheck
- npm run test:backend: 414 tests passed
- npm audit --audit-level=moderate --json: total findings 17

Part of #425