### PR TITLE
fix(design): unify entry-flow screens on the orange token #E8862A

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -262,7 +262,7 @@ export default function AuthScreen() {
             className="absolute right-5"
             style={{ top: insets.top + 12, paddingHorizontal: 4, paddingVertical: 8 }}
           >
-            <Text className="font-sans" style={{ fontSize: 14.5, fontWeight: '500', color: '#C2410C' }}>
+            <Text className="font-sans" style={{ fontSize: 14.5, fontWeight: '500', color: '#E8862A' }}>
               Discover →
             </Text>
           </Pressable>
@@ -329,7 +329,7 @@ export default function AuthScreen() {
                     'Stay connected with your center and sangha',
                   ].map((line) => (
                     <View key={line} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
-                      <Text style={{ color: '#C2410C', fontSize: 14, lineHeight: 22 }}>✓</Text>
+                      <Text style={{ color: '#E8862A', fontSize: 14, lineHeight: 22 }}>✓</Text>
                       <Text className="font-sans" style={{ flex: 1, fontSize: 14.5, lineHeight: 22, color: '#57534E' }}>{line}</Text>
                     </View>
                   ))}

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -299,7 +299,7 @@ export default function AuthScreen() {
   }
 
   const focusInputStyle: React.CSSProperties = {
-    borderColor: '#C2410C',
+    borderColor: '#E8862A',
     boxShadow: '0 0 0 3px rgba(194,65,12,0.1)',
     backgroundColor: '#FFFFFF',
   }
@@ -409,7 +409,7 @@ export default function AuthScreen() {
               fontSize: 14,
               fontFamily: 'Inclusive Sans, sans-serif',
               fontWeight: '500',
-              color: '#C2410C',
+              color: '#E8862A',
               minHeight: 44,
               display: 'flex',
               alignItems: 'center',
@@ -487,7 +487,7 @@ export default function AuthScreen() {
                 'Stay connected with your center and sangha',
               ].map((line) => (
                 <div key={line} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', marginBottom: 9 }}>
-                  <span style={{ color: '#C2410C', fontSize: 14, lineHeight: '22px' }}>✓</span>
+                  <span style={{ color: '#E8862A', fontSize: 14, lineHeight: '22px' }}>✓</span>
                   <span style={{ fontFamily: 'Inclusive Sans, sans-serif', fontSize: 14.5, lineHeight: '22px', color: '#57534E' }}>{line}</span>
                 </div>
               ))}
@@ -592,7 +592,7 @@ export default function AuthScreen() {
                   border: 'none',
                   padding: 0,
                   marginTop: -4,
-                  color: '#C2410C',
+                  color: '#E8862A',
                   fontSize: 13,
                   cursor: 'pointer',
                   textDecoration: 'underline',
@@ -643,7 +643,7 @@ export default function AuthScreen() {
                 width: '100%',
                 height: 48,
                 minHeight: 44,
-                backgroundColor: '#C2410C',
+                backgroundColor: '#E8862A',
                 color: '#FFFFFF',
                 border: 'none',
                 borderRadius: 8,
@@ -724,7 +724,7 @@ export default function AuthScreen() {
                   }
                 }}
                 style={{
-                  color: '#C2410C',
+                  color: '#E8862A',
                   cursor: 'pointer',
                   padding: '8px 4px',
                   margin: '-8px -4px',
@@ -758,7 +758,7 @@ export default function AuthScreen() {
                   }
                 }}
                 style={{
-                  color: '#C2410C',
+                  color: '#E8862A',
                   cursor: 'pointer',
                   padding: '8px 4px',
                   margin: '-8px -4px',
@@ -821,7 +821,7 @@ export default function AuthScreen() {
               tabIndex={0}
               onClick={() => { track('terms_viewed', { source: 'auth' }); router.push('/terms') }}
               onKeyDown={(e) => { if (e.key === 'Enter') { track('terms_viewed', { source: 'auth' }); router.push('/terms') } }}
-              style={{ color: '#C2410C', cursor: 'pointer' }}
+              style={{ color: '#E8862A', cursor: 'pointer' }}
             >
               Terms of Service
             </span>
@@ -831,7 +831,7 @@ export default function AuthScreen() {
               tabIndex={0}
               onClick={() => { track('privacy_policy_viewed', { source: 'auth' }); router.push('/privacy') }}
               onKeyDown={(e) => { if (e.key === 'Enter') { track('privacy_policy_viewed', { source: 'auth' }); router.push('/privacy') } }}
-              style={{ color: '#C2410C', cursor: 'pointer' }}
+              style={{ color: '#E8862A', cursor: 'pointer' }}
             >
               Privacy Policy
             </span>

--- a/packages/frontend/app/onboarding.tsx
+++ b/packages/frontend/app/onboarding.tsx
@@ -29,7 +29,7 @@ const OnboardingHeader = () => {
                 outputRange: ['0%', '100%'],
               }),
               height: '100%',
-              backgroundColor: '#ea580c',
+              backgroundColor: '#E8862A',
             }}
             className="rounded-full"
           />

--- a/packages/frontend/components/ui/AuthPromptModal.tsx
+++ b/packages/frontend/components/ui/AuthPromptModal.tsx
@@ -328,7 +328,7 @@ export default function AuthPromptModal({
                 <View style={{ gap: 9 }}>
                   {promptBullets.map((line) => (
                     <View key={line} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
-                      <Text style={{ color: '#C2410C', fontSize: 15, lineHeight: 22 }}>{'\u2713'}</Text>
+                      <Text style={{ color: '#E8862A', fontSize: 15, lineHeight: 22 }}>{'\u2713'}</Text>
                       <Text style={{ flex: 1, fontFamily: 'Inclusive Sans', fontSize: 14.5, lineHeight: 22, color: '#57534E' }}>
                         {line}
                       </Text>
@@ -340,7 +340,7 @@ export default function AuthPromptModal({
               <View style={{ gap: 12, marginTop: 4 }}>
                 {authStep !== 'initial' && (
                   <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
-                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#C2410C' }}>
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#E8862A' }}>
                       Back
                     </Text>
                   </Pressable>
@@ -501,7 +501,7 @@ export default function AuthPromptModal({
           <View style={{ gap: 10, marginTop: 4 }}>
             {authStep !== 'initial' && (
               <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
-                <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: '#C2410C' }}>
+                <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>
                   Back
                 </Text>
               </Pressable>


### PR DESCRIPTION
Part of PR #443's redlines (Phase 3 item, pulled forward since it's unblocked). Color-only change, 15 lines across 4 files.

- `#ea580c` (onboarding.tsx:32) and all `#C2410C` (auth.tsx, auth.web.tsx, AuthPromptModal.tsx) → token `#E8862A` (tokens/colors.ts accent).
- Scoped to the entry-flow screens. The app-wide sweep (33 files still carry stray oranges) belongs to #442.
- Known tradeoff, decided in #443: `#C2410C` passed WCAG AA for small text, the token does not. Brand consistency was the locked call; link text keeps its weight.

Tests: 187/187 frontend vitest pass.

Related: #443, #442, #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)