### PR TITLE
fix(invites): venue-friendly invite lookup, no false dead-invite (#403)

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -306,7 +306,12 @@ app.post('/userExistence', async (c) => {
  * Validate an invite code for beta access
  * Public endpoint (no authentication required)
  */
-app.post('/auth/validate-invite-code', rateLimit(10, 60_000), async (c) => {
+// Read-only invite lookup (Door 1 vouch + signup applied bar). Codes are
+// unguessable 48-bit randoms, so brute-force enumeration isn't a real threat;
+// the tight 10/min cap mainly punished legit invitees sharing a venue's NAT IP
+// at MSC. Raised to a venue-friendly 60/min; the client retries transient 429s
+// rather than showing "invite isn't active" (#403).
+app.post('/auth/validate-invite-code', rateLimit(60, 60_000), async (c) => {
   let body: { code?: string } = {}
   try {
     body = await c.req.json<{ code: string }>()

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -37,9 +37,12 @@ export default function AuthScreen() {
 
   // Read params for deep-link support (e.g. from AuthPromptModal, or
   // /auth/forgot's "Back to sign in" button).
-  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string }>()
+  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string; inviter?: string }>()
   const urlInviteCode = params.inviteCode
   const urlEmail = typeof params.email === 'string' ? params.email : ''
+  // Door 1 carries the resolved inviter name forward, so the applied bar shows
+  // the vouch without a second lookup. Absent → nameless.
+  const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
 
   // mode=login needs a prefilled email. mode=signup can work with only an
   // invite code because the email field stays editable in that flow.
@@ -56,31 +59,12 @@ export default function AuthScreen() {
   const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
 
   // Invite intent (#403 slice 2): the applied-invite bar + email-collision flip.
-  // `inviterName` powers the vouch copy ("Anand's invite applied"); null → nameless.
   // `collisionFlip` = we bounced a signup whose email already exists into login,
   // holding the invite to apply on the way in (new-22).
-  const [inviterName, setInviterName] = useState<string | null>(null)
   const [collisionFlip, setCollisionFlip] = useState(false)
   const hasInvite = !!extractInviteCode(inviteCode)
 
   const [showDevPanel, setShowDevPanel] = useState(false)
-
-  // Resolve the inviter's name for the applied bar whenever a code is present.
-  // Best-effort: a miss just falls back to the nameless copy.
-  useEffect(() => {
-    const code = extractInviteCode(inviteCode)
-    if (!code) {
-      setInviterName(null)
-      return
-    }
-    let cancelled = false
-    inviteClient.lookup(code).then((res) => {
-      if (!cancelled) setInviterName(res.valid ? res.inviterFirstName : null)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [inviteCode])
 
   useEffect(() => {
     const nextStep =

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -55,11 +55,14 @@ export default function AuthScreen() {
 
   // Read mode, returnTo, inviteCode, and email from URL params.
   // useLocalSearchParams stays reactive during Expo Router SPA navigation.
-  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string }>()
+  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string; inviter?: string }>()
   const initialMode = typeof params.mode === 'string' ? params.mode : ''
   const returnTo = typeof params.returnTo === 'string' ? params.returnTo : null
   const urlInviteCode = typeof params.inviteCode === 'string' ? params.inviteCode : ''
   const urlEmail = typeof params.email === 'string' ? params.email : ''
+  // Door 1 carries the resolved inviter name forward, so the applied bar shows
+  // the vouch without a second lookup. Absent → nameless.
+  const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
 
   // When inviteCode is provided via URL (e.g. from public explore flow), skip
   // the invite-code step and go straight to signup. mode=login still needs a
@@ -76,7 +79,6 @@ export default function AuthScreen() {
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const [showDevPanel, setShowDevPanel] = useState(false)
   // Invite intent (#403 slice 2): applied-invite bar + email-collision flip.
-  const [inviterName, setInviterName] = useState<string | null>(null)
   const [collisionFlip, setCollisionFlip] = useState(false)
   const hasInvite = !!extractInviteCode(inviteCode)
   const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
@@ -102,23 +104,6 @@ export default function AuthScreen() {
     setCollisionFlip(false)
     setErrors({})
   }, [initialMode, urlEmail, urlInviteCode])
-
-  // Resolve the inviter's name for the applied bar whenever a code is present.
-  // Best-effort: a miss falls back to the nameless copy.
-  useEffect(() => {
-    const code = extractInviteCode(inviteCode)
-    if (!code) {
-      setInviterName(null)
-      return
-    }
-    let cancelled = false
-    inviteClient.lookup(code).then((res) => {
-      if (!cancelled) setInviterName(res.valid ? res.inviterFirstName : null)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [inviteCode])
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/packages/frontend/app/i/[code].tsx
+++ b/packages/frontend/app/i/[code].tsx
@@ -24,7 +24,7 @@ import { useAnalytics } from '../../utils/analytics'
  *   - already logged in  → "you're already a member"        (new-05)
  */
 
-type Phase = 'resolving' | 'valid' | 'invalid' | 'member'
+type Phase = 'resolving' | 'valid' | 'invalid' | 'member' | 'error'
 
 export default function InviteLinkScreen() {
   const router = useRouter()
@@ -38,6 +38,8 @@ export default function InviteLinkScreen() {
 
   const [phase, setPhase] = useState<Phase>('resolving')
   const [inviterName, setInviterName] = useState<string | null>(null)
+  // Bumped by the retry button to re-run the lookup after a transient failure.
+  const [reloadKey, setReloadKey] = useState(0)
 
   useEffect(() => {
     if (loading) return
@@ -54,12 +56,16 @@ export default function InviteLinkScreen() {
     setPhase('resolving')
     inviteClient.lookup(code).then((res) => {
       if (cancelled) return
-      if (res.valid) {
+      if (res.status === 'valid') {
         setInviterName(res.inviterFirstName)
         setPhase('valid')
         track('door1_view', { has_inviter_name: !!res.inviterFirstName })
-      } else {
+      } else if (res.status === 'invalid') {
         setPhase('invalid')
+      } else {
+        // Transient (network / rate limit) — let the visitor retry rather than
+        // telling a real invitee their good code is dead.
+        setPhase('error')
       }
     })
     return () => {
@@ -68,17 +74,26 @@ export default function InviteLinkScreen() {
     // `track` is intentionally excluded — including the (unstable) analytics fn
     // re-runs this effect every render, which storms the lookup endpoint.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, code, isAuthenticated])
+  }, [loading, code, isAuthenticated, reloadKey])
+
+  // Carry the resolved inviter name forward so /auth shows the vouch without a
+  // second lookup. Encoded; empty when nameless.
+  const withInviter = useCallback(
+    (mode: 'signup' | 'login') =>
+      `/auth?mode=${mode}&inviteCode=${encodeURIComponent(code)}` +
+      (inviterName ? `&inviter=${encodeURIComponent(inviterName)}` : ''),
+    [code, inviterName],
+  )
 
   const accept = useCallback(() => {
     track('invite_accept_tap', { invite_code: code })
-    router.replace(`/auth?mode=signup&inviteCode=${encodeURIComponent(code)}`)
-  }, [code, router, track])
+    router.replace(withInviter('signup') as never)
+  }, [code, router, track, withInviter])
 
   const logIn = useCallback(() => {
     // Hold the code so a returning member's account gets the upgrade (#403 slice 2).
-    router.replace(`/auth?mode=login&inviteCode=${encodeURIComponent(code)}`)
-  }, [code, router])
+    router.replace(withInviter('login') as never)
+  }, [router, withInviter])
 
   const heroWidth = Math.min(width, 440)
 
@@ -174,6 +189,32 @@ export default function InviteLinkScreen() {
             title="This invite isn't active"
             subtitle="The link may have expired. Paste a fresh invite, or ask a member for one."
           />
+        )}
+
+        {phase === 'error' && (
+          // Transient failure (network / rate limit): retry, don't condemn the code.
+          <View style={{ alignItems: 'center', gap: 16 }}>
+            <View style={{ gap: 6, alignItems: 'center' }}>
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 26, color: c.text, textAlign: 'center' }}>
+                Couldn't open your invite
+              </Text>
+              <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center', lineHeight: 22 }}>
+                Check your connection and try again.
+              </Text>
+            </View>
+            <Pressable
+              onPress={() => setReloadKey((k) => k + 1)}
+              style={{
+                backgroundColor: c.accent,
+                borderRadius: 12,
+                paddingVertical: 15,
+                paddingHorizontal: 48,
+                alignItems: 'center',
+              }}
+            >
+              <Text style={{ color: c.textInverse, fontSize: 16, fontWeight: '600' }}>Try again</Text>
+            </Pressable>
+          </View>
         )}
       </View>
     </View>

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -101,17 +101,22 @@ export interface RedeemResponse extends GenericSuccessResponse {
   user: User
 }
 
-export interface InviteLookup {
-  valid: boolean
-  /** Inviter's first name for the Door 1 vouch, or null → nameless vouch. */
-  inviterFirstName: string | null
-}
+/**
+ * Outcome of an invite lookup. `valid`/`invalid` are definitive answers from the
+ * server; `error` is transient (network, 429 rate limit, 5xx) and the caller
+ * should offer a retry rather than declaring the invite dead.
+ */
+export type InviteLookup =
+  | { status: 'valid'; inviterFirstName: string | null }
+  | { status: 'invalid' }
+  | { status: 'error' }
 
 export const inviteClient = {
   /**
    * Look up an invite code for Door 1: is it usable, and who minted it. Public
-   * (no auth). Treats any network/parse failure as an invalid code so the
-   * screen degrades to the recovery state rather than hanging.
+   * (no auth). A `200 { valid:false }` is a genuinely dead code (invalid); a
+   * network failure or 429/5xx is transient (error) so callers can retry — a
+   * rate-limited invitee at a shared-IP venue must not see "invite isn't active".
    */
   async lookup(code: string): Promise<InviteLookup> {
     try {
@@ -120,13 +125,13 @@ export const inviteClient = {
         { method: 'POST', body: JSON.stringify({ code }) },
         API_TIMEOUTS.standard,
       )
+      if (!response.ok) return { status: 'error' }
       const data = await safeJson<{ valid?: boolean; inviterFirstName?: string | null }>(response)
-      if (!response.ok || !data?.valid) {
-        return { valid: false, inviterFirstName: null }
-      }
-      return { valid: true, inviterFirstName: data.inviterFirstName ?? null }
+      if (!data) return { status: 'error' }
+      if (!data.valid) return { status: 'invalid' }
+      return { status: 'valid', inviterFirstName: data.inviterFirstName ?? null }
     } catch {
-      return { valid: false, inviterFirstName: null }
+      return { status: 'error' }
     }
   },
 


### PR DESCRIPTION
Hardening the Door 1 lookup against an MSC launch-day failure mode, plus a simplification.

## The risk
`/auth/validate-invite-code` was capped at **10/min per IP**. At MSC, dozens of invitees open links on the **same venue WiFi** (one NAT IP) → 429s. And `lookup()` treated any non-200 as invalid, so a real invitee with a good code would see **"This invite isn't active."** at the worst possible moment.

## What changes
- **Rate limit 10 → 60/min.** Invite codes are unguessable 48-bit randoms, so the tight cap bought no real anti-abuse — it only punished shared-IP venues.
- **`lookup()` returns `valid | invalid | error`.** Transient failures (network, 429, 5xx) → a "Couldn't open your invite — Try again" retry on Door 1, never the dead-code recovery. Only a real `200 {valid:false}` shows "invite isn't active".
- **Inviter name carried via URL** (`/auth?...&inviter=Name`) from Door 1, so the signup applied bar shows the vouch without a second lookup. Removed the duplicate lookup effect from both auth files — one round-trip per flow instead of two.

## Verified (local web)
- Door 1 → Accept → `/auth?...&inviter=Member`; applied bar shows "Member's invite applied"; **exactly one** validate call total (was two)
- Typecheck clean (12 pre-existing, 0 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)