### PR TITLE
[codex] fix board card nested web buttons

### DIFF
--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { Image, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Building2, CalendarDays, Globe2, Lock, MessageCircle, MoreHorizontal, Send } from 'lucide-react-native'
 import { Avatar, ImageLightbox } from '../ui'
 import { useUser } from '../contexts'
@@ -334,7 +334,7 @@ export function BoardPostCard({
     <Pressable
       disabled={!onPress}
       onPress={onPress}
-      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityRole={onPress && Platform.OS !== 'web' ? 'button' : undefined}
       accessibilityLabel={onPress ? `Open post by ${message.author.name}` : undefined}
       style={{
         marginHorizontal: isFeedCard ? 0 : 0,


### PR DESCRIPTION
## Summary
- prevent the outer `BoardPostCard` press target from rendering as a web `<button>`
- keep native `accessibilityRole="button"` behavior on iOS/Android
- leave the inner image, react, and reply controls interactive on web

## Root cause
PR #244 added `accessibilityRole="button"` to the outer board card while also turning `+ React` and replies into nested `Pressable` controls. React Native Web maps `accessibilityRole="button"` to a real DOM `<button>`, which produced invalid nested buttons once the inner controls rendered as buttons too.

## Validation
- `npm run typecheck`
- `npm run test --workspace=@janata/frontend`
- `npm run build --workspace=@janata/frontend`
- `git diff --check`
- local web smoke loaded with no page errors on the logged-out home screen

Jest app tests are currently not usable in this checkout due unrelated empty app test suites / React Native Testing Library setup issues.