### PR TITLE
feat(invites): auth screen carries invite intent (#403 Phase 1.2)

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -16,6 +16,7 @@ import { AuthInput, Logo, PrimaryButton } from '../components/ui'
 import { useUser, useTheme } from '../components/contexts'
 import { validateEmail, validatePassword } from '../utils'
 import { extractInviteCode } from '../utils/validation'
+import { inviteClient } from '../src/auth/inviteClient'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
 import { API_BASE_URL } from '../src/config/api'
@@ -32,7 +33,7 @@ export default function AuthScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const { isDark } = useTheme()
-  const { checkUserExists, login, signup, loading } = useUser()
+  const { checkUserExists, login, signup, loading, getToken } = useUser()
   const { track } = useAnalytics()
 
   // Read params for deep-link support (e.g. from AuthPromptModal, or
@@ -55,7 +56,32 @@ export default function AuthScreen() {
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
 
+  // Invite intent (#403 slice 2): the applied-invite bar + email-collision flip.
+  // `inviterName` powers the vouch copy ("Anand's invite applied"); null → nameless.
+  // `collisionFlip` = we bounced a signup whose email already exists into login,
+  // holding the invite to apply on the way in (new-22).
+  const [inviterName, setInviterName] = useState<string | null>(null)
+  const [collisionFlip, setCollisionFlip] = useState(false)
+  const hasInvite = !!extractInviteCode(inviteCode)
+
   const [showDevPanel, setShowDevPanel] = useState(false)
+
+  // Resolve the inviter's name for the applied bar whenever a code is present.
+  // Best-effort: a miss just falls back to the nameless copy.
+  useEffect(() => {
+    const code = extractInviteCode(inviteCode)
+    if (!code) {
+      setInviterName(null)
+      return
+    }
+    let cancelled = false
+    inviteClient.lookup(code).then((res) => {
+      if (!cancelled) setInviterName(res.valid ? res.inviterFirstName : null)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [inviteCode])
 
   useEffect(() => {
     const nextStep =
@@ -68,6 +94,7 @@ export default function AuthScreen() {
     setInviteCode(urlInviteCode || '')
     setPassword('')
     setConfirmPassword('')
+    setCollisionFlip(false)
     setErrors({})
   }, [params.mode, urlEmail, urlInviteCode])
 
@@ -112,6 +139,20 @@ export default function AuthScreen() {
       const result = await login(username, password)
       if (result.success) {
         track('login_success', { source: 'auth' })
+        // new-22 grandfather upgrade: if the invite was held through the login
+        // (collision flip or "Already a member?" from Door 1), apply it now so
+        // an existing open-signup account gets promoted. Best-effort — a stale
+        // or already-consumed code must never block the login.
+        const heldCode = extractInviteCode(inviteCode)
+        if (heldCode) {
+          try {
+            const token = await getToken()
+            if (token) await inviteClient.redeem(token, heldCode)
+            track('invite_applied_on_login', { source: 'auth' })
+          } catch {
+            // ignore — login already succeeded
+          }
+        }
         router.replace(params.returnTo ? (params.returnTo as never) : '/(tabs)')
       } else {
         track('login_failed', { source: 'auth', reason: result.message })
@@ -121,7 +162,7 @@ export default function AuthScreen() {
       track('login_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, login, router, track])
+  }, [username, password, inviteCode, login, getToken, router, track, params.returnTo])
 
   const handleInviteCodeContinue = useCallback(async () => {
     setErrors({})
@@ -174,6 +215,16 @@ export default function AuthScreen() {
       if (result.success) {
         track('signup_success', { source: 'auth' })
         router.replace(params.returnTo ? `/onboarding?returnTo=${encodeURIComponent(params.returnTo)}` : '/onboarding')
+      } else if (/already exists/i.test(result.message || '')) {
+        // new-22: the email is already registered. Don't dead-end — flip to
+        // login holding the invite + returnTo. The held code is applied after
+        // login (see handleLogin) so a grandfathered account gets upgraded.
+        track('auth_email_collision', { source: 'auth' })
+        setCollisionFlip(true)
+        setAuthStep('login')
+        setPassword('')
+        setConfirmPassword('')
+        setErrors({})
       } else {
         track('signup_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
@@ -182,7 +233,7 @@ export default function AuthScreen() {
       track('signup_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, confirmPassword, inviteCode, signup, router, track])
+  }, [username, password, confirmPassword, inviteCode, signup, router, track, params.returnTo])
 
   const handleSubmit = useCallback(
     (e?: any) => {
@@ -210,6 +261,7 @@ export default function AuthScreen() {
     setPassword('')
     setConfirmPassword('')
     setInviteCode('')
+    setCollisionFlip(false)
     setErrors({})
   }, [authStep, track])
 
@@ -311,7 +363,9 @@ export default function AuthScreen() {
                 className="text-content dark:text-content-dark"
               >
                 {authStep === 'login'
-                  ? 'Welcome back.'
+                  ? collisionFlip
+                    ? 'You already have an account'
+                    : 'Welcome back.'
                   : authStep === 'invite-code'
                   ? 'Enter your invite link.'
                   : authStep === 'signup'
@@ -341,7 +395,9 @@ export default function AuthScreen() {
                 style={{ color: '#78716C' }}
               >
                 {authStep === 'login'
-                  ? 'Enter your password to continue'
+                  ? collisionFlip
+                    ? "Log in and we'll apply the invite to it."
+                    : 'Enter your password to continue'
                   : authStep === 'invite-code'
                   ? 'Paste your invite link or code to continue'
                   : authStep === 'signup'
@@ -349,6 +405,33 @@ export default function AuthScreen() {
                   : 'Enter your email to get started'}
               </Text>
             </View>
+
+            {/* Applied-invite bar (#403): the vouch carries into account
+                creation, and is "held" when an email collision flips to login. */}
+            {hasInvite && (authStep === 'signup' || authStep === 'login') && (
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 8,
+                  backgroundColor: 'rgba(232,134,42,0.1)',
+                  borderRadius: 12,
+                  paddingVertical: 12,
+                  paddingHorizontal: 14,
+                  marginBottom: 16,
+                }}
+              >
+                <Text style={{ fontSize: 15 }}>🪔</Text>
+                <Text className="font-sans" style={{ flex: 1, fontSize: 14, lineHeight: 20, color: '#B05A12' }}>
+                  <Text style={{ fontWeight: '700', color: '#E8862A' }}>
+                    {inviterName ? `${inviterName}'s invite applied.` : 'Invite applied.'}
+                  </Text>
+                  {authStep === 'signup'
+                    ? " You're a member the moment you finish."
+                    : ' Held while you log in.'}
+                </Text>
+              </View>
+            )}
 
             {/* Form */}
             {errorMessages.length > 0 && (

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -4,6 +4,7 @@ import { useUser } from '../components/contexts'
 import { useAnalytics } from '../utils/analytics'
 import { validateEmail, validatePassword } from '../utils'
 import { extractInviteCode } from '../utils/validation'
+import { inviteClient } from '../src/auth/inviteClient'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -50,7 +51,7 @@ const AUTH_CAROUSEL_IMAGES = [
 
 export default function AuthScreen() {
   const router = useRouter()
-  const { checkUserExists, login, signup, loading } = useUser()
+  const { checkUserExists, login, signup, loading, getToken } = useUser()
   const { track } = useAnalytics()
 
   // Read mode, returnTo, inviteCode, and email from URL params.
@@ -75,6 +76,10 @@ export default function AuthScreen() {
   const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const [showDevPanel, setShowDevPanel] = useState(false)
+  // Invite intent (#403 slice 2): applied-invite bar + email-collision flip.
+  const [inviterName, setInviterName] = useState<string | null>(null)
+  const [collisionFlip, setCollisionFlip] = useState(false)
+  const hasInvite = !!extractInviteCode(inviteCode)
   const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
   // Focus state for input styling
   const [emailFocused, setEmailFocused] = useState(false)
@@ -96,8 +101,26 @@ export default function AuthScreen() {
     setInviteCode(urlInviteCode || '')
     setPassword('')
     setConfirmPassword('')
+    setCollisionFlip(false)
     setErrors({})
   }, [initialMode, urlEmail, urlInviteCode])
+
+  // Resolve the inviter's name for the applied bar whenever a code is present.
+  // Best-effort: a miss falls back to the nameless copy.
+  useEffect(() => {
+    const code = extractInviteCode(inviteCode)
+    if (!code) {
+      setInviterName(null)
+      return
+    }
+    let cancelled = false
+    inviteClient.lookup(code).then((res) => {
+      if (!cancelled) setInviterName(res.valid ? res.inviterFirstName : null)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [inviteCode])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -149,6 +172,19 @@ export default function AuthScreen() {
       const result = await login(username, password)
       if (result.success) {
         track('login_success', { source: 'auth' })
+        // new-22 grandfather upgrade: apply an invite held through login (from a
+        // collision flip or Door 1's "Already a member?") so an existing
+        // open-signup account gets promoted. Best-effort — never blocks login.
+        const heldCode = extractInviteCode(inviteCode)
+        if (heldCode) {
+          try {
+            const token = await getToken()
+            if (token) await inviteClient.redeem(token, heldCode)
+            track('invite_applied_on_login', { source: 'auth' })
+          } catch {
+            // ignore — login already succeeded
+          }
+        }
         router.replace(returnTo ? (returnTo as never) : '/(tabs)')
       } else {
         track('login_failed', { source: 'auth', reason: result.message })
@@ -158,7 +194,7 @@ export default function AuthScreen() {
       track('login_failed', { source: 'auth', reason: 'network_error' })
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
-  }, [username, password, returnTo, login, router, track])
+  }, [username, password, inviteCode, returnTo, login, getToken, router, track])
 
   const handleSignup = useCallback(async () => {
     setErrors({})
@@ -183,6 +219,15 @@ export default function AuthScreen() {
       if (result.success) {
         track('signup_success', { source: 'auth' })
         router.replace(returnTo ? `/onboarding?returnTo=${encodeURIComponent(returnTo)}` : '/onboarding')
+      } else if (/already exists/i.test(result.message || '')) {
+        // new-22: email already registered → flip to login holding the invite,
+        // applied after login (handleLogin) to upgrade a grandfathered account.
+        track('auth_email_collision', { source: 'auth' })
+        setCollisionFlip(true)
+        setAuthStep('login')
+        setPassword('')
+        setConfirmPassword('')
+        setErrors({})
       } else {
         track('signup_failed', { source: 'auth', reason: result.message })
         setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
@@ -246,6 +291,7 @@ export default function AuthScreen() {
     setPassword('')
     setConfirmPassword('')
     setInviteCode('')
+    setCollisionFlip(false)
     setErrors({})
   }, [authStep, track])
 
@@ -313,7 +359,9 @@ export default function AuthScreen() {
 
   const heading =
     authStep === 'login'
-      ? 'Welcome back.'
+      ? collisionFlip
+        ? 'You already have an account'
+        : 'Welcome back.'
       : authStep === 'invite-code'
         ? 'Enter your invite link.'
         : authStep === 'signup'
@@ -322,7 +370,9 @@ export default function AuthScreen() {
 
   const subtitle =
     authStep === 'login'
-      ? 'Enter your password to continue'
+      ? collisionFlip
+        ? "Log in and we'll apply the invite to it."
+        : 'Enter your password to continue'
       : authStep === 'invite-code'
         ? 'Paste your invite link or code to continue'
         : authStep === 'signup'
@@ -506,6 +556,39 @@ export default function AuthScreen() {
           >
             {subtitle}
           </p>
+
+          {/* Applied-invite bar (#403): the vouch carries into account creation,
+              and is "held" when an email collision flips to login. */}
+          {hasInvite && (authStep === 'signup' || authStep === 'login') && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                backgroundColor: 'rgba(232,134,42,0.1)',
+                borderRadius: 12,
+                padding: '12px 14px',
+                marginBottom: 16,
+              }}
+            >
+              <span style={{ fontSize: 15 }}>🪔</span>
+              <span
+                style={{
+                  fontFamily: 'Inclusive Sans, sans-serif',
+                  fontSize: 14,
+                  lineHeight: '20px',
+                  color: '#B05A12',
+                }}
+              >
+                <span style={{ fontWeight: 700, color: '#E8862A' }}>
+                  {inviterName ? `${inviterName}'s invite applied.` : 'Invite applied.'}
+                </span>
+                {authStep === 'signup'
+                  ? " You're a member the moment you finish."
+                  : ' Held while you log in.'}
+              </span>
+            </div>
+          )}
 
           {/* Error alert box */}
           {errorMessages.length > 0 && (


### PR DESCRIPTION
Second slice of #403, on top of Door 1 (#452). The vouch now follows the invitee into account creation, and an email collision no longer dead-ends.

## What lands
- **Applied-invite bar on signup** — "Member's invite applied. You're a member the moment you finish." Nameless fallback when the resolver returns no name.
- **Email collision → login flip (new-22)** — registering an already-registered email flips to login holding the invite + returnTo: "You already have an account" / "Held while you log in." No raw error dead-end.
- **Grandfather upgrade** — on login with a held code, redeem it (best-effort) so an existing open-signup account gets promoted.

Applied to **both** `auth.tsx` (native) and `auth.web.tsx` (web) — the web build resolves the `.web` variant, so parity matters. Terms/Privacy footer (copy-03) already existed.

## Verified (local web)
- Signup with invite → applied bar shows the inviter's name; lookup returns 200
- Signup with an existing email → register 409 → flips to login, heading "You already have an account", bar reads "Held while you log in", single password field

## Not in this slice
Cutting the typed invite-code step (form-03) pairs with the paste-invite screen (next slice). Hard-gate enforcement and logged-out browse surfaces stay in later #403/#404 slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)