### PR TITLE
fix: quiet preview console warnings

### DIFF
--- a/packages/frontend/app/(tabs)/chat.tsx
+++ b/packages/frontend/app/(tabs)/chat.tsx
@@ -11,6 +11,7 @@ import {
 import { useNavigation, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAnalytics } from '../../utils/analytics'
+import { supportsNativeDriver } from '../../utils/animation'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import {
@@ -140,7 +141,7 @@ export default function ChatScreen() {
       toValue: 0,
       duration: 280,
       easing: Easing.out(Easing.cubic),
-      useNativeDriver: true,
+      useNativeDriver: supportsNativeDriver,
     }).start()
   }, [detailTranslateX, nativeDetailOpen, width])
 
@@ -166,7 +167,7 @@ export default function ChatScreen() {
         toValue: width,
         duration: 230,
         easing: Easing.in(Easing.cubic),
-        useNativeDriver: true,
+        useNativeDriver: supportsNativeDriver,
       }).start(({ finished }) => {
         if (finished) {
           clearDetailSelection()

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -12,6 +12,7 @@ import {
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAnalytics } from '../../utils/analytics'
+import { supportsNativeDriver } from '../../utils/animation'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { toThreadColors } from '../../tokens'
@@ -374,7 +375,7 @@ export default function FeedScreen() {
       toValue: 0,
       duration: 280,
       easing: Easing.out(Easing.cubic),
-      useNativeDriver: true,
+      useNativeDriver: supportsNativeDriver,
     }).start()
   }, [detailTranslateX, nativeDetailOpen, width])
 
@@ -445,7 +446,7 @@ export default function FeedScreen() {
         toValue: width,
         duration: 230,
         easing: Easing.in(Easing.cubic),
-        useNativeDriver: true,
+        useNativeDriver: supportsNativeDriver,
       }).start(({ finished }) => {
         if (finished) {
           clearDetailSelection()

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -29,6 +29,7 @@ import {
 import { ErrorBoundaryWithAnalytics } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
 import { AnalyticsScreenTracker, AnalyticsBootstrap } from '../utils/analytics'
+import { supportsNativeDriver } from '../utils/animation'
 import { usePushNotifications } from '../hooks/usePushNotifications'
 import { getIntroShown } from '../utils/introStorage'
 import '../globals.css'
@@ -97,6 +98,9 @@ export default function RootLayout() {
       options={{
         host: posthogHost,
         disabled: !posthogEnabled,
+        disableRemoteConfig: !posthogEnabled,
+        disableSurveys: !posthogEnabled,
+        preloadFeatureFlags: posthogEnabled,
         // Capture app opened / backgrounded / became active lifecycle events.
         captureAppLifecycleEvents: posthogEnabled,
         // Mobile session replay (iOS/Android only; no-op on web). Also requires
@@ -263,8 +267,8 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
     if (prevIsDark.current !== isDark) {
       prevIsDark.current = isDark
       Animated.sequence([
-        Animated.timing(fadeAnim, { toValue: 0.85, duration: 80, useNativeDriver: true }),
-        Animated.timing(fadeAnim, { toValue: 1, duration: 150, useNativeDriver: true }),
+        Animated.timing(fadeAnim, { toValue: 0.85, duration: 80, useNativeDriver: supportsNativeDriver }),
+        Animated.timing(fadeAnim, { toValue: 1, duration: 150, useNativeDriver: supportsNativeDriver }),
       ]).start()
     }
   }, [isDark, fadeAnim])

--- a/packages/frontend/components/SplashScreen.tsx
+++ b/packages/frontend/components/SplashScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Animated, Image, StyleSheet, useColorScheme } from 'react-native'
+import { supportsNativeDriver } from '../utils/animation'
 
 export function SplashOverlay({ isReady }: { isReady: boolean }) {
   const isDark = useColorScheme() === 'dark'
@@ -30,7 +31,7 @@ export function SplashOverlay({ isReady }: { isReady: boolean }) {
     Animated.timing(opacity, {
       toValue: 0,
       duration: 400,
-      useNativeDriver: true,
+      useNativeDriver: supportsNativeDriver,
     }).start(() => setHidden(true))
   }
 

--- a/packages/frontend/components/contexts/ThemeContext.tsx
+++ b/packages/frontend/components/contexts/ThemeContext.tsx
@@ -3,6 +3,7 @@ import { useColorScheme as useNativeWindColorScheme } from 'nativewind'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState, createContext } from 'react'
 import { Appearance, Platform, View, Animated } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { supportsNativeDriver } from '../../utils/animation'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -138,7 +139,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         Animated.timing(fadeAnim, {
           toValue: 0,
           duration: 300,
-          useNativeDriver: true,
+          useNativeDriver: supportsNativeDriver,
         }).start()
       }
       previousTheme.current = theme

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import ThemeSelector from './ThemeSelector'
 import { Avatar } from '../ui'
 import { isSuperAdmin } from '../../utils/admin'
 import { useAnalytics } from '../../utils/analytics'
+import { supportsNativeDriver } from '../../utils/animation'
 
 function SettingsPanel({ visible, onClose, onLogout }) {
   const opacityAnim = useRef(new Animated.Value(0)).current
@@ -41,13 +42,13 @@ function SettingsPanel({ visible, onClose, onLogout }) {
         Animated.timing(opacityAnim, {
           toValue: 1,
           duration: 200,
-          useNativeDriver: true,
+          useNativeDriver: supportsNativeDriver,
         }),
         Animated.spring(translateYAnim, {
           toValue: 0,
           friction: 8,
           tension: 80,
-          useNativeDriver: true,
+          useNativeDriver: supportsNativeDriver,
         }),
       ]).start()
     } else {
@@ -55,12 +56,12 @@ function SettingsPanel({ visible, onClose, onLogout }) {
         Animated.timing(opacityAnim, {
           toValue: 0,
           duration: 150,
-          useNativeDriver: true,
+          useNativeDriver: supportsNativeDriver,
         }),
         Animated.timing(translateYAnim, {
           toValue: -20,
           duration: 150,
-          useNativeDriver: true,
+          useNativeDriver: supportsNativeDriver,
         }),
       ]).start()
     }
@@ -72,7 +73,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
     Animated.timing(slideAnim, {
       toValue: idx * optionWidth,
       duration: 100,
-      useNativeDriver: true,
+      useNativeDriver: supportsNativeDriver,
       easing: Easing.inOut(Easing.ease),
     }).start()
   }, [themePreference])

--- a/packages/frontend/components/ui/Skeleton.tsx
+++ b/packages/frontend/components/ui/Skeleton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { Animated, View, type ViewStyle } from 'react-native'
 import { useColors } from '../../hooks/useColors'
+import { supportsNativeDriver } from '../../utils/animation'
 
 interface SkeletonProps {
   width?: number | string
@@ -16,8 +17,8 @@ function SkeletonBox({ width = '100%', height = 16, borderRadius = 8, style }: S
   useEffect(() => {
     const anim = Animated.loop(
       Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: supportsNativeDriver }),
+        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: supportsNativeDriver }),
       ])
     )
     anim.start()

--- a/packages/frontend/components/ui/TabSegment.tsx
+++ b/packages/frontend/components/ui/TabSegment.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { Animated, Pressable, Text, View } from 'react-native'
 import { useColors } from '../../hooks/useColors'
+import { supportsNativeDriver } from '../../utils/animation'
 
 export interface TabOption {
   value: string
@@ -22,7 +23,11 @@ export function TabSegment({ options, value, onValueChange }: TabSegmentProps) {
   const slideAnim = useRef(new Animated.Value(selectedIndex * OPTION_WIDTH)).current
 
   useEffect(() => {
-    Animated.timing(slideAnim, { toValue: selectedIndex * OPTION_WIDTH, duration: 200, useNativeDriver: true }).start()
+    Animated.timing(slideAnim, {
+      toValue: selectedIndex * OPTION_WIDTH,
+      duration: 200,
+      useNativeDriver: supportsNativeDriver,
+    }).start()
   }, [selectedIndex, slideAnim])
 
   return (

--- a/packages/frontend/utils/animation.ts
+++ b/packages/frontend/utils/animation.ts
@@ -1,0 +1,3 @@
+import { Platform } from 'react-native'
+
+export const supportsNativeDriver = Platform.OS !== 'web'


### PR DESCRIPTION
## Summary
- use a shared animation driver capability helper so web animations do not request the native driver
- prevent disabled PostHog previews from preloading remote config, surveys, or feature flags

## Verification
- npm run typecheck
- npm run test:frontend
- npm run build:frontend
- EXPO_PUBLIC_POSTHOG_KEY='' EXPO_PUBLIC_POSTHOG_HOST='' npm run build:frontend
- local static preview browser smoke: Home/Explore/Feed rendered; no Animated native-driver warning and no PostHog 404 resources
