### PR TITLE
feat(onboarding): no-centers-near-you empty state + global geocoding (onb-3b)

### DIFF
--- a/packages/frontend/components/center/CenterSearch.tsx
+++ b/packages/frontend/components/center/CenterSearch.tsx
@@ -28,6 +28,8 @@ export function CenterSearch({
   maxResults = 6,
   maxListHeight = 260,
   autoSelectNearest = false,
+  farThresholdMi,
+  emptyState,
 }: {
   onSelect: (center: CenterSearchResult) => void
   selectedCenterId?: string | null
@@ -42,6 +44,12 @@ export function CenterSearch({
   maxListHeight?: number
   /** Onboarding auto-picks the nearest center once results land. */
   autoSelectNearest?: boolean
+  /** When set, a nearest result farther than this renders `emptyState`
+      instead of the list (and skips auto-select). Lets onboarding say
+      "no centers near you" while center pickers still offer far ones. */
+  farThresholdMi?: number
+  /** Rendered when the search lands in the no-centers-near-you state. */
+  emptyState?: React.ReactNode
 }) {
   const fallbackColors = useColors()
   const colors = colorsProp ?? fallbackColors
@@ -51,6 +59,9 @@ export function CenterSearch({
   const [results, setResults] = useState<CenterSearchResult[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  // Searched fine, but the nearest center is past farThresholdMi — the
+  // "no centers near you yet" state (real today for most of the world).
+  const [tooFar, setTooFar] = useState(false)
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoSelectedFor = useRef<string>('')
 
@@ -75,9 +86,12 @@ export function CenterSearch({
     }
     setLoading(true)
     setError('')
+    setTooFar(false)
     try {
+      // Global geocoding (was countrycodes=us) — a Mumbai search should
+      // resolve Mumbai, then the farThresholdMi check decides what to show.
       const res = await fetch(
-        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1&countrycodes=us`
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1`
       )
       if (!res.ok) throw new Error('geocode failed')
       const data = await res.json()
@@ -97,6 +111,14 @@ export function CenterSearch({
         }))
         .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity))
         .slice(0, maxResults)
+      const nearestMi = ranked[0]?.distance ?? Infinity
+      if (farThresholdMi != null && nearestMi > farThresholdMi) {
+        // Don't auto-pick a center half a world away; let the host render
+        // its "no centers near you yet" state instead.
+        setResults([])
+        setTooFar(true)
+        return
+      }
       setResults(ranked)
       setError('')
       if (autoSelectNearest && ranked.length > 0 && autoSelectedFor.current !== query) {
@@ -118,6 +140,7 @@ export function CenterSearch({
     } else {
       setResults([])
       setError('')
+      setTooFar(false)
     }
     return () => {
       if (debounce.current) clearTimeout(debounce.current)
@@ -159,6 +182,14 @@ export function CenterSearch({
       {error ? (
         <Text style={{ fontSize: 12.5, color: colors.textMuted, marginTop: 8 }}>{error}</Text>
       ) : null}
+
+      {tooFar
+        ? emptyState ?? (
+            <Text style={{ fontSize: 12.5, color: colors.textMuted, marginTop: 8 }}>
+              No centers near you yet.
+            </Text>
+          )
+        : null}
 
       {results.length > 0 ? (
         <ScrollView style={{ maxHeight: maxListHeight, marginTop: 8 }} keyboardShouldPersistTaps="handled">

--- a/packages/frontend/components/onboarding/step3.tsx
+++ b/packages/frontend/components/onboarding/step3.tsx
@@ -26,15 +26,28 @@ export default function Step3() {
             </View>
 
             {/* Shared center search — same behavior as the feed's "join your
-                center" step. Auto-picks the nearest result like before. */}
+                center" step. Auto-picks the nearest result like before.
+                farThresholdMi keeps it from auto-picking a center half a
+                world away (onb-3b, real for every city outside the US). */}
             <View className="w-full max-w-md self-center">
               <CenterSearch
                 selectedCenterId={centerID}
                 autoSelectNearest
+                farThresholdMi={150}
                 placeholder="City or town name"
                 onSelect={(center) => {
                   setCenterID(center.id)
                 }}
+                emptyState={
+                  <View className="mt-3 rounded-2xl border border-dashed border-stone-300 dark:border-stone-600 px-4 py-5">
+                    <Text className="text-base font-sans font-semibold text-content dark:text-content-dark text-center mb-1">
+                      No centers near you yet
+                    </Text>
+                    <Text className="text-sm font-sans text-stone-500 dark:text-stone-400 text-center">
+                      Janata is growing. Skip for now, you can join any center later.
+                    </Text>
+                  </View>
+                }
               />
             </View>
           </View>


### PR DESCRIPTION
Phase 1 item from PR #443 (`onb-3b`), unblocked by #440 so pulled forward.

## What was broken
- `CenterSearch` geocoded with `countrycodes=us`. Type Mumbai, get "Location not found". That is the whole India story today.
- Even with global geocoding, the ranking has no distance cutoff, and onboarding auto-picks the nearest result. A Mumbai user would silently get a US center.

## What this does
- Geocode globally (drop `countrycodes=us`).
- New opt-in `farThresholdMi` + `emptyState` props on `CenterSearch`: when the nearest center is past the threshold, render the empty state instead of the list and skip auto-select. Call sites that want far results (center pickers) are untouched.
- Onboarding step 3 sets `farThresholdMi={150}` and shows the designed card: "No centers near you yet / Janata is growing. Skip for now, you can join any center later." The existing Skip stays.

Mock: `hifi/mock-v2.html` §E (onb-3b) on #443.

Tests: 187/187 frontend vitest pass.

Related: #443, #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)