### PR TITLE
chore: fix database ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,9 @@ yarn.lock
 .tamagui/
 
 # Database
-db/# Build artifacts
+db/
+
+# Build artifacts
 *.tar.gz
 .expo/
 test-dist/


### PR DESCRIPTION
## Summary
- split the malformed `.gitignore` database/build-artifact line into `db/` and `# Build artifacts`
- confirmed root `db/`, backend local DB files, dist output, and tarball backups are ignored

Closes #422.

## Verification
- git diff --check
- git check-ignore -v db/local.sqlite packages/backend/db/local.db dist/index.html .git.broken-2026-05-27.tar.gz
