### PR TITLE
feat(feed): guest rail speaks the hard gate — log in / paste invite / guest RSVP (new-15/33)

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -414,6 +414,13 @@ export default function FeedScreen() {
     router.push('/explore' as never)
   }, [router, track])
 
+  // Hard-gate path (new-15): the not-yet-invited paste an invite link/code.
+  // /auth's invite step validates it; #403's Door 1 takes over post-#440.
+  const handlePasteInvite = useCallback(() => {
+    track('feed_paste_invite_pressed', { source: 'feed_setup' })
+    router.push('/auth' as never)
+  }, [router, track])
+
   // Inline "join your center" from the empty-state rail. A guest can't persist a
   // center yet, so we stash the pick and route to auth (it survives sign-in via
   // centerPickerStore). A signed-in member joins immediately via updateProfile,
@@ -528,6 +535,7 @@ export default function FeedScreen() {
             onSignIn={handleSignIn}
             onJoinCenter={handleJoinCenter}
             onBrowseEvents={handleBrowseEvents}
+            onPasteInvite={handlePasteInvite}
             onCompose={() => {
               track('feed_compose_pressed', { source: 'feed_empty_panel' })
               setCreatePostOpen(true)

--- a/packages/frontend/components/feed/FeedEmptyState.tsx
+++ b/packages/frontend/components/feed/FeedEmptyState.tsx
@@ -24,6 +24,7 @@ export function FeedEmptyState({
   onSignIn,
   onJoinCenter,
   onBrowseEvents,
+  onPasteInvite,
   onCompose,
   onOpenGroup,
 }: {
@@ -37,6 +38,8 @@ export function FeedEmptyState({
   onSignIn: () => void
   onJoinCenter: (centerId: string) => Promise<boolean> | void
   onBrowseEvents: () => void
+  /** Hard-gate path for the not-yet-invited: paste an invite link or code. */
+  onPasteInvite?: () => void
   onCompose?: () => void
   onOpenGroup: (group: GroupBoard) => void
 }) {
@@ -63,6 +66,7 @@ export function FeedEmptyState({
       onSignIn={onSignIn}
       onJoinCenter={onJoinCenter}
       onBrowseEvents={onBrowseEvents}
+      onPasteInvite={onPasteInvite}
     />
   )
 

--- a/packages/frontend/components/feed/FeedSetupRail.tsx
+++ b/packages/frontend/components/feed/FeedSetupRail.tsx
@@ -53,6 +53,7 @@ export function FeedSetupRail({
   onSignIn,
   onJoinCenter,
   onBrowseEvents,
+  onPasteInvite,
 }: {
   colors: AppColors
   isSignedIn: boolean
@@ -60,6 +61,8 @@ export function FeedSetupRail({
   /** Resolve true on success. Guest mode routes to auth and may not resolve. */
   onJoinCenter: (centerId: string) => Promise<boolean> | void
   onBrowseEvents: () => void
+  /** Hard-gate path for the not-yet-invited: paste an invite link or code. */
+  onPasteInvite?: () => void
 }) {
   const [joiningId, setJoiningId] = useState<string | null>(null)
 
@@ -87,10 +90,12 @@ export function FeedSetupRail({
       }}
     >
       <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: colors.text }}>
-        Finish setting up your feed
+        {isSignedIn ? 'Almost there' : 'Join the conversation'}
       </Text>
       <Text style={{ fontSize: 13, lineHeight: 18, color: colors.textMuted, marginBottom: 14 }}>
-        Two quick steps and your community shows up here.
+        {isSignedIn
+          ? 'Join a center to unlock its boards.'
+          : 'Boards for your center and events. Members only.'}
       </Text>
 
       {/* Step 1 — Sign in */}
@@ -107,18 +112,32 @@ export function FeedSetupRail({
               fontWeight: step1 === 'active' ? '600' : '400',
             }}
           >
-            {step1 === 'done' ? 'Signed in' : 'Sign in'}
+            {step1 === 'done' ? 'Logged in' : 'Log in'}
           </Text>
           {step1 === 'active' ? (
-            <Pressable
-              onPress={onSignIn}
-              accessibilityRole="button"
-              style={{ marginTop: 10, backgroundColor: colors.accent, borderRadius: 999, paddingVertical: 11, alignItems: 'center' }}
-            >
-              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textInverse }}>
-                Sign in to continue
-              </Text>
-            </Pressable>
+            <View style={{ gap: 8 }}>
+              <Pressable
+                onPress={onSignIn}
+                accessibilityRole="button"
+                style={{ marginTop: 10, backgroundColor: colors.accent, borderRadius: 999, paddingVertical: 11, alignItems: 'center' }}
+              >
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textInverse }}>
+                  Log in
+                </Text>
+              </Pressable>
+              {onPasteInvite ? (
+                <Pressable onPress={onPasteInvite} accessibilityRole="button" style={{ alignItems: 'center', paddingVertical: 2 }}>
+                  <Text style={{ fontSize: 13, color: colors.textMuted }}>
+                    Have an invite? <Text style={{ color: colors.accent, fontWeight: '600' }}>Paste it</Text>
+                  </Text>
+                </Pressable>
+              ) : null}
+              <Pressable onPress={onBrowseEvents} accessibilityRole="button" style={{ alignItems: 'center', paddingVertical: 2 }}>
+                <Text style={{ fontSize: 12.5, color: colors.textMuted }}>
+                  Or RSVP to events without an account
+                </Text>
+              </Pressable>
+            </View>
           ) : null}
         </View>
       </View>


### PR DESCRIPTION
Phase 2 item from PR #443 (`new-15`/`new-33`, mock-v2 §F), unblocked by #440 so pulled forward.

`FeedEmptyState` machinery untouched (ghost feed + setup rail, guest/joinCenter/firstPost). Copy and affordances only:

- Guest rail: "Join the conversation / Boards for your center and events. Members only." Step 1 is **Log in** (primary), with "Have an invite? **Paste it**" and "Or RSVP to events without an account" beneath. No open-signup language anywhere.
- Paste-it routes to `/auth` (its invite step validates codes today); #403's Door 1 becomes the target once #440 lands.
- Signed-in rail: "Almost there / Join a center to unlock its boards."
- New PostHog event: `feed_paste_invite_pressed`.

Verified on the local stack, web 390px logged out (screenshot matches mock-v2 §F). 187/187 frontend vitest pass.

Related: #443, #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)