### PR TITLE
feat(analytics): web acquisition attribution — utm + referrer (#413)

### DIFF
--- a/packages/frontend/utils/analytics.ts
+++ b/packages/frontend/utils/analytics.ts
@@ -16,7 +16,7 @@
 import { useEffect, useRef } from 'react'
 import { usePathname } from 'expo-router'
 import { usePostHog } from 'posthog-react-native'
-import { resolveFirstSession, buildSuperProperties } from './analyticsEnv'
+import { resolveFirstSession, buildSuperProperties, readWebAcquisition } from './analyticsEnv'
 
 export { usePostHog }
 
@@ -386,6 +386,14 @@ export function AnalyticsBootstrap(): null {
       const isFirstSession = await resolveFirstSession()
       if (!active || !posthog) return
       void posthog.register(buildSuperProperties(isFirstSession))
+      // #413: web acquisition attribution. Register utm_*/referrer as super
+      // properties for this session, and stamp first-touch person properties
+      // via $set_once so signup/content_created break down by channel.
+      const acq = readWebAcquisition()
+      if (acq) {
+        void posthog.register(acq.superProps)
+        posthog.capture('web_acquisition', { ...acq.superProps, $set_once: acq.setOnce })
+      }
     })()
     return () => {
       active = false

--- a/packages/frontend/utils/analyticsEnv.ts
+++ b/packages/frontend/utils/analyticsEnv.ts
@@ -20,6 +20,9 @@ import { Platform } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const FIRST_SEEN_KEY = '@analytics_first_seen_at'
+const ACQUISITION_KEY = '@analytics_acquisition_v1'
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const
 
 /** expo-updates is optional at runtime (absent in some web/dev contexts). */
 function getReleaseChannel(): string {
@@ -53,6 +56,69 @@ export async function resolveFirstSession(): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Web acquisition attribution (#413). posthog-react-native doesn't auto-capture
+ * utm_* / referrer the way posthog-js does, so read them from the first landing
+ * URL + document.referrer and return:
+ *   - superProps: utm_* + $referrer/$referring_domain → register() so this
+ *     session's events (signup, content_created) are filterable by source.
+ *   - setOnce: $initial_* variants → first-touch person properties that stick
+ *     across sessions (PostHog's first-touch convention).
+ *
+ * Returns null off-web, after the first capture (localStorage-guarded so it's
+ * truly first-touch and internal navigations never overwrite it), or when
+ * there's nothing to attribute (no utm tags + same-origin/empty referrer).
+ */
+export function readWebAcquisition(): {
+  superProps: Record<string, string>
+  setOnce: Record<string, string>
+} | null {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return null
+  try {
+    if (localStorage.getItem(ACQUISITION_KEY)) return null
+
+    const params = new URLSearchParams(window.location.search)
+    const utm: Record<string, string> = {}
+    for (const key of UTM_KEYS) {
+      const v = params.get(key)
+      if (v) utm[key] = v
+    }
+
+    const referrer = document.referrer || ''
+    let referringDomain = ''
+    try {
+      referringDomain = referrer ? new URL(referrer).hostname : ''
+    } catch {
+      referringDomain = ''
+    }
+    const isExternalReferrer = !!referringDomain && referringDomain !== window.location.hostname
+
+    // Stamp now either way so we only inspect the genuine first landing.
+    localStorage.setItem(ACQUISITION_KEY, new Date().toISOString())
+
+    // Nothing to attribute: no campaign tags and no external referrer.
+    if (Object.keys(utm).length === 0 && !isExternalReferrer) return null
+
+    const referrerValue = isExternalReferrer ? referrer : '$direct'
+    const referringDomainValue = isExternalReferrer ? referringDomain : '$direct'
+
+    const superProps: Record<string, string> = {
+      ...utm,
+      $referrer: referrerValue,
+      $referring_domain: referringDomainValue,
+    }
+    const setOnce: Record<string, string> = {
+      $initial_referrer: referrerValue,
+      $initial_referring_domain: referringDomainValue,
+    }
+    for (const [k, v] of Object.entries(utm)) setOnce[`$initial_${k}`] = v
+
+    return { superProps, setOnce }
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
Closes #413. `posthog-react-native` doesn't auto-capture `utm_*`/referrer the way `posthog-js` does, so the landing → signup funnel had no source attribution on web — we couldn't tell which channels convert.

## What it does (web only, additive)
On the first web landing, reads `utm_source/medium/campaign/term/content` + `document.referrer` and:
- **registers** `utm_*` + `$referrer`/`$referring_domain` as super properties → this session's events (signup, `content_created`) break down by channel
- sets `$initial_*` variants as **`$set_once` person properties** (PostHog's first-touch convention) → acquisition source sticks across sessions

`localStorage`-guarded so it's truly first-touch (internal navigations never overwrite it); direct / no-utm visits record as `$direct` without noise. Native is untouched (`Platform.OS === 'web'` guard).

## Verification
- Typecheck clean; events POST to PostHog `/batch/` (200) on a `?utm_source=…` landing.
- **To confirm after ingestion:** in PostHog (project 361140), the `web_acquisition` event and the `$initial_utm_source` person property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)