### PR TITLE
feat(invites): role-bearing invite links for pilot/MSC admins (#451)

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -343,6 +343,53 @@ describe('invite gate (#403)', () => {
     expect(invitee?.invited_by_user_id).toBe(inviter?.id)
   })
 
+  describe('role-bearing invite links (#451)', () => {
+    it('lets an admin mint an admin-role link that lands the recipient at admin', async () => {
+      const adminToken = await createAdmin()
+      const { res, body } = await jsonPost(
+        '/api/auth/invite-codes',
+        { role: 'admin' },
+        authHeader(adminToken),
+      )
+      expect(res.status).toBe(200)
+      expect(body.role).toBe('admin')
+
+      await jsonPost('/api/auth/register', {
+        username: 'newadmin',
+        password: 'password123',
+        inviteCode: body.code,
+      })
+      const row = await env.DB.prepare('SELECT verification_level FROM users WHERE username = ?')
+        .bind('newadmin')
+        .first<{ verification_level: number }>()
+      // BRAHMACHARI (108) clears ADMIN_CUTOFF (107) → admin-capable.
+      expect(row?.verification_level).toBeGreaterThanOrEqual(107)
+    })
+
+    it('defaults to a member link when no role is given', async () => {
+      const { token } = await registerAndLogin('plainminter', 'password123')
+      const { body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+      expect(body.role).toBe('member')
+      expect(body.verificationLevel).toBe(NORMAL_USER)
+    })
+
+    it('blocks a regular member from minting an elevated link (403)', async () => {
+      const { token } = await registerAndLogin('plainmember', 'password123')
+      const { res } = await jsonPost('/api/auth/invite-codes', { role: 'admin' }, authHeader(token))
+      expect(res.status).toBe(403)
+    })
+
+    it('rejects an unknown role (400)', async () => {
+      const adminToken = await createAdmin()
+      const { res } = await jsonPost(
+        '/api/auth/invite-codes',
+        { role: 'superuser' },
+        authHeader(adminToken),
+      )
+      expect(res.status).toBe(400)
+    })
+  })
+
   describe('guest RSVP (new-11/11b)', () => {
     let eventId: string
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -400,9 +400,11 @@ app.post('/auth/register', rateLimit(5, 60_000), async (c) => {
     }
     inviteCodeUsed = inviteCodeData.code
     invitedByUserId = inviteCodeData.created_by_user_id
-    // Invited = verified at inception. Email confirmation stays quiet and
-    // non-blocking (used only for password recovery).
-    verificationLevel = NORMAL_USER
+    // Invited = verified at inception, at the role the link grants (#451):
+    // member links → NORMAL_USER; sevak/admin links land the recipient at that
+    // role. Floored at NORMAL_USER so a link never downgrades. Email
+    // confirmation stays quiet and non-blocking (used only for password recovery).
+    verificationLevel = Math.max(NORMAL_USER, inviteCodeData.verification_level)
   } else if (requireInvite) {
     // Invite-only: no developer bypass, no code → no account.
     return c.json(
@@ -718,8 +720,8 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
   }
 
   const body = await c.req
-    .json<{ maxUses?: number; expiresInDays?: number }>()
-    .catch(() => ({}) as { maxUses?: number; expiresInDays?: number })
+    .json<{ maxUses?: number; expiresInDays?: number; role?: string }>()
+    .catch(() => ({}) as { maxUses?: number; expiresInDays?: number; role?: string })
 
   // Optional overrides; out-of-range values are clamped in the lib, but reject
   // non-integers so a typo doesn't silently fall back to the default.
@@ -730,9 +732,31 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
     return c.json({ message: 'expiresInDays must be an integer' }, 400)
   }
 
+  // Role-bearing links (#451): default to a member link. A minter can grant up
+  // to their own level — so sevaks can mint sevak links, admins can mint admin
+  // links, but a member can only mint member links. Email-admins (ADMIN_EMAIL)
+  // count as admin-capable even if their numeric level is low.
+  let verificationLevel = NORMAL_USER
+  let grantedRole: inviteCodes.InviteRole = 'member'
+  if (body.role !== undefined) {
+    const level = inviteCodes.INVITE_ROLE_LEVELS[body.role as inviteCodes.InviteRole]
+    if (level === undefined) {
+      return c.json({ message: 'role must be one of: member, sevak, admin' }, 400)
+    }
+    const minterLevel = isAdmin(user)
+      ? Math.max(user.verification_level, inviteCodes.INVITE_ROLE_LEVELS.admin)
+      : user.verification_level
+    if (level > minterLevel) {
+      return c.json({ message: 'You can only grant a role up to your own.' }, 403)
+    }
+    verificationLevel = level
+    grantedRole = body.role as inviteCodes.InviteRole
+  }
+
   const result = await inviteCodes.mintUserInviteCode(c.env, user.id, {
     maxUses: body.maxUses,
     expiresInDays: body.expiresInDays,
+    verificationLevel,
   })
   if (!result.success) {
     console.error('mintUserInviteCode error:', result.error)
@@ -743,6 +767,8 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
     code: result.code,
     expiresAt: result.expiresAt,
     maxUses: result.maxUses,
+    role: grantedRole,
+    verificationLevel,
     shareUrl: `${INVITE_SHARE_URL_BASE}/${result.code}`,
   })
 })

--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -14,7 +14,23 @@
  */
 
 import type { Env, InviteCodeRow } from './types'
-import { ADMIN_CUTOFF, NORMAL_USER } from './constants'
+import { ADMIN_CUTOFF, NORMAL_USER, SEVAK, BRAHMACHARI } from './constants'
+
+/**
+ * Roles a member-minted invite link can grant on redemption (#451). Keeps the
+ * staged rollout self-serve: a member shares a normal link, a sevak/admin can
+ * mint a link that lands the recipient straight at their group role.
+ *   - member → NORMAL_USER (verified member)
+ *   - sevak  → SEVAK (moderator: report/remove on their boards)
+ *   - admin  → BRAHMACHARI (admin-capable; the level the app already grants for
+ *              developer/admin accounts, so it clears ADMIN_CUTOFF)
+ */
+export type InviteRole = 'member' | 'sevak' | 'admin'
+export const INVITE_ROLE_LEVELS: Record<InviteRole, number> = {
+  member: NORMAL_USER,
+  sevak: SEVAK,
+  admin: BRAHMACHARI,
+}
 
 const USER_INVITE_CODE_BYTES = 6 // 12 hex chars
 
@@ -203,6 +219,13 @@ export interface MintInviteOptions {
   maxUses?: number
   /** Days until expiry. Clamped to [1, 30]. Defaults to 7. */
   expiresInDays?: number
+  /**
+   * Role level granted on redemption (#451). Defaults to NORMAL_USER. The
+   * caller is responsible for the guardrail (a minter can't grant above their
+   * own level) — this lib only floors it at NORMAL_USER so a link never
+   * downgrades verified-at-inception.
+   */
+  verificationLevel?: number
 }
 
 /**
@@ -221,6 +244,8 @@ export async function mintUserInviteCode(
 > {
   const maxUses = clampMaxUses(options.maxUses ?? USER_INVITE_DEFAULT_MAX_USES)
   const ttlDays = clampTtlDays(options.expiresInDays ?? USER_INVITE_DEFAULT_TTL_DAYS)
+  // Floor at NORMAL_USER so a link never grants below verified-at-inception.
+  const grantLevel = Math.max(NORMAL_USER, Math.floor(options.verificationLevel ?? NORMAL_USER))
 
   // Random 12-char hex code. Collision space is 2^48 ≈ 2.8e14, plenty for
   // user-issued links. Retry up to 3 times in the (vanishingly rare) case
@@ -243,7 +268,7 @@ export async function mintUserInviteCode(
             created_by_user_id, expires_at, max_uses, uses_count)
          VALUES (?, ?, ?, 1, ?, ?, ?, ?, 0)`,
       )
-        .bind(code, `User invite from ${userId}`, NORMAL_USER, now, userId, expiresAt, maxUses)
+        .bind(code, `User invite from ${userId}`, grantLevel, now, userId, expiresAt, maxUses)
         .run()
       return { success: true, code, expiresAt, maxUses }
     } catch (error: any) {

--- a/packages/frontend/app/settings/invite.tsx
+++ b/packages/frontend/app/settings/invite.tsx
@@ -3,9 +3,10 @@ import { useState, useEffect, useCallback } from 'react'
 import { UserPlus, Link as LinkIcon, Check, Share2 } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
 import { StackHeader, GradientIconBadge } from '../../components/ui'
-import { inviteClient } from '../../src/auth/inviteClient'
+import { inviteClient, type InviteRole } from '../../src/auth/inviteClient'
 import { useColors } from '../../hooks/useColors'
 import { useAnalytics } from '../../utils/analytics'
+import { hasAdminCapability, SEVAK_LEVEL } from '../../utils/admin'
 
 const MONO_FONT = Platform.select({
   ios: 'JetBrains Mono',
@@ -15,12 +16,34 @@ const MONO_FONT = Platform.select({
 
 const linkForCode = (code: string) => `https://chinmayajanata.org/i/${code}`
 
+// Role → verification level the link grants (#451). Mirrors the backend
+// INVITE_ROLE_LEVELS; used to reuse an existing link of the same role.
+const ROLE_LEVEL: Record<InviteRole, number> = { member: 45, sevak: 54, admin: 108 }
+const ROLE_LABEL: Record<InviteRole, string> = { member: 'Member', sevak: 'Sevak', admin: 'Admin' }
+const ROLE_PHRASE: Record<InviteRole, string> = {
+  member: 'a member',
+  sevak: 'a sevak',
+  admin: 'an admin',
+}
+
 export default function InviteScreen() {
-  const { getToken } = useUser()
+  const { getToken, user } = useUser()
   const c = useColors()
   const { track } = useAnalytics()
   const isWeb = Platform.OS === 'web'
 
+  // Which roles this member may grant (#451): everyone shares a member link; a
+  // sevak can also mint sevak links, an admin can mint admin links. Mirrors the
+  // backend guardrail (can't grant above your own level), so the picker only
+  // shows roles the server will accept.
+  const level = user?.verificationLevel ?? 0
+  const availableRoles: InviteRole[] = [
+    'member',
+    ...(level >= SEVAK_LEVEL ? (['sevak'] as InviteRole[]) : []),
+    ...(hasAdminCapability(user) ? (['admin'] as InviteRole[]) : []),
+  ]
+
+  const [role, setRole] = useState<InviteRole>('member')
   const [code, setCode] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [failed, setFailed] = useState(false)
@@ -29,41 +52,49 @@ export default function InviteScreen() {
 
   const inviteUrl = code ? linkForCode(code) : null
 
-  // The member always has one ready link: reuse the first usable code they've
-  // minted, otherwise mint one. No user-facing "generate" step.
-  const loadLink = useCallback(async () => {
-    setLoading(true)
-    setFailed(false)
-    try {
-      const token = await getToken()
-      if (!token) {
-        setFailed(true)
-        return
-      }
-      const list = await inviteClient.listMyCodes(token)
-      if (list.success) {
-        const usable = list.data.codes.find((e) => e.isUsable) ?? list.data.codes[0]
-        if (usable?.code) {
-          setCode(usable.code)
+  // One ready link per role: reuse the first usable code of that role, else mint
+  // one. No user-facing "generate" step.
+  const loadLink = useCallback(
+    async (forRole: InviteRole) => {
+      setLoading(true)
+      setFailed(false)
+      try {
+        const token = await getToken()
+        if (!token) {
+          setFailed(true)
           return
         }
-      }
-      const minted = await inviteClient.mintCode(token)
-      if (minted.success) {
-        setCode(minted.data.code)
-      } else {
+        const list = await inviteClient.listMyCodes(token)
+        if (list.success) {
+          const usable = list.data.codes.find(
+            (e) => e.isUsable && e.verificationLevel === ROLE_LEVEL[forRole],
+          )
+          if (usable?.code) {
+            setCode(usable.code)
+            return
+          }
+        }
+        const minted = await inviteClient.mintCode(
+          token,
+          forRole === 'member' ? {} : { role: forRole },
+        )
+        if (minted.success) {
+          setCode(minted.data.code)
+        } else {
+          setFailed(true)
+        }
+      } catch {
         setFailed(true)
+      } finally {
+        setLoading(false)
       }
-    } catch {
-      setFailed(true)
-    } finally {
-      setLoading(false)
-    }
-  }, [getToken])
+    },
+    [getToken],
+  )
 
   useEffect(() => {
-    loadLink()
-  }, [loadLink])
+    loadLink(role)
+  }, [loadLink, role])
 
   // Single primary action: copy to clipboard on web, native share sheet on
   // device. The share sheet already offers every channel, so there are no
@@ -126,8 +157,47 @@ export default function InviteScreen() {
               lineHeight: 22,
             }}
           >
-            They get in instantly.
+            {role === 'member'
+              ? 'They get in instantly.'
+              : `They join as ${ROLE_PHRASE[role]}, instantly.`}
           </Text>
+
+          {/* Role picker (#451) — only shown to sevaks/admins, who can mint a
+              link that lands the recipient at that role. */}
+          {availableRoles.length > 1 && (
+            <View style={{ flexDirection: 'row', gap: 8, marginTop: 20 }}>
+              {availableRoles.map((r) => {
+                const active = r === role
+                return (
+                  <Pressable
+                    key={r}
+                    onPress={() => {
+                      if (r !== role) {
+                        track('invite_role_selected', { role: r })
+                        setRole(r)
+                      }
+                    }}
+                    style={{
+                      paddingVertical: 8,
+                      paddingHorizontal: 16,
+                      borderRadius: 999,
+                      backgroundColor: active ? c.accent : c.surface,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 14,
+                        fontWeight: '600',
+                        color: active ? c.textInverse : c.textMuted,
+                      }}
+                    >
+                      {ROLE_LABEL[r]}
+                    </Text>
+                  </Pressable>
+                )
+              })}
+            </View>
+          )}
 
           <View style={{ width: '100%', marginTop: 32 }}>
             <Text style={{ fontSize: 11, letterSpacing: 0.9, color: c.textFaint, marginBottom: 10 }}>
@@ -151,7 +221,7 @@ export default function InviteScreen() {
               </View>
             ) : failed ? (
               <Pressable
-                onPress={loadLink}
+                onPress={() => loadLink(role)}
                 style={{
                   height: 46,
                   borderRadius: 8,

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -69,11 +69,16 @@ const safeJson = async <T>(response: Response): Promise<T | null> => {
   }
 }
 
+/** Role a minted link grants on redemption (#451). */
+export type InviteRole = 'member' | 'sevak' | 'admin'
+
 export interface MintedInviteCode {
   code: string
   expiresAt: string
   maxUses: number
   shareUrl: string
+  role?: InviteRole
+  verificationLevel?: number
 }
 
 export interface MintInviteOptions {
@@ -81,6 +86,8 @@ export interface MintInviteOptions {
   maxUses?: number
   /** Days until expiry. Server clamps to [1, 30]. Defaults to 7. */
   expiresInDays?: number
+  /** Role the link grants. Server rejects granting above the minter's level. */
+  role?: InviteRole
 }
 
 export interface MintedCodeListEntry {
@@ -151,6 +158,7 @@ export const inviteClient = {
           body: JSON.stringify({
             ...(options.maxUses !== undefined ? { maxUses: options.maxUses } : {}),
             ...(options.expiresInDays !== undefined ? { expiresInDays: options.expiresInDays } : {}),
+            ...(options.role !== undefined ? { role: options.role } : {}),
           }),
         },
         API_TIMEOUTS.standard,
@@ -172,6 +180,8 @@ export const inviteClient = {
           expiresAt: data.expiresAt,
           maxUses: data.maxUses,
           shareUrl: data.shareUrl,
+          role: (data as { role?: InviteRole }).role,
+          verificationLevel: (data as { verificationLevel?: number }).verificationLevel,
         },
       }
     } catch (error: any) {


### PR DESCRIPTION
Closes #451 (option A: role-bearing links). The staged rollout needs ~3 admins per pilot group and ~10 at MSC, but invite links only granted `NORMAL_USER`. Now a link can carry a role, so admin/sevak provisioning is self-serve.

## Backend
- `mintUserInviteCode` takes a `verificationLevel` (floored at `NORMAL_USER`).
- `POST /auth/invite-codes` accepts `role: member | sevak | admin` → `NORMAL_USER / SEVAK / BRAHMACHARI`. Guardrail: a minter can only grant up to their own level (email-admins count as admin-capable), so members cannot mint elevated links (403); unknown role → 400.
- Register grants `max(NORMAL_USER, code.verification_level)`, so redeeming a sevak/admin link lands the recipient at that role, verified at inception.
- Preserves the hard invite gate from #470: no-code signups are still rejected when `REQUIRE_INVITE_CODE="true"`.

## Frontend
- Invite Friends screen shows a Member / Sevak / Admin picker to sevaks/admins, mirroring the backend guardrail.
- Each role reuses or mints its own link.
- `inviteClient.mintCode` carries the role; response surfaces role + level.

## Verified
- `git diff --check origin/v2...HEAD`
- `npm run typecheck`
- `npm run test:backend` — 428 passing
- `npm run test:frontend` — 197 passing
- `npm run build:frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)