### PR TITLE
refactor(auth): shared useAuthFlow hook, end auth.tsx/web duplication (#403)

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useState } from 'react'
 import {
   View,
   Text,
@@ -8,17 +8,16 @@ import {
   Pressable,
   TouchableOpacity,
 } from 'react-native'
-import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Code, ArrowLeft } from 'lucide-react-native'
 import { useAnalytics } from '../utils/analytics'
 import { AuthInput, Logo, PrimaryButton } from '../components/ui'
-import { useUser, useTheme } from '../components/contexts'
-import { validateEmail, validatePassword } from '../utils'
-import { extractInviteCode } from '../utils/validation'
-import { inviteClient } from '../src/auth/inviteClient'
+import { useTheme } from '../components/contexts'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
+import { useAuthFlow } from '../components/auth/useAuthFlow'
+
 // __DEV__ is a React Native/Expo global — always false in production builds.
 // EXPO_PUBLIC_SHOW_DEV_TOOLS=1 also enables the dev/demo tools (set on the
 // isolated v2 preview build), so role-switching works for demos there too.
@@ -26,224 +25,35 @@ const isDev =
   (typeof __DEV__ !== 'undefined' && __DEV__) ||
   process.env.EXPO_PUBLIC_SHOW_DEV_TOOLS === '1'
 
-type AuthStep = 'initial' | 'login' | 'signup'
-
 export default function AuthScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const { isDark } = useTheme()
-  const { checkUserExists, login, signup, loading, getToken } = useUser()
   const { track } = useAnalytics()
 
-  // Read params for deep-link support (e.g. from AuthPromptModal, or
-  // /auth/forgot's "Back to sign in" button).
-  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string; inviter?: string }>()
-  const urlInviteCode = params.inviteCode
-  const urlEmail = typeof params.email === 'string' ? params.email : ''
-  // Door 1 carries the resolved inviter name forward, so the applied bar shows
-  // the vouch without a second lookup. Absent → nameless.
-  const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
-
-  // mode=login needs a prefilled email. mode=signup can work with only an
-  // invite code because the email field stays editable in that flow.
-  const [authStep, setAuthStep] = useState<AuthStep>(
-    params.mode === 'login' && urlEmail ? 'login'
-      : params.mode === 'signup' && urlInviteCode ? 'signup'
-      : 'initial'
-  )
-  const [username, setUsername] = useState(urlEmail)
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
-  const [errors, setErrors] = useState<{ [key: string]: string }>({})
-  const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
-
-  // Invite intent (#403 slice 2): the applied-invite bar + email-collision flip.
-  // `collisionFlip` = we bounced a signup whose email already exists into login,
-  // holding the invite to apply on the way in (new-22).
-  const [collisionFlip, setCollisionFlip] = useState(false)
-  const hasInvite = !!extractInviteCode(inviteCode)
+  // All auth state + handlers live in the shared hook (see auth.web.tsx — same
+  // logic, different presentation). This file is RN markup only.
+  const {
+    authStep,
+    username,
+    password,
+    confirmPassword,
+    errorMessages,
+    loading,
+    inviterName,
+    hasInvite,
+    emailEditable,
+    isButtonDisabled,
+    heading,
+    subtitle,
+    changeUsername,
+    changePassword,
+    changeConfirm,
+    handleSubmit,
+    handleBack,
+  } = useAuthFlow()
 
   const [showDevPanel, setShowDevPanel] = useState(false)
-
-  useEffect(() => {
-    const nextStep =
-      params.mode === 'login' && urlEmail ? 'login'
-        : params.mode === 'signup' && urlInviteCode ? 'signup'
-        : 'initial'
-
-    setAuthStep(nextStep)
-    setUsername(urlEmail)
-    setInviteCode(urlInviteCode || '')
-    setPassword('')
-    setConfirmPassword('')
-    setCollisionFlip(false)
-    setErrors({})
-  }, [params.mode, urlEmail, urlInviteCode])
-
-  const handleContinue = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-    if (!validateEmail(username)) {
-      setErrors({ username: 'You must enter a valid email address.' })
-      return
-    }
-    try {
-      track('auth_email_submitted', { source: 'auth' })
-      const exists = await checkUserExists(username)
-      if (exists) {
-        track('auth_user_exists', { source: 'auth' })
-        setAuthStep('login')
-      } else {
-        // form-03 cut (#403): the invite is the door, so a new email goes
-        // straight to account creation. Manual codes enter via /join (new-25).
-        track('auth_user_new', { source: 'auth' })
-        setAuthStep('signup')
-      }
-    } catch (e: any) {
-      track('auth_check_failed', { source: 'auth' })
-      setErrors({ form: e.message || 'Failed to connect to server.' })
-    }
-  }, [username, checkUserExists, track])
-
-  const handleLogin = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-
-    if (!password) {
-      setErrors({ password: 'Please enter your password.' })
-      return
-    }
-    try {
-      const result = await login(username, password)
-      if (result.success) {
-        track('login_success', { source: 'auth' })
-        // new-22 grandfather upgrade: if the invite was held through the login
-        // (collision flip or "Already a member?" from Door 1), apply it now so
-        // an existing open-signup account gets promoted. Best-effort — a stale
-        // or already-consumed code must never block the login.
-        const heldCode = extractInviteCode(inviteCode)
-        if (heldCode) {
-          try {
-            const token = await getToken()
-            if (token) await inviteClient.redeem(token, heldCode)
-            track('invite_applied_on_login', { source: 'auth' })
-          } catch {
-            // ignore — login already succeeded
-          }
-        }
-        router.replace(params.returnTo ? (params.returnTo as never) : '/(tabs)')
-      } else {
-        track('login_failed', { source: 'auth', reason: result.message })
-        setErrors({ form: result.message || 'Username or password is incorrect.' })
-      }
-    } catch (e: any) {
-      track('login_failed', { source: 'auth', reason: 'network_error' })
-      setErrors({ form: 'Failed to connect to server. Please try again.' })
-    }
-  }, [username, password, inviteCode, login, getToken, router, track, params.returnTo])
-
-  const handleSignup = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-    if (!password) {
-      setErrors({ password: 'Please enter a password.' })
-      return
-    }
-    if (!validatePassword(password).isValid) {
-      setErrors({ password: 'Password does not meet complexity requirements.' })
-      return
-    }
-    if (password !== confirmPassword) {
-      setErrors({ confirmPassword: 'Passwords do not match.' })
-      return
-    }
-    try {
-      const result = await signup(username, password, extractInviteCode(inviteCode))
-      if (result.success) {
-        track('signup_success', { source: 'auth' })
-        router.replace(params.returnTo ? `/onboarding?returnTo=${encodeURIComponent(params.returnTo)}` : '/onboarding')
-      } else if (/already exists/i.test(result.message || '')) {
-        // new-22: the email is already registered. Don't dead-end — flip to
-        // login holding the invite + returnTo. The held code is applied after
-        // login (see handleLogin) so a grandfathered account gets upgraded.
-        track('auth_email_collision', { source: 'auth' })
-        setCollisionFlip(true)
-        setAuthStep('login')
-        setPassword('')
-        setConfirmPassword('')
-        setErrors({})
-      } else {
-        track('signup_failed', { source: 'auth', reason: result.message })
-        setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
-      }
-    } catch (e: any) {
-      track('signup_failed', { source: 'auth', reason: 'network_error' })
-      setErrors({ form: 'Failed to connect to server. Please try again.' })
-    }
-  }, [username, password, confirmPassword, inviteCode, signup, router, track, params.returnTo])
-
-  const handleSubmit = useCallback(
-    (e?: any) => {
-      if (Platform.OS === 'web' && e) {
-        e.preventDefault?.()
-        e.stopPropagation?.()
-      }
-
-      if (authStep === 'login') {
-        handleLogin()
-      } else if (authStep === 'signup') {
-        handleSignup()
-      } else {
-        handleContinue()
-      }
-    },
-    [authStep, handleLogin, handleSignup, handleContinue]
-  )
-
-  const handleBack = useCallback(() => {
-    track('auth_back_pressed', { source: 'auth', from_step: authStep })
-    setAuthStep('initial')
-    setPassword('')
-    setConfirmPassword('')
-    setInviteCode('')
-    setCollisionFlip(false)
-    setErrors({})
-  }, [authStep, track])
-
-  const isButtonDisabled =
-    loading ||
-    (authStep === 'initial' && !username) ||
-    (authStep !== 'initial' && !password) ||
-    (authStep === 'signup' && !confirmPassword)
-
-  // Collect error messages to display
-  const errorMessages = Object.values(errors).filter(Boolean)
-
-  // Memoize input handlers to prevent recreation
-  const handleUsernameChange = useCallback((text: string) => {
-    setUsername(text)
-    setErrors((prev) => ({ ...prev, username: '' }))
-  }, [])
-
-  const handlePasswordChange = useCallback((text: string) => {
-    setPassword(text)
-    setErrors((prev) => ({ ...prev, password: '' }))
-  }, [])
-
-  const handleConfirmPasswordChange = useCallback((text: string) => {
-    setConfirmPassword(text)
-    setErrors((prev) => ({ ...prev, confirmPassword: '' }))
-  }, [])
 
   return (
     <KeyboardAvoidingView
@@ -272,16 +82,10 @@ export default function AuthScreen() {
         {/* Main content */}
         <View
           className="flex-1 justify-center items-center w-full px-6"
-          style={{
-            paddingTop: 60,
-            paddingBottom: 48,
-          }}
+          style={{ paddingTop: 60, paddingBottom: 48 }}
         >
           {/* Container */}
-          <View
-            className="w-full"
-            style={{ maxWidth: 400 }}
-          >
+          <View className="w-full" style={{ maxWidth: 400 }}>
             {/* Back Button */}
             {authStep !== 'initial' && (
               <TouchableOpacity
@@ -290,13 +94,8 @@ export default function AuthScreen() {
                 className="flex-row items-center gap-2 mb-6 rounded-xl px-3 py-2 self-start"
                 style={{ alignSelf: 'flex-start' }}
               >
-                <ArrowLeft
-                  size={20}
-                  className={isDark ? 'text-white' : 'text-content'}
-                />
-                <Text className="font-sans font-medium text-content dark:text-content-dark">
-                  Back
-                </Text>
+                <ArrowLeft size={20} className={isDark ? 'text-white' : 'text-content'} />
+                <Text className="font-sans font-medium text-content dark:text-content-dark">Back</Text>
               </TouchableOpacity>
             )}
 
@@ -311,13 +110,7 @@ export default function AuthScreen() {
                 style={{ fontFamily: '"Inclusive Sans"', fontSize: 36, fontWeight: '400' }}
                 className="text-content dark:text-content-dark"
               >
-                {authStep === 'login'
-                  ? collisionFlip
-                    ? 'You already have an account'
-                    : 'Welcome back.'
-                  : authStep === 'signup'
-                  ? 'Join the community.'
-                  : 'Welcome.'}
+                {heading}
               </Text>
 
               {/* What Janata is — first step only, so a new member knows what
@@ -337,17 +130,8 @@ export default function AuthScreen() {
                 </View>
               )}
 
-              <Text
-                className="text-base font-sans mt-2"
-                style={{ color: '#78716C' }}
-              >
-                {authStep === 'login'
-                  ? collisionFlip
-                    ? "Log in and we'll apply the invite to it."
-                    : 'Enter your password to continue'
-                  : authStep === 'signup'
-                  ? 'Create your account to get started'
-                  : 'Enter your email to get started'}
+              <Text className="text-base font-sans mt-2" style={{ color: '#78716C' }}>
+                {subtitle}
               </Text>
             </View>
 
@@ -378,7 +162,7 @@ export default function AuthScreen() {
               </View>
             )}
 
-            {/* Form */}
+            {/* Errors */}
             {errorMessages.length > 0 && (
               <View className="w-full font-sans bg-red-50 dark:bg-red-900/20 rounded-xl px-4 py-3 mb-4">
                 {errorMessages.map((msg, idx) => (
@@ -389,11 +173,12 @@ export default function AuthScreen() {
               </View>
             )}
 
+            {/* Form */}
             <View className="gap-4">
               <View>
                 <AuthInput
                   placeholder="Email"
-                  onChangeText={handleUsernameChange}
+                  onChangeText={changeUsername}
                   value={username}
                   secureTextEntry={false}
                   editable={emailEditable}
@@ -403,7 +188,7 @@ export default function AuthScreen() {
                 <View>
                   <AuthInput
                     placeholder="Password"
-                    onChangeText={handlePasswordChange}
+                    onChangeText={changePassword}
                     value={password}
                     secureTextEntry
                     autoComplete="password"
@@ -418,7 +203,7 @@ export default function AuthScreen() {
                     <PasswordStrength password={password} show={password.length > 0} />
                     <AuthInput
                       placeholder="Password"
-                      onChangeText={handlePasswordChange}
+                      onChangeText={changePassword}
                       value={password}
                       secureTextEntry
                       autoComplete="password-new"
@@ -428,7 +213,7 @@ export default function AuthScreen() {
                   <View>
                     <AuthInput
                       placeholder="Confirm password"
-                      onChangeText={handleConfirmPasswordChange}
+                      onChangeText={changeConfirm}
                       value={confirmPassword}
                       secureTextEntry
                       autoComplete="password-new"
@@ -445,11 +230,7 @@ export default function AuthScreen() {
                 loading={loading}
                 style={{ marginTop: 8 }}
               >
-               {authStep === 'login'
-                   ? 'Log In'
-                   : authStep === 'signup'
-                   ? 'Sign Up'
-                  : 'Continue'}
+                {authStep === 'login' ? 'Log In' : authStep === 'signup' ? 'Sign Up' : 'Continue'}
               </PrimaryButton>
 
               {/* Forgot Password (only on login) */}

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -1,12 +1,9 @@
-import React, { useState, useCallback, useEffect } from 'react'
-import { useLocalSearchParams, useRouter } from 'expo-router'
-import { useUser } from '../components/contexts'
+import React, { useState, useEffect } from 'react'
+import { useRouter } from 'expo-router'
 import { useAnalytics } from '../utils/analytics'
-import { validateEmail, validatePassword } from '../utils'
-import { extractInviteCode } from '../utils/validation'
-import { inviteClient } from '../src/auth/inviteClient'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
+import { useAuthFlow } from '../components/auth/useAuthFlow'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const swamiChinmayanandaJpg = require('../assets/images/landing/Swami Chinmayananda.jpg')
 const swamiChinmayanandaAlt = require('../assets/images/landing/Swami Chinmayananda (1).jpg')
@@ -40,8 +37,6 @@ if (typeof document !== 'undefined') {
   }
 }
 
-type AuthStep = 'initial' | 'login' | 'signup'
-
 const AUTH_CAROUSEL_IMAGES = [
   swamiChinmayanandaJpg,
   swamiChinmayanandaAlt,
@@ -50,228 +45,45 @@ const AUTH_CAROUSEL_IMAGES = [
 
 export default function AuthScreen() {
   const router = useRouter()
-  const { checkUserExists, login, signup, loading, getToken } = useUser()
   const { track } = useAnalytics()
 
-  // Read mode, returnTo, inviteCode, and email from URL params.
-  // useLocalSearchParams stays reactive during Expo Router SPA navigation.
-  const params = useLocalSearchParams<{ mode?: string; returnTo?: string; inviteCode?: string; email?: string; inviter?: string }>()
-  const initialMode = typeof params.mode === 'string' ? params.mode : ''
-  const returnTo = typeof params.returnTo === 'string' ? params.returnTo : null
-  const urlInviteCode = typeof params.inviteCode === 'string' ? params.inviteCode : ''
-  const urlEmail = typeof params.email === 'string' ? params.email : ''
-  // Door 1 carries the resolved inviter name forward, so the applied bar shows
-  // the vouch without a second lookup. Absent → nameless.
-  const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
+  // Shared auth state machine (see auth.tsx — same logic, RN presentation).
+  const {
+    authStep,
+    username,
+    password,
+    confirmPassword,
+    errorMessages,
+    loading,
+    inviterName,
+    hasInvite,
+    emailEditable,
+    isButtonDisabled,
+    heading,
+    subtitle,
+    changeUsername,
+    changePassword,
+    changeConfirm,
+    handleSubmit,
+    handleBack,
+    createAccount,
+  } = useAuthFlow()
 
-  // When inviteCode is provided via URL (e.g. from public explore flow), skip
-  // the invite-code step and go straight to signup. mode=login still needs a
-  // prefilled email, while signup without an email keeps the email field editable.
-  const [authStep, setAuthStep] = useState<AuthStep>(
-    initialMode === 'login' && urlEmail ? 'login'
-      : initialMode === 'signup' && urlInviteCode ? 'signup'
-      : 'initial'
-  )
-  const [username, setUsername] = useState(urlEmail)
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
-  const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  // Web-only presentation state.
   const [showDevPanel, setShowDevPanel] = useState(false)
-  // Invite intent (#403 slice 2): applied-invite bar + email-collision flip.
-  const [collisionFlip, setCollisionFlip] = useState(false)
-  const hasInvite = !!extractInviteCode(inviteCode)
-  const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
-  // Focus state for input styling
   const [emailFocused, setEmailFocused] = useState(false)
   const [passwordFocused, setPasswordFocused] = useState(false)
   const [confirmPasswordFocused, setConfirmPasswordFocused] = useState(false)
   const [viewportWidth, setViewportWidth] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth : 1280
+    typeof window !== 'undefined' ? window.innerWidth : 1280,
   )
 
   useEffect(() => {
-    const nextStep =
-      initialMode === 'login' && urlEmail ? 'login'
-        : initialMode === 'signup' && urlInviteCode ? 'signup'
-        : 'initial'
-
-    setAuthStep(nextStep)
-    setUsername(urlEmail)
-    setInviteCode(urlInviteCode || '')
-    setPassword('')
-    setConfirmPassword('')
-    setCollisionFlip(false)
-    setErrors({})
-  }, [initialMode, urlEmail, urlInviteCode])
-
-  useEffect(() => {
     if (typeof window === 'undefined') return
-
     const onResize = () => setViewportWidth(window.innerWidth)
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   }, [])
-
-  // --- Auth Handlers (same logic as auth.tsx) ---
-
-  const handleContinue = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-    if (!validateEmail(username)) {
-      setErrors({ username: 'You must enter a valid email address.' })
-      return
-    }
-    try {
-      track('auth_email_submitted', { source: 'auth' })
-      const exists = await checkUserExists(username)
-      if (exists) {
-        track('auth_user_exists', { source: 'auth' })
-        setAuthStep('login')
-      } else {
-        // form-03 cut (#403): the invite is the door, so a new email goes
-        // straight to account creation. Manual codes enter via /join (new-25).
-        track('auth_user_new', { source: 'auth' })
-        setAuthStep('signup')
-      }
-    } catch (e: any) {
-      track('auth_check_failed', { source: 'auth' })
-      setErrors({ form: e.message || 'Failed to connect to server.' })
-    }
-  }, [username, checkUserExists, track])
-
-  const handleLogin = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-    if (!password) {
-      setErrors({ password: 'Please enter your password.' })
-      return
-    }
-    try {
-      const result = await login(username, password)
-      if (result.success) {
-        track('login_success', { source: 'auth' })
-        // new-22 grandfather upgrade: apply an invite held through login (from a
-        // collision flip or Door 1's "Already a member?") so an existing
-        // open-signup account gets promoted. Best-effort — never blocks login.
-        const heldCode = extractInviteCode(inviteCode)
-        if (heldCode) {
-          try {
-            const token = await getToken()
-            if (token) await inviteClient.redeem(token, heldCode)
-            track('invite_applied_on_login', { source: 'auth' })
-          } catch {
-            // ignore — login already succeeded
-          }
-        }
-        router.replace(returnTo ? (returnTo as never) : '/(tabs)')
-      } else {
-        track('login_failed', { source: 'auth', reason: result.message })
-        setErrors({ form: result.message || 'Username or password is incorrect.' })
-      }
-    } catch (e: any) {
-      track('login_failed', { source: 'auth', reason: 'network_error' })
-      setErrors({ form: 'Failed to connect to server. Please try again.' })
-    }
-  }, [username, password, inviteCode, returnTo, login, getToken, router, track])
-
-  const handleSignup = useCallback(async () => {
-    setErrors({})
-    if (!username) {
-      setErrors({ username: 'Please enter a username.' })
-      return
-    }
-    if (!password) {
-      setErrors({ password: 'Please enter a password.' })
-      return
-    }
-    if (!validatePassword(password).isValid) {
-      setErrors({ password: 'Password does not meet complexity requirements.' })
-      return
-    }
-    if (password !== confirmPassword) {
-      setErrors({ confirmPassword: 'Passwords do not match.' })
-      return
-    }
-    try {
-      const result = await signup(username, password, extractInviteCode(inviteCode))
-      if (result.success) {
-        track('signup_success', { source: 'auth' })
-        router.replace(returnTo ? `/onboarding?returnTo=${encodeURIComponent(returnTo)}` : '/onboarding')
-      } else if (/already exists/i.test(result.message || '')) {
-        // new-22: email already registered → flip to login holding the invite,
-        // applied after login (handleLogin) to upgrade a grandfathered account.
-        track('auth_email_collision', { source: 'auth' })
-        setCollisionFlip(true)
-        setAuthStep('login')
-        setPassword('')
-        setConfirmPassword('')
-        setErrors({})
-      } else {
-        track('signup_failed', { source: 'auth', reason: result.message })
-        setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
-      }
-    } catch (e: any) {
-      track('signup_failed', { source: 'auth', reason: 'network_error' })
-      setErrors({ form: 'Failed to connect to server. Please try again.' })
-    }
-  }, [username, password, confirmPassword, inviteCode, returnTo, signup, router, track])
-
-  const handleSubmit = useCallback(
-    (e?: any) => {
-      if (e) {
-        e.preventDefault?.()
-        e.stopPropagation?.()
-      }
-      if (authStep === 'login') {
-        handleLogin()
-      } else if (authStep === 'signup') {
-        handleSignup()
-      } else {
-        handleContinue()
-      }
-    },
-    [authStep, handleLogin, handleSignup, handleContinue]
-  )
-
-  const handleBack = useCallback(() => {
-    track('auth_back_pressed', { source: 'auth', from_step: authStep })
-    setAuthStep('initial')
-    setPassword('')
-    setConfirmPassword('')
-    setInviteCode('')
-    setCollisionFlip(false)
-    setErrors({})
-  }, [authStep, track])
-
-  const handleUsernameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setUsername(e.target.value)
-    setErrors((prev) => ({ ...prev, username: '' }))
-  }, [])
-
-  const handlePasswordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value)
-    setErrors((prev) => ({ ...prev, password: '' }))
-  }, [])
-
-  const handleConfirmPasswordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setConfirmPassword(e.target.value)
-    setErrors((prev) => ({ ...prev, confirmPassword: '' }))
-  }, [])
-
-  const isButtonDisabled =
-    loading ||
-    (authStep === 'initial' && !username) ||
-    (authStep !== 'initial' && !password) ||
-    (authStep === 'signup' && !confirmPassword)
-
-  const errorMessages = Object.values(errors).filter(Boolean)
 
   // --- Input style helpers ---
 
@@ -292,37 +104,15 @@ export default function AuthScreen() {
     boxSizing: 'border-box' as const,
     WebkitAppearance: 'none' as const,
   }
-
   const focusInputStyle: React.CSSProperties = {
     borderColor: '#E8862A',
     boxShadow: '0 0 0 3px rgba(194,65,12,0.1)',
     backgroundColor: '#FFFFFF',
   }
-
   const getInputStyle = (focused: boolean): React.CSSProperties => ({
     ...baseInputStyle,
     ...(focused ? focusInputStyle : {}),
   })
-
-  // --- Heading and subtitle per step ---
-
-  const heading =
-    authStep === 'login'
-      ? collisionFlip
-        ? 'You already have an account'
-        : 'Welcome back.'
-      : authStep === 'signup'
-        ? 'Join the community.'
-        : 'Welcome.'
-
-  const subtitle =
-    authStep === 'login'
-      ? collisionFlip
-        ? "Log in and we'll apply the invite to it."
-        : 'Enter your password to continue'
-      : authStep === 'signup'
-        ? 'Create your account to get started'
-        : 'Enter your email to get started'
 
   const buttonText = loading
     ? 'Please wait...'
@@ -560,17 +350,14 @@ export default function AuthScreen() {
           )}
 
           {/* Form */}
-          <form
-            onSubmit={handleSubmit}
-            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
-          >
+          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
             {/* Email input */}
             <input
               className="auth-input"
               type="email"
               placeholder="Email"
               value={username}
-              onChange={handleUsernameChange}
+              onChange={(e) => changeUsername(e.target.value)}
               disabled={!emailEditable}
               onFocus={() => setEmailFocused(true)}
               onBlur={() => setEmailFocused(false)}
@@ -584,7 +371,7 @@ export default function AuthScreen() {
                 type="password"
                 placeholder="Password"
                 value={password}
-                onChange={handlePasswordChange}
+                onChange={(e) => changePassword(e.target.value)}
                 autoComplete="current-password"
                 onFocus={() => setPasswordFocused(true)}
                 onBlur={() => setPasswordFocused(false)}
@@ -600,7 +387,7 @@ export default function AuthScreen() {
                   type="password"
                   placeholder="Password"
                   value={password}
-                  onChange={handlePasswordChange}
+                  onChange={(e) => changePassword(e.target.value)}
                   autoComplete="new-password"
                   onFocus={() => setPasswordFocused(true)}
                   onBlur={() => setPasswordFocused(false)}
@@ -614,7 +401,7 @@ export default function AuthScreen() {
                   type="password"
                   placeholder="Confirm password"
                   value={confirmPassword}
-                  onChange={handleConfirmPasswordChange}
+                  onChange={(e) => changeConfirm(e.target.value)}
                   autoComplete="new-password"
                   onFocus={() => setConfirmPasswordFocused(true)}
                   onBlur={() => setConfirmPasswordFocused(false)}
@@ -665,53 +452,8 @@ export default function AuthScreen() {
               <span
                 role="button"
                 tabIndex={0}
-                onClick={async () => {
-                  if (!username) {
-                    setErrors({ username: 'Please enter your email first.' })
-                    return
-                  }
-                  if (!validateEmail(username)) {
-                    setErrors({ username: 'You must enter a valid email address.' })
-                    return
-                  }
-                  track('auth_create_account_pressed', { source: 'auth' })
-                  try {
-                    const exists = await checkUserExists(username)
-                    if (exists) {
-                      setErrors({ form: 'An account with this email already exists. Please log in.' })
-                      setAuthStep('login')
-                    } else {
-                      setAuthStep('signup')
-                    }
-                  } catch (e: any) {
-                    setErrors({ form: e.message || 'Failed to connect to server.' })
-                  }
-                }}
-                onKeyDown={async (e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    if (!username) {
-                      setErrors({ username: 'Please enter your email first.' })
-                      return
-                    }
-                    if (!validateEmail(username)) {
-                      setErrors({ username: 'You must enter a valid email address.' })
-                      return
-                    }
-                    track('auth_create_account_pressed', { source: 'auth' })
-                    try {
-                      const exists = await checkUserExists(username)
-                      if (exists) {
-                        setErrors({ form: 'An account with this email already exists. Please log in.' })
-                        setAuthStep('login')
-                      } else {
-                        setAuthStep('signup')
-                      }
-                    } catch (e: any) {
-                      setErrors({ form: e.message || 'Failed to connect to server.' })
-                    }
-                  }
-                }}
+                onClick={createAccount}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); createAccount() } }}
                 style={{
                   color: '#E8862A',
                   cursor: 'pointer',

--- a/packages/frontend/components/auth/useAuthFlow.ts
+++ b/packages/frontend/components/auth/useAuthFlow.ts
@@ -1,0 +1,295 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter, useLocalSearchParams } from 'expo-router'
+import { useUser } from '../contexts'
+import { useAnalytics } from '../../utils/analytics'
+import { validateEmail, validatePassword } from '../../utils'
+import { extractInviteCode } from '../../utils/validation'
+import { inviteClient } from '../../src/auth/inviteClient'
+
+export type AuthStep = 'initial' | 'login' | 'signup'
+
+/**
+ * useAuthFlow — the auth state machine shared by auth.tsx (native) and
+ * auth.web.tsx (web). The two screens are platform-split for presentation only
+ * (RN views vs HTML); this hook holds the logic so it lives in ONE place. Edits
+ * to behavior (invite intent, email collision, grandfather upgrade) happen here,
+ * not twice. Each screen wires the returned state/handlers into its own markup.
+ */
+export function useAuthFlow() {
+  const router = useRouter()
+  const { checkUserExists, login, signup, loading, getToken } = useUser()
+  const { track } = useAnalytics()
+
+  const params = useLocalSearchParams<{
+    mode?: string
+    returnTo?: string
+    inviteCode?: string
+    email?: string
+    inviter?: string
+  }>()
+  const urlInviteCode = typeof params.inviteCode === 'string' ? params.inviteCode : ''
+  const urlEmail = typeof params.email === 'string' ? params.email : ''
+  const returnTo = typeof params.returnTo === 'string' ? params.returnTo : null
+  // Door 1 carries the resolved inviter name forward, so the applied bar shows
+  // the vouch without a second lookup. Absent → nameless.
+  const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
+
+  // mode=login needs a prefilled email. mode=signup works with only an invite
+  // code because the email field stays editable in that flow.
+  const initialStep = (): AuthStep =>
+    params.mode === 'login' && urlEmail
+      ? 'login'
+      : params.mode === 'signup' && urlInviteCode
+        ? 'signup'
+        : 'initial'
+
+  const [authStep, setAuthStep] = useState<AuthStep>(initialStep)
+  const [username, setUsername] = useState(urlEmail)
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [inviteCode, setInviteCode] = useState(urlInviteCode || '')
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  // collisionFlip = a signup whose email already exists bounced into login,
+  // holding the invite to apply on the way in (new-22).
+  const [collisionFlip, setCollisionFlip] = useState(false)
+
+  const emailEditable = authStep === 'initial' || (authStep === 'signup' && !urlEmail)
+  const hasInvite = !!extractInviteCode(inviteCode)
+
+  // Re-sync when the URL params change (e.g. AuthPromptModal deep links).
+  useEffect(() => {
+    setAuthStep(initialStep())
+    setUsername(urlEmail)
+    setInviteCode(urlInviteCode || '')
+    setPassword('')
+    setConfirmPassword('')
+    setCollisionFlip(false)
+    setErrors({})
+    // initialStep is derived from these same params; listing the inputs is enough.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.mode, urlEmail, urlInviteCode])
+
+  const changeUsername = useCallback((text: string) => {
+    setUsername(text)
+    setErrors((prev) => ({ ...prev, username: '' }))
+  }, [])
+  const changePassword = useCallback((text: string) => {
+    setPassword(text)
+    setErrors((prev) => ({ ...prev, password: '' }))
+  }, [])
+  const changeConfirm = useCallback((text: string) => {
+    setConfirmPassword(text)
+    setErrors((prev) => ({ ...prev, confirmPassword: '' }))
+  }, [])
+
+  const handleContinue = useCallback(async () => {
+    setErrors({})
+    if (!username) {
+      setErrors({ username: 'Please enter a username.' })
+      return
+    }
+    if (!validateEmail(username)) {
+      setErrors({ username: 'You must enter a valid email address.' })
+      return
+    }
+    try {
+      track('auth_email_submitted', { source: 'auth' })
+      const exists = await checkUserExists(username)
+      if (exists) {
+        track('auth_user_exists', { source: 'auth' })
+        setAuthStep('login')
+      } else {
+        // form-03 cut (#403): the invite is the door, so a new email goes
+        // straight to account creation. Manual codes enter via /join (new-25).
+        track('auth_user_new', { source: 'auth' })
+        setAuthStep('signup')
+      }
+    } catch (e: any) {
+      track('auth_check_failed', { source: 'auth' })
+      setErrors({ form: e.message || 'Failed to connect to server.' })
+    }
+  }, [username, checkUserExists, track])
+
+  const handleLogin = useCallback(async () => {
+    setErrors({})
+    if (!username) {
+      setErrors({ username: 'Please enter a username.' })
+      return
+    }
+    if (!password) {
+      setErrors({ password: 'Please enter your password.' })
+      return
+    }
+    try {
+      const result = await login(username, password)
+      if (result.success) {
+        track('login_success', { source: 'auth' })
+        // new-22 grandfather upgrade: apply an invite held through login (a
+        // collision flip or Door 1's "Already a member?") so an existing
+        // open-signup account gets promoted. Best-effort — never blocks login.
+        const heldCode = extractInviteCode(inviteCode)
+        if (heldCode) {
+          try {
+            const token = await getToken()
+            if (token) await inviteClient.redeem(token, heldCode)
+            track('invite_applied_on_login', { source: 'auth' })
+          } catch {
+            // ignore — login already succeeded
+          }
+        }
+        router.replace(returnTo ? (returnTo as never) : '/(tabs)')
+      } else {
+        track('login_failed', { source: 'auth', reason: result.message })
+        setErrors({ form: result.message || 'Username or password is incorrect.' })
+      }
+    } catch (e: any) {
+      track('login_failed', { source: 'auth', reason: 'network_error' })
+      setErrors({ form: 'Failed to connect to server. Please try again.' })
+    }
+  }, [username, password, inviteCode, login, getToken, router, track, returnTo])
+
+  const handleSignup = useCallback(async () => {
+    setErrors({})
+    if (!username) {
+      setErrors({ username: 'Please enter a username.' })
+      return
+    }
+    if (!password) {
+      setErrors({ password: 'Please enter a password.' })
+      return
+    }
+    if (!validatePassword(password).isValid) {
+      setErrors({ password: 'Password does not meet complexity requirements.' })
+      return
+    }
+    if (password !== confirmPassword) {
+      setErrors({ confirmPassword: 'Passwords do not match.' })
+      return
+    }
+    try {
+      const result = await signup(username, password, extractInviteCode(inviteCode))
+      if (result.success) {
+        track('signup_success', { source: 'auth' })
+        router.replace(
+          returnTo ? `/onboarding?returnTo=${encodeURIComponent(returnTo)}` : '/onboarding',
+        )
+      } else if (/already exists/i.test(result.message || '')) {
+        // new-22: email already registered → flip to login holding the invite,
+        // applied after login (handleLogin) to upgrade a grandfathered account.
+        track('auth_email_collision', { source: 'auth' })
+        setCollisionFlip(true)
+        setAuthStep('login')
+        setPassword('')
+        setConfirmPassword('')
+        setErrors({})
+      } else {
+        track('signup_failed', { source: 'auth', reason: result.message })
+        setErrors({ form: result.message || 'Failed to sign up. Please try again.' })
+      }
+    } catch (e: any) {
+      track('signup_failed', { source: 'auth', reason: 'network_error' })
+      setErrors({ form: 'Failed to connect to server. Please try again.' })
+    }
+  }, [username, password, confirmPassword, inviteCode, signup, router, track, returnTo])
+
+  const handleSubmit = useCallback(
+    (e?: any) => {
+      if (e?.preventDefault) {
+        e.preventDefault()
+        e.stopPropagation?.()
+      }
+      if (authStep === 'login') handleLogin()
+      else if (authStep === 'signup') handleSignup()
+      else handleContinue()
+    },
+    [authStep, handleLogin, handleSignup, handleContinue],
+  )
+
+  const handleBack = useCallback(() => {
+    track('auth_back_pressed', { source: 'auth', from_step: authStep })
+    setAuthStep('initial')
+    setPassword('')
+    setConfirmPassword('')
+    setInviteCode('')
+    setCollisionFlip(false)
+    setErrors({})
+  }, [authStep, track])
+
+  // Web "Create one" affordance: validate the email, then route to login or
+  // signup. (Native reaches signup through handleContinue.)
+  const createAccount = useCallback(async () => {
+    if (!username) {
+      setErrors({ username: 'Please enter your email first.' })
+      return
+    }
+    if (!validateEmail(username)) {
+      setErrors({ username: 'You must enter a valid email address.' })
+      return
+    }
+    track('auth_create_account_pressed', { source: 'auth' })
+    try {
+      const exists = await checkUserExists(username)
+      if (exists) {
+        setErrors({ form: 'An account with this email already exists. Please log in.' })
+        setAuthStep('login')
+      } else {
+        setAuthStep('signup')
+      }
+    } catch (e: any) {
+      setErrors({ form: e.message || 'Failed to connect to server.' })
+    }
+  }, [username, checkUserExists, track])
+
+  const isButtonDisabled =
+    loading ||
+    (authStep === 'initial' && !username) ||
+    (authStep !== 'initial' && !password) ||
+    (authStep === 'signup' && !confirmPassword)
+
+  const errorMessages = Object.values(errors).filter(Boolean)
+
+  const heading =
+    authStep === 'login'
+      ? collisionFlip
+        ? 'You already have an account'
+        : 'Welcome back.'
+      : authStep === 'signup'
+        ? 'Join the community.'
+        : 'Welcome.'
+
+  const subtitle =
+    authStep === 'login'
+      ? collisionFlip
+        ? "Log in and we'll apply the invite to it."
+        : 'Enter your password to continue'
+      : authStep === 'signup'
+        ? 'Create your account to get started'
+        : 'Enter your email to get started'
+
+  return {
+    // state
+    authStep,
+    username,
+    password,
+    confirmPassword,
+    errors,
+    errorMessages,
+    collisionFlip,
+    loading,
+    // derived
+    inviterName,
+    hasInvite,
+    emailEditable,
+    isButtonDisabled,
+    heading,
+    subtitle,
+    // change handlers (value-based; web wraps with e => change(e.target.value))
+    changeUsername,
+    changePassword,
+    changeConfirm,
+    // actions
+    handleSubmit,
+    handleBack,
+    createAccount,
+  }
+}


### PR DESCRIPTION
Removes the structural tax behind the slice-2/3 double-editing: `auth.tsx` (native) and `auth.web.tsx` (web) each held a full copy of the auth state machine.

## What changes
- New `components/auth/useAuthFlow.ts` owns params, state, the param-sync effect, and the continue/login/signup/collision/grandfather-upgrade handlers + derived heading/subtitle/booleans.
- Both screens become presentation-only (RN views vs HTML) consuming the hook. Behavior can no longer drift between platforms, and future auth edits happen once.
- Button label stays per-platform ("Log In" native / "Sign In" web); everything else is shared.

## Pure refactor — no behavior change
Verified on web through the hook:
- Signup with invite → named applied bar
- Email collision → flip to login, "Held while you log in"
- Full login: email → "Welcome back." → Sign In → authenticated → `/`
- Initial-step "Create one" and "Have an invite? Paste it" links

Stacks logically on #455 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)