### PR TITLE
feat(invites): paste-invite screen + cut typed invite step (#403 Phase 1.3)

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -234,6 +234,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
         pathname.startsWith('/center/') ||
         pathname.startsWith('/i/') ||
         pathname.startsWith('/invite/') ||
+        pathname === '/join' ||
         pathname.startsWith('/privacy') ||
         pathname.startsWith('/terms') ||
         pathname.startsWith('/cookies')

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -19,7 +19,6 @@ import { extractInviteCode } from '../utils/validation'
 import { inviteClient } from '../src/auth/inviteClient'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
-import { API_BASE_URL } from '../src/config/api'
 // __DEV__ is a React Native/Expo global — always false in production builds.
 // EXPO_PUBLIC_SHOW_DEV_TOOLS=1 also enables the dev/demo tools (set on the
 // isolated v2 preview build), so role-switching works for demos there too.
@@ -27,7 +26,7 @@ const isDev =
   (typeof __DEV__ !== 'undefined' && __DEV__) ||
   process.env.EXPO_PUBLIC_SHOW_DEV_TOOLS === '1'
 
-type AuthStep = 'initial' | 'login' | 'invite-code' | 'signup'
+type AuthStep = 'initial' | 'login' | 'signup'
 
 export default function AuthScreen() {
   const router = useRouter()
@@ -115,8 +114,10 @@ export default function AuthScreen() {
         track('auth_user_exists', { source: 'auth' })
         setAuthStep('login')
       } else {
+        // form-03 cut (#403): the invite is the door, so a new email goes
+        // straight to account creation. Manual codes enter via /join (new-25).
         track('auth_user_new', { source: 'auth' })
-        setAuthStep('invite-code')
+        setAuthStep('signup')
       }
     } catch (e: any) {
       track('auth_check_failed', { source: 'auth' })
@@ -163,34 +164,6 @@ export default function AuthScreen() {
       setErrors({ form: 'Failed to connect to server. Please try again.' })
     }
   }, [username, password, inviteCode, login, getToken, router, track, params.returnTo])
-
-  const handleInviteCodeContinue = useCallback(async () => {
-    setErrors({})
-    if (!inviteCode) {
-      setErrors({ inviteCode: 'Please enter your invite code.' })
-      return
-    }
-    try {
-      track('auth_invite_code_submitted', { source: 'auth' })
-      // Validate the invite code with the backend
-      const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: extractInviteCode(inviteCode) }),
-      })
-      const data = await response.json()
-      if (data.valid) {
-        track('auth_invite_code_valid', { source: 'auth' })
-        setAuthStep('signup')
-      } else {
-        track('auth_invite_code_invalid', { source: 'auth' })
-        setErrors({ form: data.error || 'Invalid or inactive invite code.' })
-      }
-    } catch (e: any) {
-      track('auth_invite_code_check_failed', { source: 'auth' })
-      setErrors({ form: 'Failed to validate invite code. Please try again.' })
-    }
-  }, [inviteCode, track])
 
   const handleSignup = useCallback(async () => {
     setErrors({})
@@ -244,15 +217,13 @@ export default function AuthScreen() {
 
       if (authStep === 'login') {
         handleLogin()
-      } else if (authStep === 'invite-code') {
-        handleInviteCodeContinue()
       } else if (authStep === 'signup') {
         handleSignup()
       } else {
         handleContinue()
       }
     },
-    [authStep, handleLogin, handleInviteCodeContinue, handleSignup, handleContinue]
+    [authStep, handleLogin, handleSignup, handleContinue]
   )
 
   const handleBack = useCallback(() => {
@@ -268,8 +239,7 @@ export default function AuthScreen() {
   const isButtonDisabled =
     loading ||
     (authStep === 'initial' && !username) ||
-    (authStep === 'invite-code' && !inviteCode) ||
-    (authStep !== 'initial' && authStep !== 'invite-code' && !password) ||
+    (authStep !== 'initial' && !password) ||
     (authStep === 'signup' && !confirmPassword)
 
   // Collect error messages to display
@@ -289,11 +259,6 @@ export default function AuthScreen() {
   const handleConfirmPasswordChange = useCallback((text: string) => {
     setConfirmPassword(text)
     setErrors((prev) => ({ ...prev, confirmPassword: '' }))
-  }, [])
-
-  const handleInviteCodeChange = useCallback((text: string) => {
-    setInviteCode(text)
-    setErrors((prev) => ({ ...prev, inviteCode: '' }))
   }, [])
 
   return (
@@ -366,8 +331,6 @@ export default function AuthScreen() {
                   ? collisionFlip
                     ? 'You already have an account'
                     : 'Welcome back.'
-                  : authStep === 'invite-code'
-                  ? 'Enter your invite link.'
                   : authStep === 'signup'
                   ? 'Join the community.'
                   : 'Welcome.'}
@@ -398,8 +361,6 @@ export default function AuthScreen() {
                   ? collisionFlip
                     ? "Log in and we'll apply the invite to it."
                     : 'Enter your password to continue'
-                  : authStep === 'invite-code'
-                  ? 'Paste your invite link or code to continue'
                   : authStep === 'signup'
                   ? 'Create your account to get started'
                   : 'Enter your email to get started'}
@@ -467,19 +428,6 @@ export default function AuthScreen() {
                 </View>
               )}
 
-              {authStep === 'invite-code' && (
-                <View>
-                  <AuthInput
-                    placeholder="Invite link or code"
-                    onChangeText={handleInviteCodeChange}
-                    value={inviteCode}
-                    secureTextEntry={false}
-                    autoComplete="off"
-                    style={{}}
-                  />
-                </View>
-              )}
-
               {authStep === 'signup' && (
                 <>
                   <View>
@@ -515,8 +463,6 @@ export default function AuthScreen() {
               >
                {authStep === 'login'
                    ? 'Log In'
-                   : authStep === 'invite-code'
-                   ? 'Continue'
                    : authStep === 'signup'
                    ? 'Sign Up'
                   : 'Continue'}
@@ -529,6 +475,19 @@ export default function AuthScreen() {
                   onPress={() => { track('auth_forgot_password_pressed', { source: 'auth' }); router.push('/auth/forgot') }}
                 >
                   <Text className="text-primary font-sans font-medium">Forgot password?</Text>
+                </Pressable>
+              )}
+
+              {/* Have an invite? — manual code entry now that the typed step is
+                  cut (form-03). Routes to the neutral paste screen (new-25). */}
+              {authStep === 'initial' && (
+                <Pressable
+                  className="items-center mt-2"
+                  onPress={() => { track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') }}
+                >
+                  <Text className="font-sans" style={{ fontSize: 14, color: '#78716C' }}>
+                    Have an invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Paste it</Text>
+                  </Text>
                 </Pressable>
               )}
             </View>

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -13,7 +13,6 @@ const swamiChinmayanandaAlt = require('../assets/images/landing/Swami Chinmayana
 const swamiChinmayanandaOption2 = require('../assets/images/landing/Swami Chinmayananda Option 2.jpeg')
 import DevPanel from '../components/DevPanel'
 import Logo from '../components/ui/Logo'
-import { API_BASE_URL } from '../src/config/api'
 
 // __DEV__ is a React Native/Expo global — always false in production builds.
 // EXPO_PUBLIC_SHOW_DEV_TOOLS=1 also enables the dev/demo tools (set on the
@@ -41,7 +40,7 @@ if (typeof document !== 'undefined') {
   }
 }
 
-type AuthStep = 'initial' | 'login' | 'invite-code' | 'signup'
+type AuthStep = 'initial' | 'login' | 'signup'
 
 const AUTH_CAROUSEL_IMAGES = [
   swamiChinmayanandaJpg,
@@ -85,7 +84,6 @@ export default function AuthScreen() {
   const [emailFocused, setEmailFocused] = useState(false)
   const [passwordFocused, setPasswordFocused] = useState(false)
   const [confirmPasswordFocused, setConfirmPasswordFocused] = useState(false)
-  const [inviteCodeFocused, setInviteCodeFocused] = useState(false)
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth : 1280
   )
@@ -149,8 +147,10 @@ export default function AuthScreen() {
         track('auth_user_exists', { source: 'auth' })
         setAuthStep('login')
       } else {
+        // form-03 cut (#403): the invite is the door, so a new email goes
+        // straight to account creation. Manual codes enter via /join (new-25).
         track('auth_user_new', { source: 'auth' })
-        setAuthStep('invite-code')
+        setAuthStep('signup')
       }
     } catch (e: any) {
       track('auth_check_failed', { source: 'auth' })
@@ -238,34 +238,6 @@ export default function AuthScreen() {
     }
   }, [username, password, confirmPassword, inviteCode, returnTo, signup, router, track])
 
-  const handleInviteCodeContinue = useCallback(async () => {
-    setErrors({})
-    if (!inviteCode) {
-      setErrors({ inviteCode: 'Please enter your invite code.' })
-      return
-    }
-    try {
-      track('auth_invite_code_submitted', { source: 'auth' })
-      // Validate the invite code with the backend
-      const response = await fetch(`${API_BASE_URL}/auth/validate-invite-code`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: extractInviteCode(inviteCode) }),
-      })
-      const data = await response.json()
-      if (data.valid) {
-        track('auth_invite_code_valid', { source: 'auth' })
-        setAuthStep('signup')
-      } else {
-        track('auth_invite_code_invalid', { source: 'auth' })
-        setErrors({ form: data.error || 'Invalid or inactive invite code.' })
-      }
-    } catch (e: any) {
-      track('auth_invite_code_check_failed', { source: 'auth' })
-      setErrors({ form: 'Failed to validate invite code. Please try again.' })
-    }
-  }, [inviteCode, track])
-
   const handleSubmit = useCallback(
     (e?: any) => {
       if (e) {
@@ -274,15 +246,13 @@ export default function AuthScreen() {
       }
       if (authStep === 'login') {
         handleLogin()
-      } else if (authStep === 'invite-code') {
-        handleInviteCodeContinue()
       } else if (authStep === 'signup') {
         handleSignup()
       } else {
         handleContinue()
       }
     },
-    [authStep, handleLogin, handleInviteCodeContinue, handleSignup, handleContinue]
+    [authStep, handleLogin, handleSignup, handleContinue]
   )
 
   const handleBack = useCallback(() => {
@@ -310,16 +280,10 @@ export default function AuthScreen() {
     setErrors((prev) => ({ ...prev, confirmPassword: '' }))
   }, [])
 
-  const handleInviteCodeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setInviteCode(e.target.value)
-    setErrors((prev) => ({ ...prev, inviteCode: '' }))
-  }, [])
-
   const isButtonDisabled =
     loading ||
     (authStep === 'initial' && !username) ||
-    (authStep === 'invite-code' && !inviteCode) ||
-    (authStep !== 'initial' && authStep !== 'invite-code' && !password) ||
+    (authStep !== 'initial' && !password) ||
     (authStep === 'signup' && !confirmPassword)
 
   const errorMessages = Object.values(errors).filter(Boolean)
@@ -362,32 +326,26 @@ export default function AuthScreen() {
       ? collisionFlip
         ? 'You already have an account'
         : 'Welcome back.'
-      : authStep === 'invite-code'
-        ? 'Enter your invite link.'
-        : authStep === 'signup'
-          ? 'Join the community.'
-          : 'Welcome.'
+      : authStep === 'signup'
+        ? 'Join the community.'
+        : 'Welcome.'
 
   const subtitle =
     authStep === 'login'
       ? collisionFlip
         ? "Log in and we'll apply the invite to it."
         : 'Enter your password to continue'
-      : authStep === 'invite-code'
-        ? 'Paste your invite link or code to continue'
-        : authStep === 'signup'
-          ? 'Create your account to get started'
-          : 'Enter your email to get started'
+      : authStep === 'signup'
+        ? 'Create your account to get started'
+        : 'Enter your email to get started'
 
   const buttonText = loading
     ? 'Please wait...'
     : authStep === 'login'
       ? 'Sign In'
-      : authStep === 'invite-code'
-        ? 'Continue'
-        : authStep === 'signup'
-          ? 'Create Account'
-          : 'Continue'
+      : authStep === 'signup'
+        ? 'Create Account'
+        : 'Continue'
   const isNarrowWeb = viewportWidth < 1024
   const isMobile = viewportWidth < 640
 
@@ -649,43 +607,6 @@ export default function AuthScreen() {
               />
             )}
 
-            {/* Invite code input (invite-code step) */}
-            {authStep === 'invite-code' && (
-              <input
-                className="auth-input"
-                type="text"
-                placeholder="Invite link or code"
-                value={inviteCode}
-                onChange={handleInviteCodeChange}
-                autoComplete="off"
-                onFocus={() => setInviteCodeFocused(true)}
-                onBlur={() => setInviteCodeFocused(false)}
-                style={getInputStyle(inviteCodeFocused)}
-              />
-            )}
-            {authStep === 'invite-code' && (
-              <button
-                type="button"
-                onClick={() => {
-                  track('verification_explainer_opened', { source: 'auth' })
-                  router.push('/verification' as never)
-                }}
-                style={{
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  marginTop: -4,
-                  color: '#E8862A',
-                  fontSize: 13,
-                  cursor: 'pointer',
-                  textDecoration: 'underline',
-                  alignSelf: 'flex-start',
-                }}
-              >
-                How does verification work?
-              </button>
-            )}
-
             {/* Password + PasswordStrength + Confirm (signup) */}
             {authStep === 'signup' && (
               <>
@@ -815,6 +736,31 @@ export default function AuthScreen() {
                 }}
               >
                 Create one
+              </span>
+            </p>
+          )}
+
+          {/* Have an invite? — manual code entry now that the typed step is cut
+              (form-03). Routes to the neutral paste screen (new-25). */}
+          {authStep === 'initial' && (
+            <p
+              style={{
+                fontSize: 14,
+                color: '#78716C',
+                textAlign: 'center',
+                marginTop: 4,
+                fontFamily: 'Inclusive Sans, sans-serif',
+              }}
+            >
+              Have an invite?{' '}
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() => { track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') }}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') } }}
+                style={{ color: '#E8862A', cursor: 'pointer', fontWeight: 600, padding: '8px 4px', margin: '-8px -4px', display: 'inline-block' }}
+              >
+                Paste it
               </span>
             </p>
           )}

--- a/packages/frontend/app/i/[code].tsx
+++ b/packages/frontend/app/i/[code].tsx
@@ -1,13 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import {
-  View,
-  Text,
-  Pressable,
-  ActivityIndicator,
-  Image,
-  TextInput,
-  useWindowDimensions,
-} from 'react-native'
+import { View, Text, Pressable, ActivityIndicator, Image, useWindowDimensions } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
@@ -15,6 +7,7 @@ import { extractInviteCode } from '../../utils/validation'
 import { inviteClient } from '../../src/auth/inviteClient'
 import { INTRO_STEPS } from '../../components/intro/IntroSteps'
 import IntroCard from '../../components/intro/IntroCard'
+import PasteInvite from '../../components/invite/PasteInvite'
 import { useAnalytics } from '../../utils/analytics'
 
 /**
@@ -45,7 +38,6 @@ export default function InviteLinkScreen() {
 
   const [phase, setPhase] = useState<Phase>('resolving')
   const [inviterName, setInviterName] = useState<string | null>(null)
-  const [pasted, setPasted] = useState('')
 
   useEffect(() => {
     if (loading) return
@@ -88,13 +80,7 @@ export default function InviteLinkScreen() {
     router.replace(`/auth?mode=login&inviteCode=${encodeURIComponent(code)}`)
   }, [code, router])
 
-  const openPasted = useCallback(() => {
-    const next = extractInviteCode(pasted)
-    if (next) router.replace(`/i/${encodeURIComponent(next)}`)
-  }, [pasted, router])
-
   const heroWidth = Math.min(width, 440)
-  const canOpenPasted = !!extractInviteCode(pasted)
 
   return (
     <View style={{ flex: 1, backgroundColor: c.bg, alignItems: 'center', justifyContent: 'center' }}>
@@ -182,63 +168,12 @@ export default function InviteLinkScreen() {
         )}
 
         {phase === 'invalid' && (
-          // new-04 — dead/expired code: recovery, never a silent dump into signup.
-          <View style={{ width: '100%', alignItems: 'center', gap: 16 }}>
-            <View style={{ gap: 6, alignItems: 'center' }}>
-              <Text
-                style={{
-                  fontFamily: 'Inclusive Sans',
-                  fontSize: 26,
-                  color: c.text,
-                  textAlign: 'center',
-                }}
-              >
-                This invite isn't active
-              </Text>
-              <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center', lineHeight: 22 }}>
-                The link may have expired. Paste a fresh invite, or ask a member for one.
-              </Text>
-            </View>
-            <View style={{ width: '100%', gap: 10 }}>
-              <TextInput
-                value={pasted}
-                onChangeText={setPasted}
-                placeholder="Paste an invite link"
-                placeholderTextColor={c.textFaint}
-                autoCapitalize="none"
-                autoCorrect={false}
-                onSubmitEditing={openPasted}
-                style={{
-                  backgroundColor: c.surface,
-                  borderRadius: 8,
-                  paddingVertical: 12,
-                  paddingHorizontal: 14,
-                  fontSize: 15,
-                  color: c.text,
-                }}
-              />
-              <Pressable
-                onPress={openPasted}
-                disabled={!canOpenPasted}
-                style={{
-                  backgroundColor: canOpenPasted ? c.accent : c.surface,
-                  borderRadius: 12,
-                  paddingVertical: 15,
-                  alignItems: 'center',
-                }}
-              >
-                <Text
-                  style={{
-                    color: canOpenPasted ? c.textInverse : c.textFaint,
-                    fontSize: 16,
-                    fontWeight: '600',
-                  }}
-                >
-                  Open invite
-                </Text>
-              </Pressable>
-            </View>
-          </View>
+          // new-04 — dead/expired code: recovery (error variant of new-25).
+          // Never a silent dump into signup.
+          <PasteInvite
+            title="This invite isn't active"
+            subtitle="The link may have expired. Paste a fresh invite, or ask a member for one."
+          />
         )}
       </View>
     </View>

--- a/packages/frontend/app/join.tsx
+++ b/packages/frontend/app/join.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useColors } from '../hooks/useColors'
+import { extractInviteCode } from '../utils/validation'
+import PasteInvite from '../components/invite/PasteInvite'
+
+/**
+ * /join — neutral "Have an invite?" paste screen (new-25). The target of every
+ * "Have an invite?" affordance. Takes a link or bare code and hands off to
+ * Door 1 (`/i/[code]`), the single resolver.
+ *
+ * Also catches legacy `chinmayajanata.org/join?code=CODE` links: if a `code`
+ * param is present, skip the paste step and go straight to Door 1.
+ */
+export default function JoinScreen() {
+  const c = useColors()
+  const router = useRouter()
+  const { code: raw } = useLocalSearchParams<{ code?: string }>()
+  const legacyCode = extractInviteCode(typeof raw === 'string' ? raw : '')
+
+  useEffect(() => {
+    if (legacyCode) router.replace(`/i/${encodeURIComponent(legacyCode)}`)
+  }, [legacyCode, router])
+
+  if (legacyCode) return <View style={{ flex: 1, backgroundColor: c.bg }} />
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: c.bg,
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingHorizontal: 24,
+      }}
+    >
+      <PasteInvite
+        title="Have an invite?"
+        subtitle="Paste your invite link or code."
+        showBrowse
+      />
+    </View>
+  )
+}

--- a/packages/frontend/components/invite/PasteInvite.tsx
+++ b/packages/frontend/components/invite/PasteInvite.tsx
@@ -1,0 +1,90 @@
+import { useState, useCallback } from 'react'
+import { View, Text, TextInput, Pressable } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useColors } from '../../hooks/useColors'
+import { extractInviteCode } from '../../utils/validation'
+
+type PasteInviteProps = {
+  /** Headline — neutral ("Have an invite?") or error ("This invite isn't active"). */
+  title: string
+  /** Supporting line under the headline. */
+  subtitle: string
+  /** Show the "No invite? Browse events" escape (neutral entry only). */
+  showBrowse?: boolean
+}
+
+/**
+ * Shared paste-an-invite block (new-25). Used as the neutral entry screen
+ * (`/join`) and, with error copy, as Door 1's dead-code recovery (new-04).
+ * Takes a pasted link or bare code, normalizes it, and routes to Door 1 so the
+ * one resolver decides valid / invalid / already-a-member. RN primitives only,
+ * so the same component renders on web and native.
+ */
+export default function PasteInvite({ title, subtitle, showBrowse }: PasteInviteProps) {
+  const c = useColors()
+  const router = useRouter()
+  const [pasted, setPasted] = useState('')
+  const canOpen = !!extractInviteCode(pasted)
+
+  const open = useCallback(() => {
+    const code = extractInviteCode(pasted)
+    if (code) router.replace(`/i/${encodeURIComponent(code)}`)
+  }, [pasted, router])
+
+  return (
+    <View style={{ width: '100%', maxWidth: 440, alignItems: 'center', gap: 16 }}>
+      <View style={{ gap: 6, alignItems: 'center' }}>
+        <Text
+          style={{ fontFamily: 'Inclusive Sans', fontSize: 26, color: c.text, textAlign: 'center' }}
+        >
+          {title}
+        </Text>
+        <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center', lineHeight: 22 }}>
+          {subtitle}
+        </Text>
+      </View>
+
+      <View style={{ width: '100%', gap: 10 }}>
+        <TextInput
+          value={pasted}
+          onChangeText={setPasted}
+          placeholder="Paste an invite link or code"
+          placeholderTextColor={c.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          onSubmitEditing={open}
+          style={{
+            backgroundColor: c.surface,
+            borderRadius: 8,
+            paddingVertical: 12,
+            paddingHorizontal: 14,
+            fontSize: 15,
+            color: c.text,
+          }}
+        />
+        <Pressable
+          onPress={open}
+          disabled={!canOpen}
+          style={{
+            backgroundColor: canOpen ? c.accent : c.surface,
+            borderRadius: 12,
+            paddingVertical: 15,
+            alignItems: 'center',
+          }}
+        >
+          <Text style={{ color: canOpen ? c.textInverse : c.textFaint, fontSize: 16, fontWeight: '600' }}>
+            Open invite
+          </Text>
+        </Pressable>
+      </View>
+
+      {showBrowse && (
+        <Pressable onPress={() => router.replace('/(tabs)')} style={{ paddingVertical: 8 }}>
+          <Text style={{ color: c.textMuted, fontSize: 14 }}>
+            No invite? <Text style={{ color: c.accent, fontWeight: '600' }}>Browse events</Text>
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}


### PR DESCRIPTION
Third slice of #403, on top of Door 1 (#452) and auth invite-intent (#453). The invite is the door, so the typed invite-code step (form-03) is removed; manual codes enter through a neutral paste screen.

## What lands
- **Shared `PasteInvite` component** (RN primitives → web + native): paste a link or bare code, normalize, hand off to Door 1 (the single resolver).
- **`/join` route (new-25)** — "Have an invite? / Paste your invite link or code." + "No invite? Browse events". Also catches legacy `chinmayajanata.org/join?code=CODE` links and forwards to Door 1.
- **Door 1 dead-code recovery (new-04)** now reuses `PasteInvite` (error variant), deleting the duplicated inline paste UI.
- **form-03 cut** in `auth.tsx` + `auth.web.tsx` — a new email goes straight to account creation; "Have an invite? Paste it" on the initial step routes to `/join`. Dead invite-code handlers/inputs removed.
- **`_layout.tsx`** — `/join` is a public (logged-out) route, like `/i` and `/invite`.

## Verified (local web)
- `/join` renders; pasting a code → Open invite → `/i/CODE` Door 1 vouch
- New-email signup skips the typed step (lands on "Join the community.", 2 password fields); no invite-code input remains
- Door 1 invalid code still recovers via the shared component
- "Have an invite? Paste it" present on the auth initial step

## Not in this slice
Guest RSVP (new-11) is the next slice. Hard-gate enforcement and logged-out browse surfaces stay in later #403/#404 slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)