### PR TITLE
feat(invites): account-less guest RSVP sheet (#403 Phase 1.4)

### DIFF
--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -35,7 +35,7 @@ import EventDetailPanel from '../../components/events/EventDetailPanel.web'
 import EventFormPanel from '../../components/events/EventFormPanel.web'
 import CenterDetailPanel from '../../components/center/CenterDetailPanel.web'
 import { useDetailColors } from '../../hooks/useDetailColors'
-import AuthPromptModal from '../../components/ui/AuthPromptModal'
+import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
 import type { MapPoint, EventDisplay, AttendeeInfo } from '../../utils/api'
 import { removeEvent } from '../../utils/api'
 import { extractCityState } from '../../utils/addressParsing'
@@ -131,11 +131,11 @@ function EventPanelInner({
       prevRegisteredRef.current = event.isRegistered
     }
   }, [event?.isRegistered, event?.attendees, attendees, onStatusChange])
-  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
+  const [showGuestRsvp, setShowGuestRsvp] = useState(false)
 
   const handleToggleRegistration = async () => {
     if (!user) {
-      setShowAuthPrompt(true)
+      setShowGuestRsvp(true)
       return
     }
     if (!user.username) return
@@ -192,10 +192,10 @@ function EventPanelInner({
             : undefined
         }
       />
-      <AuthPromptModal
-        visible={showAuthPrompt}
-        onClose={() => setShowAuthPrompt(false)}
-        returnTo={`/explore?detail=event&id=${eventId}`}
+      <GuestRsvpSheet
+        visible={showGuestRsvp}
+        onClose={() => setShowGuestRsvp(false)}
+        eventId={eventId}
         eventTitle={event.title}
       />
     </>

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -25,7 +25,7 @@ import { createBoardPost, removeEvent } from '../../utils/api'
 import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../components/boards'
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
-import AuthPromptModal from '../../components/ui/AuthPromptModal'
+import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
@@ -589,7 +589,7 @@ export default function EventDetailPage() {
   const appColors = useColors()
   const hasTrackedView = useRef(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
-  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
+  const [showGuestRsvp, setShowGuestRsvp] = useState(false)
 
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
   const canEdit = isAdmin || isCreator
@@ -635,10 +635,11 @@ export default function EventDetailPage() {
   }
 
   const handleToggleRegistration = async () => {
-    // Guest taps RSVP → prompt to sign in (mirrors the web event detail).
+    // Guest taps RSVP → account-less RSVP sheet (name+email). Accounts are
+    // invite-only; the member path is the invite wall (#404), not RSVP.
     if (!user) {
-      track('event_auth_prompt_shown', { eventId: id, source: 'event_detail' })
-      setShowAuthPrompt(true)
+      track('event_guest_rsvp_opened', { eventId: id, source: 'event_detail' })
+      setShowGuestRsvp(true)
       return
     }
     if (!user.username) return
@@ -857,10 +858,10 @@ export default function EventDetailPage() {
         colors={colors}
       />
 
-      <AuthPromptModal
-        visible={showAuthPrompt}
-        onClose={() => setShowAuthPrompt(false)}
-        returnTo={`/events/${id}`}
+      <GuestRsvpSheet
+        visible={showGuestRsvp}
+        onClose={() => setShowGuestRsvp(false)}
+        eventId={id as string}
         eventTitle={event?.title}
       />
     </SafeAreaView>

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -11,7 +11,7 @@ import Avatar from '../../components/ui/Avatar'
 import Badge from '../../components/ui/Badge'
 import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
 import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
-import AuthPromptModal from '../../components/ui/AuthPromptModal'
+import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
 import { DetailSection } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
@@ -85,7 +85,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const { event, loading, toggleRegistration, isToggling, attendees, isCreator } = useEventDetail(eventId, user?.username, user?.id)
   const colors = useDetailColors()
   const appColors = useColors()
-  const [showAuthPrompt, setShowAuthPrompt] = useState(false)
+  const [showGuestRsvp, setShowGuestRsvp] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const hasTrackedView = useRef(false)
@@ -366,8 +366,8 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
                 <PrimaryButton
                   onPress={() => {
                     if (!user) {
-                      track('event_auth_prompt_shown', { eventId, source: 'event_detail' })
-                      setShowAuthPrompt(true)
+                      track('event_guest_rsvp_opened', { eventId, source: 'event_detail' })
+                      setShowGuestRsvp(true)
                     } else if (user.username) {
                       track('event_registered', { eventId, source: 'event_detail' })
                       toggleRegistration(user.username)
@@ -421,8 +421,8 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
             <PrimaryButton
               onPress={() => {
                 if (!user) {
-                  track('event_auth_prompt_shown', { eventId, source: 'event_detail' })
-                  setShowAuthPrompt(true)
+                  track('event_guest_rsvp_opened', { eventId, source: 'event_detail' })
+                  setShowGuestRsvp(true)
                 } else if (user.username) {
                   track('event_registered', { eventId, source: 'event_detail' })
                   toggleRegistration(user.username)
@@ -437,10 +437,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         </View>
       )}
 
-      <AuthPromptModal
-        visible={showAuthPrompt}
-        onClose={() => setShowAuthPrompt(false)}
-        returnTo={`/events/${eventId}`}
+      <GuestRsvpSheet
+        visible={showGuestRsvp}
+        onClose={() => setShowGuestRsvp(false)}
+        eventId={eventId}
         eventTitle={event?.title}
       />
     </View>

--- a/packages/frontend/components/events/GuestRsvpSheet.tsx
+++ b/packages/frontend/components/events/GuestRsvpSheet.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect, useCallback } from 'react'
+import { View, Text, Pressable, Modal, TextInput } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useDetailColors } from '../../hooks/useDetailColors'
+import { useAnalytics } from '../../utils/analytics'
+import { validateEmail } from '../../utils'
+import { attendEventGuest } from '../../utils/api'
+import PrimaryButton from '../ui/buttons/PrimaryButton'
+
+interface GuestRsvpSheetProps {
+  visible: boolean
+  onClose: () => void
+  eventId: string
+  eventTitle?: string
+}
+
+type Status = 'form' | 'submitting' | 'success' | 'already' | 'requiresVerified' | 'error'
+
+/**
+ * Account-less RSVP sheet (new-11 / new-11b). The low-friction guest funnel:
+ * name + email, no account. Backed by POST /attendEventGuest. Same component on
+ * web and native (RN Modal). Cancel-via-email is a follow-up (needs prod Resend).
+ */
+export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }: GuestRsvpSheetProps) {
+  const colors = useDetailColors()
+  const router = useRouter()
+  const { track } = useAnalytics()
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<Status>('form')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  const reset = useCallback(() => {
+    setName('')
+    setEmail('')
+    setStatus('form')
+    setErrorMsg('')
+  }, [])
+
+  const close = useCallback(() => {
+    reset()
+    onClose()
+  }, [reset, onClose])
+
+  useEffect(() => {
+    if (!visible) reset()
+  }, [visible, reset])
+
+  const submit = useCallback(async () => {
+    const trimmedName = name.trim()
+    const trimmedEmail = email.trim()
+    if (!trimmedName) {
+      setErrorMsg('Please enter your name.')
+      return
+    }
+    if (!validateEmail(trimmedEmail)) {
+      setErrorMsg('Enter a valid email address.')
+      return
+    }
+    setErrorMsg('')
+    setStatus('submitting')
+    try {
+      const res = await attendEventGuest(eventId, trimmedName, trimmedEmail)
+      track('guest_rsvp_submit', { eventId, alreadyRsvped: res.alreadyRsvped })
+      setStatus(res.alreadyRsvped ? 'already' : 'success')
+    } catch (e: any) {
+      if (e?.status === 403) {
+        setStatus('requiresVerified')
+      } else {
+        setErrorMsg(e?.message || 'Could not RSVP. Please try again.')
+        setStatus('error')
+      }
+    }
+  }, [name, email, eventId, track])
+
+  if (!visible) return null
+
+  const forEvent = eventTitle ? ` to ${eventTitle}` : ''
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={close}>
+      <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center', padding: 16 }}>
+        <Pressable style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }} onPress={close} />
+        <View
+          style={{
+            backgroundColor: colors.panelBg,
+            borderRadius: 16,
+            padding: 28,
+            width: 380,
+            maxWidth: '100%',
+            gap: 16,
+          }}
+        >
+          {(status === 'form' || status === 'submitting' || status === 'error') && (
+            <>
+              <View style={{ gap: 6 }}>
+                <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
+                  RSVP{forEvent}
+                </Text>
+                <Text style={{ fontSize: 15, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 22 }}>
+                  Just your name and email. No account needed.
+                </Text>
+              </View>
+              <View style={{ gap: 10 }}>
+                <TextInput
+                  value={name}
+                  onChangeText={(v) => { setName(v); setErrorMsg('') }}
+                  placeholder="Your name"
+                  autoCapitalize="words"
+                  placeholderTextColor={colors.textMuted}
+                  style={inputStyle(colors)}
+                />
+                <TextInput
+                  value={email}
+                  onChangeText={(v) => { setEmail(v); setErrorMsg('') }}
+                  placeholder="Email"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  onSubmitEditing={submit}
+                  placeholderTextColor={colors.textMuted}
+                  style={inputStyle(colors)}
+                />
+                {errorMsg ? (
+                  <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C' }}>{errorMsg}</Text>
+                ) : null}
+                <PrimaryButton onPress={submit} disabled={status === 'submitting'}>
+                  {status === 'submitting' ? 'RSVPing…' : 'RSVP'}
+                </PrimaryButton>
+              </View>
+              <Pressable onPress={close} style={{ alignSelf: 'center', paddingTop: 2 }}>
+                <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textMuted }}>Maybe later</Text>
+              </Pressable>
+            </>
+          )}
+
+          {status === 'success' && (
+            <View style={{ gap: 12, alignItems: 'center' }}>
+              <Text style={{ fontSize: 40 }}>🎉</Text>
+              <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
+                You're going{forEvent}
+              </Text>
+              <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 21 }}>
+                Want the full app? Members join Janata by invite. Ask a member to send you one.
+              </Text>
+              <PrimaryButton onPress={close} style={{ alignSelf: 'stretch' }}>Done</PrimaryButton>
+            </View>
+          )}
+
+          {status === 'already' && (
+            <View style={{ gap: 12, alignItems: 'center' }}>
+              <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
+                You're already on the list
+              </Text>
+              <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 21 }}>
+                You already RSVPed{forEvent} with this email.
+              </Text>
+              <PrimaryButton onPress={close} style={{ alignSelf: 'stretch' }}>Done</PrimaryButton>
+            </View>
+          )}
+
+          {status === 'requiresVerified' && (
+            <View style={{ gap: 12, alignItems: 'center' }}>
+              <Text style={{ fontSize: 22, fontFamily: 'Inclusive Sans', color: colors.text, textAlign: 'center' }}>
+                This event needs an account
+              </Text>
+              <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 21 }}>
+                Members join Janata by invite. Have one? Paste it to get in.
+              </Text>
+              <PrimaryButton
+                onPress={() => { close(); router.push('/join') }}
+                style={{ alignSelf: 'stretch' }}
+              >
+                Have an invite? Paste it
+              </PrimaryButton>
+              <Pressable onPress={close} style={{ paddingTop: 2 }}>
+                <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textMuted }}>Maybe later</Text>
+              </Pressable>
+            </View>
+          )}
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+function inputStyle(colors: ReturnType<typeof useDetailColors>) {
+  return {
+    width: '100%' as const,
+    height: 48,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    fontSize: 16,
+    fontFamily: 'Inclusive Sans',
+    color: colors.text,
+    backgroundColor: colors.cardBg,
+  }
+}

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -416,6 +416,30 @@ export async function fetchEventUsers(eventID: string): Promise<UserData[]> {
   }
 }
 
+/**
+ * Account-less RSVP (new-11): name + email, no auth. Returns `alreadyRsvped`
+ * so the sheet can show the dedupe state (new-11b). Throws with `.status` set
+ * so callers can special-case 403 (event requires a verified account).
+ */
+export async function attendEventGuest(
+  eventID: string,
+  name: string,
+  email: string,
+): Promise<{ alreadyRsvped: boolean }> {
+  const response = await apiFetch('/attendEventGuest', {
+    method: 'POST',
+    body: JSON.stringify({ eventID, name, email }),
+  })
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ message: 'Failed to RSVP' }))
+    const e = new Error(err.message || 'Failed to RSVP') as Error & { status?: number }
+    e.status = response.status
+    throw e
+  }
+  const data = await response.json()
+  return { alreadyRsvped: data.alreadyRsvped === true }
+}
+
 export async function attendEvent(eventID: string): Promise<{ peopleAttending: number }> {
   const response = await authFetch('/attendEvent', {
     method: 'POST',


### PR DESCRIPTION
Final slice of #403 Phase 1. The low-friction guest funnel (new-11 / new-11b): RSVP without an account.

## What lands
- **`GuestRsvpSheet`** (shared web + native) — tapping RSVP while logged out opens a name+email sheet, not the member sign-up modal (accounts are invite-only; the member path is the invite wall, #404).
  - Success → "You're going" + invite nudge ("Members join Janata by invite. Ask a member to send you one.")
  - Same email again → "You're already on the list" (new-11b dedupe)
  - Verified-only event → "needs an account" → paste an invite
- Wired into **all three** logged-out RSVP surfaces: native event detail, mobile-web event detail, desktop explore event panel.
- New `attendEventGuest()` client. Backend endpoint + `event_guest_rsvps` table already shipped (#191 / migration 0023), so no migration here.

## Verified (local web)
- Success ("You're going" + nudge), dedupe ("already on the list" — confirmed single DB row), and the verified-only → "needs an account" path

## Follow-up (not in this slice)
Confirmation email with a cancel link — guests have no session, so email is the only cancel channel. Needs prod Resend config (not locally testable), so it's a separate backend task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)