### PR TITLE
feat(invites): Door 1 invite landing — vouch + accept (#403 Phase 1.1)

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -320,7 +320,10 @@ app.post('/auth/validate-invite-code', rateLimit(10, 60_000), async (c) => {
 
   const status = await inviteCodes.classifyInviteCode(c.env, body.code)
   if (status === 'ok') {
-    return c.json({ valid: true })
+    // Door 1 vouch (#403): include the inviter's first name when the link was
+    // minted by a member. Null for admin cohort codes → nameless vouch.
+    const inviterFirstName = await inviteCodes.getInviterFirstName(c.env, body.code)
+    return c.json({ valid: true, inviterFirstName })
   }
 
   const messages: Record<Exclude<inviteCodes.InviteCodeStatus, 'ok'>, string> = {

--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -83,6 +83,26 @@ export async function validateInviteCode(
 }
 
 /**
+ * Resolve the first name of whoever minted this code, for the Door 1 vouch
+ * banner ("Anand invited you to Janata"). User-minted links carry a
+ * `created_by_user_id`; admin cohort codes don't, so this returns null and the
+ * UI falls back to the nameless vouch. Also null when the inviter has no first
+ * name set, so Door 1 can never render "undefined invited you" (#403).
+ */
+export async function getInviterFirstName(
+  env: Env,
+  code: string,
+): Promise<string | null> {
+  const row = await getInviteCode(env, code)
+  if (!row || !row.created_by_user_id) return null
+  const inviter = await env.DB.prepare('SELECT first_name FROM users WHERE id = ?')
+    .bind(row.created_by_user_id)
+    .first<{ first_name: string | null }>()
+  const name = inviter?.first_name?.trim()
+  return name && name.length > 0 ? name : null
+}
+
+/**
  * Get an invite code regardless of state (active/expired/exhausted).
  * Used for admin lookups and consumption flows that need to inspect
  * a previously-valid code.

--- a/packages/frontend/app/i/[code].tsx
+++ b/packages/frontend/app/i/[code].tsx
@@ -1,51 +1,246 @@
-import { useEffect } from 'react'
-import { View, ActivityIndicator, Text } from 'react-native'
+import { useEffect, useState, useCallback } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  Image,
+  TextInput,
+  useWindowDimensions,
+} from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { extractInviteCode } from '../../utils/validation'
+import { inviteClient } from '../../src/auth/inviteClient'
+import { INTRO_STEPS } from '../../components/intro/IntroSteps'
+import IntroCard from '../../components/intro/IntroCard'
+import { useAnalytics } from '../../utils/analytics'
 
 /**
- * /i/[code] — canonical invite landing (chinmayajanata.org/i/CODE).
+ * /i/[code] — Door 1, the invite landing (chinmayajanata.org/i/CODE).
  *
- * This is both the universal/app-link target and the web fallback when the
- * native app is not installed. It keeps the fallback intentionally small:
- * normalize the code and hand logged-out invitees into signup with the invite
- * applied. Richer vouch + onboarding intro UI is #403's AuthFlowCore work.
+ * This is where a real member's invite link lands. It vouches ("Anand invited
+ * you to Janata"), shows one strong hero, and hands off into signup with the
+ * code applied — auth fires only at Accept (#403). #440 built the plumbing this
+ * sits on (route, deep-link registration, register flips NORMAL_USER on a
+ * consumed code). Four terminal states, never a silent redirect:
+ *
+ *   - valid + logged out → Door 1 vouch + Accept           (new-01/01b/02/03)
+ *   - dead/expired code  → recovery, paste a fresh link     (new-04)
+ *   - already logged in  → "you're already a member"        (new-05)
  */
+
+type Phase = 'resolving' | 'valid' | 'invalid' | 'member'
+
 export default function InviteLinkScreen() {
   const router = useRouter()
   const c = useColors()
-  const { isAuthenticated, loading } = useUser()
+  const { track } = useAnalytics()
+  const { width } = useWindowDimensions()
+  const { authStatus, loading } = useUser()
+  const isAuthenticated = authStatus === 'authenticated'
   const { code: raw } = useLocalSearchParams<{ code: string }>()
   const code = extractInviteCode(typeof raw === 'string' ? raw : '')
 
+  const [phase, setPhase] = useState<Phase>('resolving')
+  const [inviterName, setInviterName] = useState<string | null>(null)
+  const [pasted, setPasted] = useState('')
+
   useEffect(() => {
     if (loading) return
-    if (!code) {
-      router.replace('/auth')
-      return
-    }
+    // Already a member: no signup ever (new-05).
     if (isAuthenticated) {
-      // Already a member; #403 will replace this with the invite intent flow.
-      router.replace('/(tabs)')
+      setPhase('member')
       return
     }
+    if (!code) {
+      setPhase('invalid')
+      return
+    }
+    let cancelled = false
+    setPhase('resolving')
+    inviteClient.lookup(code).then((res) => {
+      if (cancelled) return
+      if (res.valid) {
+        setInviterName(res.inviterFirstName)
+        setPhase('valid')
+        track('door1_view', { has_inviter_name: !!res.inviterFirstName })
+      } else {
+        setPhase('invalid')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+    // `track` is intentionally excluded — including the (unstable) analytics fn
+    // re-runs this effect every render, which storms the lookup endpoint.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, code, isAuthenticated])
+
+  const accept = useCallback(() => {
+    track('invite_accept_tap', { invite_code: code })
     router.replace(`/auth?mode=signup&inviteCode=${encodeURIComponent(code)}`)
-  }, [loading, code, isAuthenticated, router])
+  }, [code, router, track])
+
+  const logIn = useCallback(() => {
+    // Hold the code so a returning member's account gets the upgrade (#403 slice 2).
+    router.replace(`/auth?mode=login&inviteCode=${encodeURIComponent(code)}`)
+  }, [code, router])
+
+  const openPasted = useCallback(() => {
+    const next = extractInviteCode(pasted)
+    if (next) router.replace(`/i/${encodeURIComponent(next)}`)
+  }, [pasted, router])
+
+  const heroWidth = Math.min(width, 440)
+  const canOpenPasted = !!extractInviteCode(pasted)
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: c.bg,
-        gap: 12,
-      }}
-    >
-      <ActivityIndicator color={c.accent} />
-      <Text style={{ color: c.textMuted, fontSize: 14 }}>Opening your invite...</Text>
+    <View style={{ flex: 1, backgroundColor: c.bg, alignItems: 'center', justifyContent: 'center' }}>
+      <View style={{ width: '100%', maxWidth: 440, paddingHorizontal: 24, alignItems: 'center' }}>
+        {phase === 'resolving' && (
+          <View style={{ alignItems: 'center', gap: 12 }}>
+            <ActivityIndicator color={c.accent} />
+            <Text style={{ color: c.textMuted, fontSize: 14 }}>Opening your invite…</Text>
+          </View>
+        )}
+
+        {phase === 'valid' && (
+          <>
+            {/* new-01 / new-01b — vouch banner; nameless when the resolver has no name */}
+            <View
+              style={{
+                backgroundColor: c.accentSoft,
+                borderRadius: 999,
+                paddingVertical: 8,
+                paddingHorizontal: 16,
+                marginBottom: 8,
+              }}
+            >
+              <Text style={{ color: c.accent, fontSize: 14, fontWeight: '600', textAlign: 'center' }}>
+                {inviterName ? `${inviterName} invited you to Janata` : "You're invited to Janata"}
+              </Text>
+            </View>
+
+            {/* new-02 — one strong hero, reusing the real onboarding intro art + copy */}
+            <IntroCard step={INTRO_STEPS[0]} width={heroWidth} index={0} />
+
+            {/* new-03 — Accept (primary) + Already a member (ghost) */}
+            <View style={{ width: '100%', gap: 12, marginTop: 8 }}>
+              <Pressable
+                onPress={accept}
+                style={{
+                  backgroundColor: c.accent,
+                  borderRadius: 12,
+                  paddingVertical: 15,
+                  alignItems: 'center',
+                }}
+              >
+                <Text style={{ color: c.textInverse, fontSize: 16, fontWeight: '600' }}>
+                  Accept invite
+                </Text>
+              </Pressable>
+              <Pressable onPress={logIn} style={{ paddingVertical: 10, alignItems: 'center' }}>
+                <Text style={{ color: c.textMuted, fontSize: 14 }}>
+                  Already a member? <Text style={{ color: c.accent, fontWeight: '600' }}>Log in</Text>
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        )}
+
+        {phase === 'member' && (
+          // new-05 — auto-logged-in: no signup, just back into the app.
+          <View style={{ alignItems: 'center', gap: 16 }}>
+            <Image
+              source={INTRO_STEPS[2].image}
+              style={{ width: 120, height: 120 }}
+              resizeMode="contain"
+            />
+            <View style={{ gap: 6, alignItems: 'center' }}>
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 26, color: c.text }}>
+                You're already a member
+              </Text>
+              <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center' }}>
+                No need to sign up again.
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => router.replace('/(tabs)')}
+              style={{
+                backgroundColor: c.accent,
+                borderRadius: 12,
+                paddingVertical: 15,
+                paddingHorizontal: 48,
+                alignItems: 'center',
+              }}
+            >
+              <Text style={{ color: c.textInverse, fontSize: 16, fontWeight: '600' }}>Open Janata</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {phase === 'invalid' && (
+          // new-04 — dead/expired code: recovery, never a silent dump into signup.
+          <View style={{ width: '100%', alignItems: 'center', gap: 16 }}>
+            <View style={{ gap: 6, alignItems: 'center' }}>
+              <Text
+                style={{
+                  fontFamily: 'Inclusive Sans',
+                  fontSize: 26,
+                  color: c.text,
+                  textAlign: 'center',
+                }}
+              >
+                This invite isn't active
+              </Text>
+              <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center', lineHeight: 22 }}>
+                The link may have expired. Paste a fresh invite, or ask a member for one.
+              </Text>
+            </View>
+            <View style={{ width: '100%', gap: 10 }}>
+              <TextInput
+                value={pasted}
+                onChangeText={setPasted}
+                placeholder="Paste an invite link"
+                placeholderTextColor={c.textFaint}
+                autoCapitalize="none"
+                autoCorrect={false}
+                onSubmitEditing={openPasted}
+                style={{
+                  backgroundColor: c.surface,
+                  borderRadius: 8,
+                  paddingVertical: 12,
+                  paddingHorizontal: 14,
+                  fontSize: 15,
+                  color: c.text,
+                }}
+              />
+              <Pressable
+                onPress={openPasted}
+                disabled={!canOpenPasted}
+                style={{
+                  backgroundColor: canOpenPasted ? c.accent : c.surface,
+                  borderRadius: 12,
+                  paddingVertical: 15,
+                  alignItems: 'center',
+                }}
+              >
+                <Text
+                  style={{
+                    color: canOpenPasted ? c.textInverse : c.textFaint,
+                    fontSize: 16,
+                    fontWeight: '600',
+                  }}
+                >
+                  Open invite
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </View>
     </View>
   )
 }

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -101,7 +101,35 @@ export interface RedeemResponse extends GenericSuccessResponse {
   user: User
 }
 
+export interface InviteLookup {
+  valid: boolean
+  /** Inviter's first name for the Door 1 vouch, or null → nameless vouch. */
+  inviterFirstName: string | null
+}
+
 export const inviteClient = {
+  /**
+   * Look up an invite code for Door 1: is it usable, and who minted it. Public
+   * (no auth). Treats any network/parse failure as an invalid code so the
+   * screen degrades to the recovery state rather than hanging.
+   */
+  async lookup(code: string): Promise<InviteLookup> {
+    try {
+      const response = await withTimeout(
+        buildUrl('/auth/validate-invite-code'),
+        { method: 'POST', body: JSON.stringify({ code }) },
+        API_TIMEOUTS.standard,
+      )
+      const data = await safeJson<{ valid?: boolean; inviterFirstName?: string | null }>(response)
+      if (!response.ok || !data?.valid) {
+        return { valid: false, inviterFirstName: null }
+      }
+      return { valid: true, inviterFirstName: data.inviterFirstName ?? null }
+    } catch {
+      return { valid: false, inviterFirstName: null }
+    }
+  },
+
   /**
    * Mint a new multi-use invite code tied to the caller. Defaults to 25 uses
    * / 7-day expiry; pass `options` to adjust (server clamps maxUses to


### PR DESCRIPTION
First slice of #403. Turns `/i/[code]` from a silent redirect into **Door 1**, the designed invite landing.

## What lands
- **Vouch** — "Member invited you to Janata", resolved from the invite code's creator. Nameless fallback ("You're invited to Janata") for admin cohort codes; "undefined invited you" is impossible (new-01/01b).
- **One strong hero** — reuses the real onboarding intro art + copy (new-02).
- **Accept** → signup with the code applied → verified member at inception (new-03). **Already a member? Log in** holds the code for the upgrade (wired in slice 2).
- **Already logged in** → "You're already a member" / Open Janata. No signup (new-05).
- **Dead/expired code** → recovery: paste a fresh link. Never a silent dump into signup (new-04).

## Backend
- `POST /auth/validate-invite-code` now returns `inviterFirstName` (from the code's `created_by_user_id`), so the vouch is real for member-minted links.

## Also
- Fixes a pre-existing type error (`useUser` exposes `authStatus`, not `isAuthenticated`).
- Fixes an effect-dep bug that re-ran the lookup every render and stormed the rate limiter.

## Verified (local web)
- Valid link → named vouch + hero + Accept → `/auth?mode=signup&inviteCode=…`
- Already-member and dead-code states render correctly
- Backend returns `{valid:true, inviterFirstName:"Member"}` / `{valid:false}` for bogus
- Frontend typecheck: 13 → 12 errors (removed the `isAuthenticated` bug; zero new)

## Not in this slice (later #403/#404)
Hard-gate enforcement, log-in-with-held-code upgrade, paste-invite screen, guest RSVP, logged-out browse surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)