### PR TITLE
feat(profile): public member profile + tappable feed authors (#441)

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -303,6 +303,53 @@ describe('invite gate (#403)', () => {
     expect(invitee?.invited_by_user_id).toBe(inviter?.id)
   })
 
+  describe('role-bearing invite links (#451)', () => {
+    it('lets an admin mint an admin-role link that lands the recipient at admin', async () => {
+      const adminToken = await createAdmin()
+      const { res, body } = await jsonPost(
+        '/api/auth/invite-codes',
+        { role: 'admin' },
+        authHeader(adminToken),
+      )
+      expect(res.status).toBe(200)
+      expect(body.role).toBe('admin')
+
+      await jsonPost('/api/auth/register', {
+        username: 'newadmin',
+        password: 'password123',
+        inviteCode: body.code,
+      })
+      const row = await env.DB.prepare('SELECT verification_level FROM users WHERE username = ?')
+        .bind('newadmin')
+        .first<{ verification_level: number }>()
+      // BRAHMACHARI (108) clears ADMIN_CUTOFF (107) → admin-capable.
+      expect(row?.verification_level).toBeGreaterThanOrEqual(107)
+    })
+
+    it('defaults to a member link when no role is given', async () => {
+      const { token } = await registerAndLogin('plainminter', 'password123')
+      const { body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+      expect(body.role).toBe('member')
+      expect(body.verificationLevel).toBe(NORMAL_USER)
+    })
+
+    it('blocks a regular member from minting an elevated link (403)', async () => {
+      const { token } = await registerAndLogin('plainmember', 'password123')
+      const { res } = await jsonPost('/api/auth/invite-codes', { role: 'admin' }, authHeader(token))
+      expect(res.status).toBe(403)
+    })
+
+    it('rejects an unknown role (400)', async () => {
+      const adminToken = await createAdmin()
+      const { res } = await jsonPost(
+        '/api/auth/invite-codes',
+        { role: 'superuser' },
+        authHeader(adminToken),
+      )
+      expect(res.status).toBe(400)
+    })
+  })
+
   describe('guest RSVP (new-11/11b)', () => {
     let eventId: string
 

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -423,6 +423,41 @@ describe('invite gate (#403)', () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════
+// PUBLIC MEMBER PROFILE (#441)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('GET /api/profile/:username — public profile (#441)', () => {
+  it('returns a safe public profile, omitting email and phone', async () => {
+    const { token } = await registerAndLogin('viewer', 'password123')
+    await registerAndLogin('subject', 'password123')
+    await env.DB.prepare('UPDATE users SET first_name = ?, last_name = ?, bio = ? WHERE username = ?')
+      .bind('Subj', 'Ect', 'hi there', 'subject')
+      .run()
+
+    const { res, body } = await fetchJSON('/api/profile/subject', { headers: authHeader(token) })
+    expect(res.status).toBe(200)
+    expect(body.profile.firstName).toBe('Subj')
+    expect(body.profile.bio).toBe('hi there')
+    expect(typeof body.profile.verificationLevel).toBe('number')
+    // Safe subset only — private fields must not leak.
+    expect(body.profile.email).toBeUndefined()
+    expect(body.profile.phoneNumber).toBeUndefined()
+    expect(body.profile.dateOfBirth).toBeUndefined()
+  })
+
+  it('404s for an unknown member', async () => {
+    const { token } = await registerAndLogin('viewer2', 'password123')
+    const { res } = await fetchJSON('/api/profile/nobody', { headers: authHeader(token) })
+    expect(res.status).toBe(404)
+  })
+
+  it('requires authentication', async () => {
+    const { res } = await fetchJSON('/api/profile/whoever')
+    expect(res.status).toBe(401)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
 // AUTH: AUTHENTICATE
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -11,7 +11,7 @@ import { applyMigration, dropAllTables, TEST_INVITE_CODE } from './setup'
 import { app } from '../app'
 import { hashPassword } from '../auth'
 import { clearRateLimits } from '../middleware'
-import { ADMIN_EMAIL } from '../constants'
+import { ADMIN_EMAIL, NORMAL_USER } from '../constants'
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -247,6 +247,131 @@ describe('POST /api/auth/register', () => {
       password: '',
     })
     expect(res.status).toBe(400)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// INVITE GATE (#403): vouch name, verified-at-inception, attribution, guest RSVP
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('invite gate (#403)', () => {
+  async function mintCodeAs(token: string): Promise<string> {
+    const { body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
+    return body.code
+  }
+
+  it('validate-invite-code returns the inviter first name for a member-minted code', async () => {
+    const { token } = await registerAndLogin('asha', 'password123')
+    await env.DB.prepare('UPDATE users SET first_name = ? WHERE username = ?').bind('Asha', 'asha').run()
+    const code = await mintCodeAs(token)
+    const { body } = await jsonPost('/api/auth/validate-invite-code', { code })
+    expect(body.valid).toBe(true)
+    expect(body.inviterFirstName).toBe('Asha')
+  })
+
+  it('validate-invite-code returns a null inviter name for an admin cohort code', async () => {
+    const { body } = await jsonPost('/api/auth/validate-invite-code', { code: TEST_INVITE_CODE })
+    expect(body.valid).toBe(true)
+    expect(body.inviterFirstName).toBeNull()
+  })
+
+  it('validate-invite-code rejects a bogus code', async () => {
+    const { body } = await jsonPost('/api/auth/validate-invite-code', { code: 'NOPE000NOPE0' })
+    expect(body.valid).toBe(false)
+  })
+
+  it('registering through a member invite verifies at inception and records attribution', async () => {
+    const { token } = await registerAndLogin('inviter', 'password123')
+    const code = await mintCodeAs(token)
+    const { res } = await jsonPost('/api/auth/register', {
+      username: 'invitee',
+      password: 'password123',
+      inviteCode: code,
+    })
+    expect(res.status).toBe(201)
+
+    const inviter = await env.DB.prepare('SELECT id FROM users WHERE username = ?')
+      .bind('inviter')
+      .first<{ id: string }>()
+    const invitee = await env.DB.prepare(
+      'SELECT verification_level, invited_by_user_id FROM users WHERE username = ?',
+    )
+      .bind('invitee')
+      .first<{ verification_level: number; invited_by_user_id: string | null }>()
+
+    expect(invitee?.verification_level).toBe(NORMAL_USER)
+    expect(invitee?.invited_by_user_id).toBe(inviter?.id)
+  })
+
+  describe('guest RSVP (new-11/11b)', () => {
+    let eventId: string
+
+    beforeEach(async () => {
+      const adminToken = await createAdmin()
+      const { token } = await registerAndLogin('host', 'password123')
+      const { body: center } = await jsonPost(
+        '/api/addCenter',
+        { centerName: 'Guest Center', latitude: 37.0, longitude: -121.0 },
+        authHeader(adminToken),
+      )
+      const { body: ev } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'Open Event',
+          description: 'x',
+          date: '2030-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: center.id,
+        },
+        authHeader(token),
+      )
+      eventId = ev.id
+    })
+
+    it('records a guest RSVP and dedupes the same email (new-11b)', async () => {
+      const first = await jsonPost('/api/attendEventGuest', {
+        eventID: eventId,
+        name: 'Guest One',
+        email: 'guest@example.com',
+      })
+      expect(first.res.status).toBe(200)
+      expect(first.body.alreadyRsvped).toBe(false)
+
+      const second = await jsonPost('/api/attendEventGuest', {
+        eventID: eventId,
+        name: 'Guest One',
+        email: 'guest@example.com',
+      })
+      expect(second.res.status).toBe(200)
+      expect(second.body.alreadyRsvped).toBe(true)
+
+      const row = await env.DB.prepare(
+        'SELECT COUNT(*) AS c FROM event_guest_rsvps WHERE event_id = ? AND email = ?',
+      )
+        .bind(eventId, 'guest@example.com')
+        .first<{ c: number }>()
+      expect(row?.c).toBe(1)
+    })
+
+    it('rejects a guest RSVP with an invalid email (400)', async () => {
+      const { res } = await jsonPost('/api/attendEventGuest', {
+        eventID: eventId,
+        name: 'No Email',
+        email: 'not-an-email',
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('blocks guest RSVP on a verified-only event (403)', async () => {
+      await env.DB.prepare('UPDATE events SET requires_verified = 1 WHERE id = ?').bind(eventId).run()
+      const { res } = await jsonPost('/api/attendEventGuest', {
+        eventID: eventId,
+        name: 'Gated Guest',
+        email: 'gated@example.com',
+      })
+      expect(res.status).toBe(403)
+    })
   })
 })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -13,6 +13,7 @@ import { cors } from 'hono/cors'
 import type { Env, UserRow, EventRow, CenterRow, BoardPostApiResponse, BoardType } from './types'
 import {
   userRowToApi,
+  userRowToPublicProfile,
   centerRowToApi,
   eventRowToApi,
   boardRowToApi,
@@ -1258,6 +1259,21 @@ app.post('/getUserEvents', authMiddleware, async (c) => {
 // ═══════════════════════════════════════════════════════════════════════
 // PROFILE ROUTES
 // ═══════════════════════════════════════════════════════════════════════
+
+// Public member profile (#441): identity + role + center for any signed-in
+// member to view by tapping a feed author. Safe-subset fields only.
+app.get('/profile/:username', authMiddleware, async (c) => {
+  const { username } = c.req.param()
+  const targetUser = await db.getUserByUsername(c.env.DB, username)
+  if (!targetUser) return c.json({ message: 'User not found' }, 404)
+  const profile = userRowToPublicProfile(targetUser)
+  let centerName: string | null = null
+  if (targetUser.center_id) {
+    const center = await db.getCenterById(c.env.DB, targetUser.center_id)
+    centerName = center?.name ?? null
+  }
+  return c.json({ profile: { ...profile, centerName } })
+})
 
 app.get('/profile/:username/events', authMiddleware, async (c) => {
   const { username } = c.req.param()

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -392,9 +392,11 @@ app.post('/auth/register', rateLimit(5, 60_000), async (c) => {
     }
     inviteCodeUsed = inviteCodeData.code
     invitedByUserId = inviteCodeData.created_by_user_id
-    // Invited = verified at inception. Email confirmation stays quiet and
-    // non-blocking (used only for password recovery).
-    verificationLevel = NORMAL_USER
+    // Invited = verified at inception, at the role the link grants (#451):
+    // member links → NORMAL_USER; sevak/admin links land the recipient at that
+    // role. Floored at NORMAL_USER so a link never downgrades. Email
+    // confirmation stays quiet and non-blocking (used only for password recovery).
+    verificationLevel = Math.max(NORMAL_USER, inviteCodeData.verification_level)
   }
 
   const hashedPassword = await hashPassword(validPassword)
@@ -704,8 +706,8 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
   }
 
   const body = await c.req
-    .json<{ maxUses?: number; expiresInDays?: number }>()
-    .catch(() => ({}) as { maxUses?: number; expiresInDays?: number })
+    .json<{ maxUses?: number; expiresInDays?: number; role?: string }>()
+    .catch(() => ({}) as { maxUses?: number; expiresInDays?: number; role?: string })
 
   // Optional overrides; out-of-range values are clamped in the lib, but reject
   // non-integers so a typo doesn't silently fall back to the default.
@@ -716,9 +718,31 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
     return c.json({ message: 'expiresInDays must be an integer' }, 400)
   }
 
+  // Role-bearing links (#451): default to a member link. A minter can grant up
+  // to their own level — so sevaks can mint sevak links, admins can mint admin
+  // links, but a member can only mint member links. Email-admins (ADMIN_EMAIL)
+  // count as admin-capable even if their numeric level is low.
+  let verificationLevel = NORMAL_USER
+  let grantedRole: inviteCodes.InviteRole = 'member'
+  if (body.role !== undefined) {
+    const level = inviteCodes.INVITE_ROLE_LEVELS[body.role as inviteCodes.InviteRole]
+    if (level === undefined) {
+      return c.json({ message: 'role must be one of: member, sevak, admin' }, 400)
+    }
+    const minterLevel = isAdmin(user)
+      ? Math.max(user.verification_level, inviteCodes.INVITE_ROLE_LEVELS.admin)
+      : user.verification_level
+    if (level > minterLevel) {
+      return c.json({ message: 'You can only grant a role up to your own.' }, 403)
+    }
+    verificationLevel = level
+    grantedRole = body.role as inviteCodes.InviteRole
+  }
+
   const result = await inviteCodes.mintUserInviteCode(c.env, user.id, {
     maxUses: body.maxUses,
     expiresInDays: body.expiresInDays,
+    verificationLevel,
   })
   if (!result.success) {
     console.error('mintUserInviteCode error:', result.error)
@@ -729,6 +753,8 @@ app.post('/auth/invite-codes', authMiddleware, async (c) => {
     code: result.code,
     expiresAt: result.expiresAt,
     maxUses: result.maxUses,
+    role: grantedRole,
+    verificationLevel,
     shareUrl: `${INVITE_SHARE_URL_BASE}/${result.code}`,
   })
 })

--- a/packages/backend/src/inviteCodes.ts
+++ b/packages/backend/src/inviteCodes.ts
@@ -14,7 +14,23 @@
  */
 
 import type { Env, InviteCodeRow } from './types'
-import { ADMIN_CUTOFF, NORMAL_USER } from './constants'
+import { ADMIN_CUTOFF, NORMAL_USER, SEVAK, BRAHMACHARI } from './constants'
+
+/**
+ * Roles a member-minted invite link can grant on redemption (#451). Keeps the
+ * staged rollout self-serve: a member shares a normal link, a sevak/admin can
+ * mint a link that lands the recipient straight at their group role.
+ *   - member → NORMAL_USER (verified member)
+ *   - sevak  → SEVAK (moderator: report/remove on their boards)
+ *   - admin  → BRAHMACHARI (admin-capable; the level the app already grants for
+ *              developer/admin accounts, so it clears ADMIN_CUTOFF)
+ */
+export type InviteRole = 'member' | 'sevak' | 'admin'
+export const INVITE_ROLE_LEVELS: Record<InviteRole, number> = {
+  member: NORMAL_USER,
+  sevak: SEVAK,
+  admin: BRAHMACHARI,
+}
 
 const USER_INVITE_CODE_BYTES = 6 // 12 hex chars
 
@@ -203,6 +219,13 @@ export interface MintInviteOptions {
   maxUses?: number
   /** Days until expiry. Clamped to [1, 30]. Defaults to 7. */
   expiresInDays?: number
+  /**
+   * Role level granted on redemption (#451). Defaults to NORMAL_USER. The
+   * caller is responsible for the guardrail (a minter can't grant above their
+   * own level) — this lib only floors it at NORMAL_USER so a link never
+   * downgrades verified-at-inception.
+   */
+  verificationLevel?: number
 }
 
 /**
@@ -221,6 +244,8 @@ export async function mintUserInviteCode(
 > {
   const maxUses = clampMaxUses(options.maxUses ?? USER_INVITE_DEFAULT_MAX_USES)
   const ttlDays = clampTtlDays(options.expiresInDays ?? USER_INVITE_DEFAULT_TTL_DAYS)
+  // Floor at NORMAL_USER so a link never grants below verified-at-inception.
+  const grantLevel = Math.max(NORMAL_USER, Math.floor(options.verificationLevel ?? NORMAL_USER))
 
   // Random 12-char hex code. Collision space is 2^48 ≈ 2.8e14, plenty for
   // user-issued links. Retry up to 3 times in the (vanishingly rare) case
@@ -243,7 +268,7 @@ export async function mintUserInviteCode(
             created_by_user_id, expires_at, max_uses, uses_count)
          VALUES (?, ?, ?, 1, ?, ?, ?, ?, 0)`,
       )
-        .bind(code, `User invite from ${userId}`, NORMAL_USER, now, userId, expiresAt, maxUses)
+        .bind(code, `User invite from ${userId}`, grantLevel, now, userId, expiresAt, maxUses)
         .run()
       return { success: true, code, expiresAt, maxUses }
     } catch (error: any) {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -344,6 +344,30 @@ export function userRowToApi(row: UserRow): UserApiResponse {
   }
 }
 
+/**
+ * Public member profile (#441) — the safe subset another signed-in member may
+ * see when tapping a feed author. Deliberately omits email, phone, DOB, points,
+ * lookingFor, and suspension internals; identity + role + community context only.
+ */
+export function userRowToPublicProfile(row: UserRow) {
+  return {
+    id: row.id,
+    username: row.username,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    profileImage: row.profile_image,
+    bio: row.bio,
+    centerID: row.center_id,
+    verificationLevel: row.verification_level,
+    isVerified: row.verification_level >= NORMAL_USER,
+    interests: safeParseJsonArray(row.interests),
+    school: row.school,
+    work: row.work,
+    region: row.region,
+    createdAt: row.created_at,
+  }
+}
+
 export function centerRowToApi(row: CenterRow): CenterApiResponse {
   return {
     centerID: row.id,

--- a/packages/frontend/app/profile/[username].tsx
+++ b/packages/frontend/app/profile/[username].tsx
@@ -56,7 +56,11 @@ export default function PublicProfileScreen() {
     return () => {
       cancelled = true
     }
-  }, [username, track])
+    // `track` is intentionally excluded — it isn't referentially stable, and
+    // including it re-runs this effect every render, cancelling the in-flight
+    // fetch so `loading` never clears (infinite spinner).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [username])
 
   const openEvent = useCallback(
     (id: string) => {

--- a/packages/frontend/app/profile/[username].tsx
+++ b/packages/frontend/app/profile/[username].tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState, useCallback } from 'react'
+import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ChevronLeft, MapPin } from 'lucide-react-native'
+import Avatar from '../../components/ui/Avatar'
+import { useColors } from '../../hooks/useColors'
+import { useAnalytics } from '../../utils/analytics'
+import { fetchPublicProfile, fetchUserPosts, type PublicProfile, type EventData } from '../../utils/api'
+
+/** Role label from verification level (mirrors the self-profile thresholds). */
+function roleLabel(vl: number): string | null {
+  return vl >= 1000008
+    ? 'Global Head'
+    : vl >= 1008
+      ? 'Swami'
+      : vl >= 108
+        ? 'Brahmachari'
+        : vl >= 54
+          ? 'Sevak'
+          : vl >= 45
+            ? 'Verified member'
+            : null
+}
+
+/**
+ * /profile/[username] — public member profile (#441). Any signed-in member can
+ * open it by tapping a feed author: identity, role, home center, bio, interests,
+ * and the events they host. Read-only; the safe-subset fields from the backend.
+ */
+export default function PublicProfileScreen() {
+  const c = useColors()
+  const router = useRouter()
+  const { track } = useAnalytics()
+  const { username: raw } = useLocalSearchParams<{ username: string }>()
+  const username = typeof raw === 'string' ? raw : ''
+
+  const [profile, setProfile] = useState<PublicProfile | null>(null)
+  const [events, setEvents] = useState<EventData[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!username) {
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    void (async () => {
+      const [p, posts] = await Promise.all([fetchPublicProfile(username), fetchUserPosts(username)])
+      if (cancelled) return
+      setProfile(p)
+      setEvents(posts)
+      setLoading(false)
+      if (p) track('profile_viewed', { username, verification_level: p.verificationLevel })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [username, track])
+
+  const openEvent = useCallback(
+    (id: string) => {
+      track('event_list_item_pressed', { eventId: id, source: 'public_profile' })
+      router.push(`/events/${id}`)
+    },
+    [router, track],
+  )
+
+  const fullName = profile ? `${profile.firstName ?? ''} ${profile.lastName ?? ''}`.trim() : ''
+  const role = profile ? roleLabel(profile.verificationLevel) : null
+
+  return (
+    <View style={{ flex: 1, backgroundColor: c.bg }}>
+      {/* Back header */}
+      <View style={{ paddingTop: 12 }}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 16, paddingVertical: 10 }}
+        >
+          <ChevronLeft size={22} color={c.accent} />
+          <Text style={{ fontSize: 15, color: c.accent }}>Back</Text>
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={c.accent} />
+        </View>
+      ) : !profile ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8, paddingHorizontal: 24 }}>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 22, color: c.text }}>Member not found</Text>
+          <Text style={{ fontSize: 15, color: c.textMuted, textAlign: 'center' }}>
+            This profile isn't available.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={{ paddingBottom: 48 }}>
+          <View style={{ alignItems: 'center', paddingHorizontal: 24, paddingTop: 8 }}>
+            <Avatar image={profile.profileImage ?? undefined} name={fullName || profile.username} size={96} />
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 26, color: c.text, marginTop: 14, textAlign: 'center' }}>
+              {fullName || profile.username}
+            </Text>
+            {role && (
+              <View
+                style={{
+                  backgroundColor: c.accentSoft,
+                  borderRadius: 999,
+                  paddingVertical: 5,
+                  paddingHorizontal: 14,
+                  marginTop: 8,
+                }}
+              >
+                <Text style={{ color: c.accent, fontSize: 13, fontWeight: '600' }}>{role}</Text>
+              </View>
+            )}
+            {profile.centerName && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
+                <MapPin size={14} color={c.textMuted} />
+                <Text style={{ fontSize: 14, color: c.textMuted }}>{profile.centerName}</Text>
+              </View>
+            )}
+            {profile.bio ? (
+              <Text style={{ fontSize: 15, color: c.text, textAlign: 'center', lineHeight: 22, marginTop: 14 }}>
+                {profile.bio}
+              </Text>
+            ) : null}
+          </View>
+
+          {profile.interests && profile.interests.length > 0 && (
+            <View style={{ paddingHorizontal: 24, marginTop: 24 }}>
+              <Text style={{ fontSize: 11, letterSpacing: 0.9, color: c.textFaint, marginBottom: 10 }}>
+                INTERESTS
+              </Text>
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+                {profile.interests.map((tag) => (
+                  <View key={tag} style={{ backgroundColor: c.surface, borderRadius: 999, paddingVertical: 6, paddingHorizontal: 14 }}>
+                    <Text style={{ fontSize: 13, color: c.text }}>{tag}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+
+          {events.length > 0 && (
+            <View style={{ paddingHorizontal: 24, marginTop: 24 }}>
+              <Text style={{ fontSize: 11, letterSpacing: 0.9, color: c.textFaint, marginBottom: 10 }}>
+                EVENTS THEY HOST
+              </Text>
+              <View style={{ gap: 10 }}>
+                {events.map((e) => (
+                  <Pressable
+                    key={e.eventID}
+                    onPress={() => openEvent(e.eventID)}
+                    style={{
+                      backgroundColor: c.surface,
+                      borderRadius: 12,
+                      paddingVertical: 12,
+                      paddingHorizontal: 14,
+                    }}
+                  >
+                    <Text style={{ fontSize: 15, fontWeight: '600', color: c.text }} numberOfLines={1}>
+                      {e.title}
+                    </Text>
+                    {(e.date || e.address) && (
+                      <Text style={{ fontSize: 13, color: c.textMuted, marginTop: 2 }} numberOfLines={1}>
+                        {[e.date, e.address].filter(Boolean).join(' · ')}
+                      </Text>
+                    )}
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  )
+}

--- a/packages/frontend/app/settings/invite.tsx
+++ b/packages/frontend/app/settings/invite.tsx
@@ -3,9 +3,10 @@ import { useState, useEffect, useCallback } from 'react'
 import { UserPlus, Link as LinkIcon, Check, Share2 } from 'lucide-react-native'
 import { useUser } from '../../components/contexts'
 import { StackHeader, GradientIconBadge } from '../../components/ui'
-import { inviteClient } from '../../src/auth/inviteClient'
+import { inviteClient, type InviteRole } from '../../src/auth/inviteClient'
 import { useColors } from '../../hooks/useColors'
 import { useAnalytics } from '../../utils/analytics'
+import { hasAdminCapability, SEVAK_LEVEL } from '../../utils/admin'
 
 const MONO_FONT = Platform.select({
   ios: 'JetBrains Mono',
@@ -15,12 +16,34 @@ const MONO_FONT = Platform.select({
 
 const linkForCode = (code: string) => `https://chinmayajanata.org/i/${code}`
 
+// Role → verification level the link grants (#451). Mirrors the backend
+// INVITE_ROLE_LEVELS; used to reuse an existing link of the same role.
+const ROLE_LEVEL: Record<InviteRole, number> = { member: 45, sevak: 54, admin: 108 }
+const ROLE_LABEL: Record<InviteRole, string> = { member: 'Member', sevak: 'Sevak', admin: 'Admin' }
+const ROLE_PHRASE: Record<InviteRole, string> = {
+  member: 'a member',
+  sevak: 'a sevak',
+  admin: 'an admin',
+}
+
 export default function InviteScreen() {
-  const { getToken } = useUser()
+  const { getToken, user } = useUser()
   const c = useColors()
   const { track } = useAnalytics()
   const isWeb = Platform.OS === 'web'
 
+  // Which roles this member may grant (#451): everyone shares a member link; a
+  // sevak can also mint sevak links, an admin can mint admin links. Mirrors the
+  // backend guardrail (can't grant above your own level), so the picker only
+  // shows roles the server will accept.
+  const level = user?.verificationLevel ?? 0
+  const availableRoles: InviteRole[] = [
+    'member',
+    ...(level >= SEVAK_LEVEL ? (['sevak'] as InviteRole[]) : []),
+    ...(hasAdminCapability(user) ? (['admin'] as InviteRole[]) : []),
+  ]
+
+  const [role, setRole] = useState<InviteRole>('member')
   const [code, setCode] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [failed, setFailed] = useState(false)
@@ -29,41 +52,49 @@ export default function InviteScreen() {
 
   const inviteUrl = code ? linkForCode(code) : null
 
-  // The member always has one ready link: reuse the first usable code they've
-  // minted, otherwise mint one. No user-facing "generate" step.
-  const loadLink = useCallback(async () => {
-    setLoading(true)
-    setFailed(false)
-    try {
-      const token = await getToken()
-      if (!token) {
-        setFailed(true)
-        return
-      }
-      const list = await inviteClient.listMyCodes(token)
-      if (list.success) {
-        const usable = list.data.codes.find((e) => e.isUsable) ?? list.data.codes[0]
-        if (usable?.code) {
-          setCode(usable.code)
+  // One ready link per role: reuse the first usable code of that role, else mint
+  // one. No user-facing "generate" step.
+  const loadLink = useCallback(
+    async (forRole: InviteRole) => {
+      setLoading(true)
+      setFailed(false)
+      try {
+        const token = await getToken()
+        if (!token) {
+          setFailed(true)
           return
         }
-      }
-      const minted = await inviteClient.mintCode(token)
-      if (minted.success) {
-        setCode(minted.data.code)
-      } else {
+        const list = await inviteClient.listMyCodes(token)
+        if (list.success) {
+          const usable = list.data.codes.find(
+            (e) => e.isUsable && e.verificationLevel === ROLE_LEVEL[forRole],
+          )
+          if (usable?.code) {
+            setCode(usable.code)
+            return
+          }
+        }
+        const minted = await inviteClient.mintCode(
+          token,
+          forRole === 'member' ? {} : { role: forRole },
+        )
+        if (minted.success) {
+          setCode(minted.data.code)
+        } else {
+          setFailed(true)
+        }
+      } catch {
         setFailed(true)
+      } finally {
+        setLoading(false)
       }
-    } catch {
-      setFailed(true)
-    } finally {
-      setLoading(false)
-    }
-  }, [getToken])
+    },
+    [getToken],
+  )
 
   useEffect(() => {
-    loadLink()
-  }, [loadLink])
+    loadLink(role)
+  }, [loadLink, role])
 
   // Single primary action: copy to clipboard on web, native share sheet on
   // device. The share sheet already offers every channel, so there are no
@@ -126,8 +157,47 @@ export default function InviteScreen() {
               lineHeight: 22,
             }}
           >
-            They get in instantly.
+            {role === 'member'
+              ? 'They get in instantly.'
+              : `They join as ${ROLE_PHRASE[role]}, instantly.`}
           </Text>
+
+          {/* Role picker (#451) — only shown to sevaks/admins, who can mint a
+              link that lands the recipient at that role. */}
+          {availableRoles.length > 1 && (
+            <View style={{ flexDirection: 'row', gap: 8, marginTop: 20 }}>
+              {availableRoles.map((r) => {
+                const active = r === role
+                return (
+                  <Pressable
+                    key={r}
+                    onPress={() => {
+                      if (r !== role) {
+                        track('invite_role_selected', { role: r })
+                        setRole(r)
+                      }
+                    }}
+                    style={{
+                      paddingVertical: 8,
+                      paddingHorizontal: 16,
+                      borderRadius: 999,
+                      backgroundColor: active ? c.accent : c.surface,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 14,
+                        fontWeight: '600',
+                        color: active ? c.textInverse : c.textMuted,
+                      }}
+                    >
+                      {ROLE_LABEL[r]}
+                    </Text>
+                  </Pressable>
+                )
+              })}
+            </View>
+          )}
 
           <View style={{ width: '100%', marginTop: 32 }}>
             <Text style={{ fontSize: 11, letterSpacing: 0.9, color: c.textFaint, marginBottom: 10 }}>
@@ -151,7 +221,7 @@ export default function InviteScreen() {
               </View>
             ) : failed ? (
               <Pressable
-                onPress={loadLink}
+                onPress={() => loadLink(role)}
                 style={{
                   height: 46,
                   borderRadius: 8,

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { useRouter } from 'expo-router'
 import { Building2, CalendarDays, Globe2, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar, ImageLightbox } from '../ui'
 import { useUser } from '../contexts'
@@ -320,6 +321,13 @@ export function BoardPostCard({
   const accent = colors.accent ?? '#E8862A'
   const accentSoft = colors.accentSoft ?? '#FFF7ED'
   const [lightboxOpen, setLightboxOpen] = useState(false)
+  const router = useRouter()
+  // Tap the author → their public profile (#441). Absent for "You"/system.
+  const authorUsername = message.author.username
+  const openAuthor =
+    authorUsername && message.author.id !== 'me'
+      ? () => router.push(`/profile/${authorUsername}`)
+      : undefined
   const isFeedCard = showSource || asCard
   const sourceIcon =
     message.sourceKind === 'public' ? (
@@ -386,12 +394,14 @@ export function BoardPostCard({
       ) : null}
 
       <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
-        <Avatar
-          name={message.author.name}
-          initials={message.author.initials}
-          size={42}
-          backgroundColor={message.author.accentColor}
-        />
+        <Pressable onPress={openAuthor} disabled={!openAuthor}>
+          <Avatar
+            name={message.author.name}
+            initials={message.author.initials}
+            size={42}
+            backgroundColor={message.author.accentColor}
+          />
+        </Pressable>
 
         <View style={{ flex: 1, gap: 8 }}>
           <View
@@ -406,14 +416,16 @@ export function BoardPostCard({
               <View
                 style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}
               >
-                <Text
-                  style={{
-                    fontSize: isFeedCard ? 14 : 16,
-                    color: colors.text,
-                  }}
-                >
-                  {message.author.name}
-                </Text>
+                <Pressable onPress={openAuthor} disabled={!openAuthor}>
+                  <Text
+                    style={{
+                      fontSize: isFeedCard ? 14 : 16,
+                      color: colors.text,
+                    }}
+                  >
+                    {message.author.name}
+                  </Text>
+                </Pressable>
                 {message.author.verification === 'sevak' ? (
                   <Text
                     style={{

--- a/packages/frontend/components/boards/__mocks__/mockData.ts
+++ b/packages/frontend/components/boards/__mocks__/mockData.ts
@@ -7,6 +7,8 @@ export interface PersonSummary {
   subtitle?: string
   verification?: VerificationKind
   accentColor?: string
+  /** Handle for linking to the public profile (#441). Absent for "You"/system. */
+  username?: string
 }
 
 export interface BoardMessage {

--- a/packages/frontend/components/boards/liveBoard.ts
+++ b/packages/frontend/components/boards/liveBoard.ts
@@ -44,6 +44,7 @@ export function boardPostToMessage(post: BoardPostData): BoardMessage {
       subtitle: post.author.centerID ? 'Verified member' : undefined,
       verification: verificationFor(post.author),
       accentColor: colorFor(post.author.id || post.author.username),
+      username: post.author.username,
     },
     timestamp: formatTimestamp(post.createdAt),
     body: post.body,

--- a/packages/frontend/components/feed/FeedList.tsx
+++ b/packages/frontend/components/feed/FeedList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
 import { Building2, CalendarDays, ChevronRight, Globe2 } from 'lucide-react-native'
 import type { ThreadPanelColors } from '../boards'
 import type { AppColors } from '../../tokens'
@@ -23,6 +24,7 @@ export function FeedList({
   onOpenGroup: (group: GroupBoard) => void
   onSelectPost: (id: string) => void
 }) {
+  const router = useRouter()
   const [visibleCount, setVisibleCount] = useState(25)
   const visiblePosts = posts.slice(0, visibleCount)
   const hasMore = visibleCount < posts.length
@@ -84,6 +86,11 @@ export function FeedList({
           post={post}
           colors={feedColors}
           onPress={() => onSelectPost(post.id)}
+          onAuthorPress={
+            post.author.username && post.author.id !== 'me'
+              ? () => router.push(`/profile/${post.author.username}`)
+              : undefined
+          }
         />
       ))}
       {hasMore ? (

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -9,10 +9,13 @@ export function FeedPostCard({
   post,
   colors,
   onPress,
+  onAuthorPress,
 }: {
   post: FeedPost
   colors: AppColors
   onPress?: () => void
+  /** Tap the author (avatar/name) → open their public profile (#441). */
+  onAuthorPress?: () => void
 }) {
   const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
   const replies = post.replyCount ?? 2
@@ -55,15 +58,19 @@ export function FeedPostCard({
       </View>
 
       <View style={{ flexDirection: 'row', gap: 12 }}>
-        <Avatar
-          name={post.author.name}
-          initials={post.author.initials}
-          size={38}
-          backgroundColor={post.author.accentColor}
-        />
+        <Pressable onPress={onAuthorPress} disabled={!onAuthorPress}>
+          <Avatar
+            name={post.author.name}
+            initials={post.author.initials}
+            size={38}
+            backgroundColor={post.author.accentColor}
+          />
+        </Pressable>
         <View style={{ flex: 1, gap: 6 }}>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-            <Text style={{ fontSize: 14, color: colors.text }}>{post.author.name}</Text>
+            <Pressable onPress={onAuthorPress} disabled={!onAuthorPress}>
+              <Text style={{ fontSize: 14, color: colors.text }}>{post.author.name}</Text>
+            </Pressable>
             {post.author.verification === 'sevak' ? (
               <View
                 style={{

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -36,6 +36,7 @@ export function authorFromUser(user: User | null): PersonSummary {
     initials,
     verification: verificationFor(user),
     accentColor: colorFor(user.id || user.username),
+    username: user.username,
   }
 }
 

--- a/packages/frontend/src/auth/inviteClient.ts
+++ b/packages/frontend/src/auth/inviteClient.ts
@@ -69,11 +69,16 @@ const safeJson = async <T>(response: Response): Promise<T | null> => {
   }
 }
 
+/** Role a minted link grants on redemption (#451). */
+export type InviteRole = 'member' | 'sevak' | 'admin'
+
 export interface MintedInviteCode {
   code: string
   expiresAt: string
   maxUses: number
   shareUrl: string
+  role?: InviteRole
+  verificationLevel?: number
 }
 
 export interface MintInviteOptions {
@@ -81,6 +86,8 @@ export interface MintInviteOptions {
   maxUses?: number
   /** Days until expiry. Server clamps to [1, 30]. Defaults to 7. */
   expiresInDays?: number
+  /** Role the link grants. Server rejects granting above the minter's level. */
+  role?: InviteRole
 }
 
 export interface MintedCodeListEntry {
@@ -151,6 +158,7 @@ export const inviteClient = {
           body: JSON.stringify({
             ...(options.maxUses !== undefined ? { maxUses: options.maxUses } : {}),
             ...(options.expiresInDays !== undefined ? { expiresInDays: options.expiresInDays } : {}),
+            ...(options.role !== undefined ? { role: options.role } : {}),
           }),
         },
         API_TIMEOUTS.standard,
@@ -172,6 +180,8 @@ export const inviteClient = {
           expiresAt: data.expiresAt,
           maxUses: data.maxUses,
           shareUrl: data.shareUrl,
+          role: (data as { role?: InviteRole }).role,
+          verificationLevel: (data as { verificationLevel?: number }).verificationLevel,
         },
       }
     } catch (error: any) {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -723,6 +723,42 @@ export async function setBoardPostPinned(
 
 // ── Profile endpoints ─────────────────────────────────────────────────
 
+export interface PublicProfile {
+  id: string
+  username: string
+  firstName: string
+  lastName: string
+  profileImage: string | null
+  bio: string | null
+  centerID: string | null
+  centerName: string | null
+  verificationLevel: number
+  isVerified: boolean
+  interests: string[] | null
+  school: string | null
+  work: string | null
+  region: string | null
+  createdAt: string
+}
+
+/** Public member profile (#441). Signed-in only. Returns null if not found. */
+export async function fetchPublicProfile(username: string): Promise<PublicProfile | null> {
+  try {
+    const response = await authFetch(`/profile/${encodeURIComponent(username)}`)
+    if (!response.ok) return null
+    const data = await response.json()
+    const p = data.profile as PublicProfile | undefined
+    if (!p) return null
+    if (p.profileImage && p.profileImage.startsWith('/')) {
+      p.profileImage = `${API_BASE_URL}${p.profileImage}`
+    }
+    return p
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchPublicProfile]', err?.message || err)
+    return null
+  }
+}
+
 export async function fetchUserEvents(username: string): Promise<EventData[]> {
   try {
     const response = await authFetch(`/profile/${encodeURIComponent(username)}/events`)


### PR DESCRIPTION
Closes #441. Feed posts showed an author + verification badge, but the block wasn't tappable and there was no way to view another member. This closes the social loop: post → who is this → what else have they done.

> **Stacked on #463 → #461.** Base is `KishParikh13/role-invite-links` (shares `app.test.ts`/`app.ts`). Merge #461 → #463 → this, or retarget to `v2` once they land.

## Backend
- `GET /profile/:username` (auth) returns a **safe public subset**: identity, role/verification, home center (+name), bio, interests, school/work/region. Omits email, phone, DOB, points, lookingFor, suspension. New `userRowToPublicProfile` mapper so private fields can't leak.

## Frontend
- New **`/profile/[username]`** screen: avatar, name, role label, home center, bio, interests, and the events they host (tap → event). Read-only.
- `fetchPublicProfile` client.
- **Tappable author** in the feed: threaded `username` through `PersonSummary` / `authorFromUser` / `boardPostToMessage`, and wired both renderers (`BoardPostCard` main feed + `FeedPostCard` workspace) to open the profile. Self/"You" authors aren't linked.

## Verified (local web)
- `/profile/sevak@…` renders identity + Sevak badge + center
- Tapping a feed author → `/profile/<username>`
- 3 new backend tests (safe subset incl. no email; 404 unknown; 401 unauthenticated). 204 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)