### PR TITLE
chore: guard admin console errors

### DIFF
--- a/packages/frontend/components/admin/CentersTab.tsx
+++ b/packages/frontend/components/admin/CentersTab.tsx
@@ -63,7 +63,7 @@ export default function CentersTab() {
       setCenters(result.data)
       setTotal(result.total)
     } catch (err: any) {
-      console.error('Failed to load centers:', err)
+      if (__DEV__) console.error('Failed to load centers:', err)
       setError(err?.message || 'Failed to load centers. Are you logged in?')
     } finally {
       setLoading(false)
@@ -171,7 +171,7 @@ export default function CentersTab() {
       track('admin_center_verified', { centerId: selected.centerID, source: 'admin' })
       loadCenters(search)
     } catch (err) {
-      console.error('Failed to toggle verification:', err)
+      if (__DEV__) console.error('Failed to toggle verification:', err)
     }
   }
 
@@ -184,7 +184,7 @@ export default function CentersTab() {
       setSelectedId(null)
       loadCenters(search)
     } catch (err) {
-      console.error('Failed to delete center:', err)
+      if (__DEV__) console.error('Failed to delete center:', err)
     }
   }
 

--- a/packages/frontend/components/admin/EventsTab.tsx
+++ b/packages/frontend/components/admin/EventsTab.tsx
@@ -46,7 +46,7 @@ export default function EventsTab() {
       setEvents(result.data)
       setTotal(result.total)
     } catch (err: any) {
-      console.error('Failed to load events:', err)
+      if (__DEV__) console.error('Failed to load events:', err)
       setError(err?.message || 'Failed to load events. Are you logged in?')
     } finally {
       setLoading(false)
@@ -78,7 +78,7 @@ export default function EventsTab() {
       setSelectedId(null)
       loadEvents(search)
     } catch (err) {
-      console.error('Failed to delete event:', err)
+      if (__DEV__) console.error('Failed to delete event:', err)
     }
   }
 

--- a/packages/frontend/components/admin/InviteCodesTab.tsx
+++ b/packages/frontend/components/admin/InviteCodesTab.tsx
@@ -177,7 +177,7 @@ export default function InviteCodesTab() {
       const updated = result.data.find((c) => c.code === selectedCode.code)
       if (updated) setSelectedCode(updated)
     } catch (err) {
-      console.error('Failed to toggle invite code:', err)
+      if (__DEV__) console.error('Failed to toggle invite code:', err)
     }
   }
 

--- a/packages/frontend/components/admin/ModerationTab.tsx
+++ b/packages/frontend/components/admin/ModerationTab.tsx
@@ -176,7 +176,7 @@ export default function ModerationTab() {
       setSelected(null)
       await loadQueue()
     } catch (err) {
-      console.error('Moderation action failed:', err)
+      if (__DEV__) console.error('Moderation action failed:', err)
     } finally {
       setActing(false)
     }

--- a/packages/frontend/components/admin/NotificationsTab.tsx
+++ b/packages/frontend/components/admin/NotificationsTab.tsx
@@ -87,7 +87,7 @@ export default function NotificationsTab() {
       loadNotifications()
       loadStats()
     } catch (err) {
-      console.error('Failed to delete notification:', err)
+      if (__DEV__) console.error('Failed to delete notification:', err)
     }
   }
 

--- a/packages/frontend/components/admin/UsersTab.tsx
+++ b/packages/frontend/components/admin/UsersTab.tsx
@@ -67,7 +67,7 @@ export default function UsersTab() {
       setUsers(result.data)
       setTotal(result.total)
     } catch (err: any) {
-      console.error('Failed to load users:', err)
+      if (__DEV__) console.error('Failed to load users:', err)
       setError(err?.message || 'Failed to load users. Are you logged in?')
     } finally {
       setLoading(false)
@@ -175,7 +175,7 @@ export default function UsersTab() {
         prev ? { ...prev, isVerified: result.isVerified } : null
       )
     } catch (err) {
-      console.error('Failed to toggle verification:', err)
+      if (__DEV__) console.error('Failed to toggle verification:', err)
     }
   }
 
@@ -188,7 +188,7 @@ export default function UsersTab() {
       setSelectedUser(null)
       loadUsers(search)
     } catch (err) {
-      console.error('Failed to delete user:', err)
+      if (__DEV__) console.error('Failed to delete user:', err)
     }
   }
 


### PR DESCRIPTION
## Summary
- guard admin tab `console.error` calls behind `__DEV__`
- preserve existing user-facing admin error states and result messages

Closes #424.

## Verification
- git diff --check
- `rg -n "console\.error" packages/frontend/components/admin | rg -v "if \(__DEV__\) console\.error" || true`
- npm run test:frontend
- npm run build:frontend
