### PR TITLE
[codex] Simplify profile and settings navigation

### DIFF
--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -1,13 +1,13 @@
 // Profile tab — native (iOS/Android). Direction B, stacked single column.
 // Mirrors the web Profile (app/(tabs)/profile.web.tsx): a display-only social
 // profile (identity + interests, then engagement: stats, upcoming events,
-// centers). Editing lives on /edit-profile; account management on /settings.
+// centers). Editing lives on /edit-profile.
 // The "You" header + settings gear are provided by the navigator (TabHeader).
 import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share } from 'react-native'
 import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  Pencil, Share2, ChevronRight, BadgeCheck, MapPin, UserPlus,
+  Pencil, Share2, ChevronRight, BadgeCheck, MapPin,
   Megaphone, CalendarDays, Building2,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
@@ -69,7 +69,9 @@ export default function Profile() {
       : vl >= 45 ? 'Verified member'
       : null
   const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
+  const showHomeCenterInProfile = !!homeCenter && groups.length === 0
   const interests = user?.interests || []
+  const showActivityStats = createdCount > 0 || events.length > 0
 
   const today = new Date().toISOString().split('T')[0]
   const upcoming = [...events]
@@ -84,7 +86,6 @@ export default function Profile() {
       track('profile_shared', { source: 'profile', username: user?.username })
     } catch { /* dismissed */ }
   }
-  const onInvite = () => { track('settings_invite_pressed', { source: 'profile' }); router.push('/settings/invite') }
   const onExplore = () => { track('profile_explore_cta', { source: 'profile' }); router.push('/explore') }
 
   const card = { backgroundColor: c.card, borderWidth: 1, borderColor: c.border, borderRadius: 20 } as const
@@ -146,7 +147,7 @@ export default function Profile() {
               <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
             </View>
           ) : null}
-          {homeCenter ? (
+          {showHomeCenterInProfile ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
               <MapPin size={13} color={c.textFaint} />
               <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
@@ -156,11 +157,7 @@ export default function Profile() {
 
         {user?.bio ? (
           <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
-        ) : (
-          <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
-            No bio yet — tap Edit to introduce yourself.
-          </Text>
-        )}
+        ) : null}
 
         <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
           <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 11, borderRadius: 12, backgroundColor: c.text }}>
@@ -183,24 +180,15 @@ export default function Profile() {
           </View>
         ) : null}
 
-        <Pressable
-          onPress={onInvite}
-          style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
-        >
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            <UserPlus size={16} color={c.textSecondary} />
-            <Text style={{ fontSize: 14, color: c.textSecondary }}>Invite Friends</Text>
-          </View>
-          <ChevronRight size={18} color={c.iconMuted} />
-        </Pressable>
       </View>
 
       {/* Stats */}
-      <View style={{ flexDirection: 'row', gap: 12, marginTop: 18 }}>
-        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
-        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
-        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
-      </View>
+      {showActivityStats ? (
+        <View style={{ flexDirection: 'row', gap: 12, marginTop: 18 }}>
+          <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+          <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        </View>
+      ) : null}
 
       {/* Upcoming events */}
       <SectionLabel>Upcoming events</SectionLabel>

--- a/packages/frontend/app/(tabs)/profile.web.tsx
+++ b/packages/frontend/app/(tabs)/profile.web.tsx
@@ -1,7 +1,6 @@
 // Profile tab — web (desktop two-column / mobile stacked). Direction B.
 // Display-only social profile: identity + interests on the left, engagement
-// (stats, upcoming events, centers) on the right. Editing lives on /edit-profile;
-// account management lives on /settings (reached via "Account & Settings").
+// (stats, upcoming events, centers) on the right. Editing lives on /edit-profile.
 import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share, Platform, useWindowDimensions } from 'react-native'
 import { useRouter, useFocusEffect } from 'expo-router'
@@ -69,7 +68,9 @@ export default function Profile() {
       : vl >= 45 ? 'Verified member'
       : null
   const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
+  const showHomeCenterInProfile = !!homeCenter && groups.length === 0
   const interests = user?.interests || []
+  const showActivityStats = createdCount > 0 || events.length > 0
 
   const today = new Date().toISOString().split('T')[0]
   const upcoming = [...events]
@@ -84,7 +85,6 @@ export default function Profile() {
       track('profile_shared', { source: 'profile_web', username: user?.username })
     } catch { /* dismissed */ }
   }
-  const onSettings = () => { track('nav_settings_opened', { source: 'profile_web', destination: 'preferences' }); router.push('/settings') }
   const onExplore = () => { track('profile_explore_cta', { source: 'profile_web' }); router.push('/explore') }
 
   // ── Reusable pieces ──────────────────────────────────────
@@ -101,14 +101,13 @@ export default function Profile() {
           </View>
         )}
         <Text style={{ fontSize: 21, fontWeight: '700', color: c.text, marginTop: 14, textAlign: 'center' }}>{displayName}</Text>
-        {user?.username ? <Text style={{ fontSize: 14, color: c.textMuted, marginTop: 1 }}>@{user.username}</Text> : null}
         {roleLabel ? (
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10, backgroundColor: c.accentSoft, paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999 }}>
             <BadgeCheck size={14} color="#C2410C" />
             <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
           </View>
         ) : null}
-        {homeCenter ? (
+        {showHomeCenterInProfile ? (
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
             <MapPin size={13} color={c.textFaint} />
             <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
@@ -118,11 +117,7 @@ export default function Profile() {
 
       {user?.bio ? (
         <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
-      ) : (
-        <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
-          No bio yet — tap Edit to introduce yourself.
-        </Text>
-      )}
+      ) : null}
 
       <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
         <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 10, borderRadius: 12, backgroundColor: c.text }}>
@@ -145,13 +140,6 @@ export default function Profile() {
         </View>
       ) : null}
 
-      <Pressable
-        onPress={onSettings}
-        style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
-      >
-        <Text style={{ fontSize: 14, color: c.textSecondary }}>Account &amp; Settings</Text>
-        <ChevronRight size={18} color={c.iconMuted} />
-      </Pressable>
     </View>
   )
 
@@ -169,11 +157,12 @@ export default function Profile() {
 
   const RightColumn = (
     <View>
-      <View style={{ flexDirection: 'row', gap: 14 }}>
-        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
-        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
-        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
-      </View>
+      {showActivityStats ? (
+        <View style={{ flexDirection: 'row', gap: 14 }}>
+          <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+          <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        </View>
+      ) : null}
 
       <SectionLabel>Upcoming events</SectionLabel>
       {upcoming.length > 0 ? (

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -1,39 +1,66 @@
-import React, { useState, useEffect } from 'react'
-import { View, Pressable, ScrollView, Modal, Alert, Platform } from 'react-native'
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  View,
+} from 'react-native'
 import { useRouter } from 'expo-router'
 import {
-  Shield,
-  Info,
-  FileText,
-  ChevronRight,
-  LogOut,
   AlertTriangle,
-  UserPlus,
+  BadgeCheck,
   Bell,
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  FileText,
+  Info,
+  Link as LinkIcon,
+  LockKeyhole,
+  LogOut,
+  MapPin,
+  Pencil,
+  Share2,
+  Shield,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
-import { Avatar, Text, Section, StackHeader } from '../../components/ui'
+import { Avatar, Text, StackHeader } from '../../components/ui'
 import ThemeSelector from '../../components/settings/ThemeSelector'
 import { useAnalytics } from '../../utils/analytics'
+import { isSuperAdmin } from '../../utils/admin'
+import { inviteClient } from '../../src/auth/inviteClient'
+import { fetchCenters, type CenterData } from '../../utils/api'
 import Constants from 'expo-constants'
 
 const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
+const linkForCode = (code: string) => `https://chinmayajanata.org/i/${code}`
 
 export default function PreferencesNative() {
   const router = useRouter()
-  const { user, loading, logout } = useUser()
-
-  // Account-only screen — bounce guests to sign-in (a deep link / returnTo
-  // could otherwise land a logged-out visitor here).
-  useEffect(() => {
-    if (Platform.OS !== 'web' && !loading && !user) router.replace('/auth')
-  }, [user, loading])
+  const { user, loading, logout, deleteAccount, getToken } = useUser()
   const { isDark } = useTheme()
-  const { deleteAccount } = useUser()
   const { track } = useAnalytics()
+
+  const [allCenters, setAllCenters] = useState<CenterData[]>([])
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null)
+  const [inviteLoading, setInviteLoading] = useState(false)
+  const [inviteFailed, setInviteFailed] = useState(false)
+  const [legalOpen, setLegalOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const currentYear = new Date().getFullYear()
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' && !loading && !user) router.replace('/auth')
+  }, [router, user, loading])
+
+  useEffect(() => {
+    fetchCenters().then(setAllCenters).catch(() => {})
+  }, [])
 
   const textColor = isDark ? '#FAFAFA' : '#1C1917'
   const mutedTextColor = isDark ? '#A8A29E' : '#78716C'
@@ -41,9 +68,100 @@ export default function PreferencesNative() {
   const borderColor = isDark ? '#262626' : '#ECE7DE'
   const cardBg = isDark ? '#262626' : '#FFFFFF'
   const pageBg = isDark ? '#1A1A1A' : '#F5F5F4'
+  const surfaceBg = isDark ? '#1F1F1F' : '#F7F4EF'
+  const pressedBg = isDark ? '#303030' : '#F0EDE8'
+  const iconColor = isDark ? '#A8A29E' : '#78716C'
+
+  const displayName =
+    user?.firstName && user?.lastName
+      ? `${user.firstName} ${user.lastName}`
+      : user?.firstName || user?.username || 'You'
+  const accountIdentifier = user?.email || user?.username || null
+  const accountLabel = accountIdentifier
+    ? accountIdentifier.includes('@') ? accountIdentifier : `@${accountIdentifier}`
+    : null
+  const vl = user?.verificationLevel ?? 0
+  const roleLabel =
+    vl >= 1000008 ? 'Global Head'
+      : vl >= 1008 ? 'Swami'
+      : vl >= 108 ? 'Brahmachari'
+      : vl >= 54 ? 'Sevak'
+      : vl >= 45 ? 'Verified member'
+      : null
+  const canInvite = vl >= 45
+  const homeCenter = allCenters.find((center) => center.centerID === user?.centerID)
+  const homeCenterLabel = homeCenter?.name || (user?.centerID ? 'Home center selected' : 'No home center yet')
+  const lookingFor = Array.isArray(user?.lookingFor) ? user.lookingFor.filter(Boolean).join(', ') : ''
+  const interests = Array.isArray(user?.interests) ? user.interests.filter(Boolean).join(', ') : ''
+  const hasProfileDetails = !!(
+    user?.bio ||
+    user?.email ||
+    user?.phoneNumber ||
+    user?.school ||
+    user?.work ||
+    user?.region ||
+    lookingFor ||
+    interests
+  )
+
+  const loadInviteLink = useCallback(async () => {
+    if (!user || !canInvite) {
+      setInviteUrl(null)
+      setInviteFailed(false)
+      return
+    }
+    setInviteLoading(true)
+    setInviteFailed(false)
+    try {
+      const token = await getToken()
+      if (!token) {
+        setInviteFailed(true)
+        return
+      }
+      const list = await inviteClient.listMyCodes(token)
+      if (list.success) {
+        const usable = list.data.codes.find((entry) => entry.isUsable) ?? list.data.codes[0]
+        if (usable?.code) {
+          setInviteUrl(usable.shareUrl || linkForCode(usable.code))
+          return
+        }
+      }
+      const minted = await inviteClient.mintCode(token)
+      if (minted.success) {
+        setInviteUrl(minted.data.shareUrl || linkForCode(minted.data.code))
+      } else {
+        setInviteFailed(true)
+      }
+    } catch {
+      setInviteFailed(true)
+    } finally {
+      setInviteLoading(false)
+    }
+  }, [canInvite, getToken, user])
+
+  useEffect(() => {
+    loadInviteLink()
+  }, [loadInviteLink])
+
+  const shareInviteLink = async () => {
+    if (!inviteUrl) return
+    try {
+      await Share.share({
+        title: 'Join me on Janata',
+        message: `Join me on Janata. This invite gets you in instantly. ${inviteUrl}`,
+        url: inviteUrl,
+      })
+      track('invite_link_shared', {
+        source: 'settings_native_profile_card',
+        method: 'share',
+      })
+    } catch {
+      // Native share sheet can be dismissed without an actionable error.
+    }
+  }
 
   const handleLogout = async () => {
-    track('nav_logout')
+    track('nav_logout', { source: 'settings_native' })
     await logout()
     router.replace('/auth')
   }
@@ -60,7 +178,7 @@ export default function PreferencesNative() {
         track('delete_account_failed', { source: 'settings', reason: result.message })
         Alert.alert('Error', result.message || 'Failed to delete account')
       }
-    } catch (error) {
+    } catch {
       track('delete_account_failed', { source: 'settings', reason: 'exception' })
       Alert.alert('Error', 'Failed to delete account. Please try again.')
     } finally {
@@ -68,84 +186,111 @@ export default function PreferencesNative() {
     }
   }
 
-  const displayName =
-    user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}` : user?.username || ''
-
-  const MenuRow = ({
-    onPress,
-    children,
-    showArrow = true,
-  }: {
-    onPress: () => void
-    children: React.ReactNode
-    showArrow?: boolean
-  }) => (
-    <Pressable
+  const Card = ({ children }: { children: React.ReactNode }) => (
+    <View
       style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        paddingVertical: 14,
-        paddingHorizontal: 16,
         backgroundColor: cardBg,
+        borderWidth: 1,
+        borderColor,
+        borderRadius: 18,
+        overflow: 'hidden',
       }}
-      onPress={onPress}
     >
       {children}
-      {showArrow && <ChevronRight size={20} color={textColor} />}
+    </View>
+  )
+
+  const DetailItem = ({ label, value }: { label: string; value?: string | null }) => {
+    if (!value) return null
+    return (
+      <View style={{ gap: 2 }}>
+        <Text style={{ fontSize: 11, color: faintColor, textTransform: 'uppercase', letterSpacing: 0.6 }}>
+          {label}
+        </Text>
+        <Text style={{ fontSize: 13.5, color: textColor, lineHeight: 19 }} numberOfLines={2}>
+          {value}
+        </Text>
+      </View>
+    )
+  }
+
+  const ActionCard = ({
+    icon,
+    title,
+    detail,
+    onPress,
+  }: {
+    icon: React.ReactNode
+    title: string
+    detail: string
+    onPress: () => void
+  }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        padding: 18,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor,
+        backgroundColor: pressed ? pressedBg : cardBg,
+      })}
+    >
+      <View
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 12,
+          backgroundColor: surfaceBg,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {icon}
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>{title}</Text>
+        <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }} numberOfLines={2}>
+          {detail}
+        </Text>
+      </View>
+      <ChevronRight size={18} color={iconColor} />
     </Pressable>
   )
 
-  /** Static label/value row (e.g. About) — avoids MenuRow flex-start packing label + value together */
-  const AboutInfoRow = ({
-    icon: Icon,
-    label,
-    value,
+  const LegalRow = ({
+    icon,
+    title,
+    onPress,
+    destructive,
     isLast,
   }: {
-    icon: typeof Info
-    label: string
-    value: string
+    icon: React.ReactNode
+    title: string
+    onPress: () => void
+    destructive?: boolean
     isLast?: boolean
   }) => (
-    <View
-      style={{
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({
         flexDirection: 'row',
         alignItems: 'center',
+        gap: 12,
         paddingVertical: 14,
-        paddingHorizontal: 16,
-        backgroundColor: cardBg,
         borderBottomWidth: isLast ? 0 : 1,
         borderBottomColor: borderColor,
-        gap: 12,
-      }}
+        backgroundColor: pressed ? pressedBg : 'transparent',
+      })}
     >
-      <Icon size={20} color={textColor} />
-      <Text
-        style={{
-          fontSize: 16,
-          color: textColor,
-          flex: 1,
-          minWidth: 0,
-        }}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-      >
-        {label}
+      <View style={{ width: 22, alignItems: 'center' }}>{icon}</View>
+      <Text style={{ flex: 1, fontSize: 15, color: destructive ? '#DC2626' : textColor, fontWeight: destructive ? '600' : '500' }}>
+        {title}
       </Text>
-      <Text
-        style={{
-          fontSize: 15,
-          color: mutedTextColor,
-          textAlign: 'right',
-          flexShrink: 0,
-          maxWidth: '52%',
-        }}
-        numberOfLines={2}
-      >
-        {value}
-      </Text>
-    </View>
+      <ChevronRight size={17} color={destructive ? '#DC2626' : iconColor} />
+    </Pressable>
   )
 
   return (
@@ -156,170 +301,271 @@ export default function PreferencesNative() {
         style={{ flex: 1, backgroundColor: pageBg }}
         contentContainerStyle={{
           paddingHorizontal: 16,
-          paddingTop: 20,
+          paddingTop: 18,
           paddingBottom: 40,
+          gap: 14,
         }}
       >
-        {/* Appearance */}
-        <Section title="APPEARANCE" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <View style={{ paddingVertical: 14, paddingHorizontal: 16, backgroundColor: cardBg }}>
-              <ThemeSelector />
+        <Card>
+          <View style={{ padding: 20 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+              <Avatar image={user?.profileImage || undefined} name={displayName} size={56} />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ fontSize: 18, fontWeight: '600', color: textColor }} numberOfLines={1}>
+                  {displayName}
+                </Text>
+                {accountLabel ? (
+                  <Text style={{ fontSize: 14, color: mutedTextColor, marginTop: 1 }} numberOfLines={1}>
+                    {accountLabel}
+                  </Text>
+                ) : null}
+              </View>
             </View>
-          </View>
-        </Section>
-        {/* Connect */}
-        <Section title="NOTIFICATIONS" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <MenuRow onPress={() => {
-              track('settings_notifications_pressed', { source: 'settings' })
-              router.push('/settings/notifications')
-            }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <Bell size={20} color={textColor} />
-                <Text style={{ fontSize: 15, color: textColor }}>Notification preferences</Text>
-              </View>
-            </MenuRow>
-          </View>
-        </Section>
 
-        <Section title="CONNECT" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <MenuRow onPress={() => {
-              track('settings_invite_pressed', { source: 'settings' })
-              router.push('/settings/invite')
-            }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <UserPlus size={20} color={textColor} />
-                <Text style={{ fontSize: 15, color: textColor }}>Invite Friends</Text>
-              </View>
-            </MenuRow>
-          </View>
-        </Section>
-        {/* Regulatory */}
-        <Section title="REGULATORY" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <MenuRow
-              onPress={() => {
-                track('privacy_policy_viewed')
-                router.push('/privacy')
-              }}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <Shield size={20} color={textColor} />
-                <Text style={{ fontSize: 15, color: textColor }}>Privacy Policy</Text>
-              </View>
-            </MenuRow>
-            <MenuRow
-              onPress={() => {
-                track('terms_viewed')
-                router.push('/terms')
-              }}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <FileText size={20} color={textColor} />
-                <Text style={{ fontSize: 15, color: textColor }}>Terms of Service</Text>
-              </View>
-            </MenuRow>
-            <MenuRow
-              onPress={() => {
-                track('cookie_policy_viewed')
-                router.push('/cookies')
-              }}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <Info size={20} color={textColor} />
-                <Text style={{ fontSize: 15, color: textColor }}>Cookie Policy</Text>
-              </View>
-            </MenuRow>
-          </View>
-        </Section>
-
-        {/* About */}
-        <Section title="ABOUT" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <AboutInfoRow icon={Info} label="Version" value={APP_VERSION} />
-            <AboutInfoRow
-              icon={Info}
-              label="Chinmaya Janata"
-              value={`© ${currentYear}\nChinmaya Mission`}
-              isLast
-            />
-          </View>
-        </Section>
-
-        {/* Account Actions */}
-        <Section title="ACCOUNT" titleColor={faintColor}>
-          <View
-            style={{
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor,
-              marginHorizontal: -16,
-            }}
-          >
-            <MenuRow onPress={handleLogout} showArrow={false}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <LogOut size={20} color="#ef4444" />
-                <Text style={{ fontSize: 15, color: '#ef4444', fontWeight: '600' }}>Log Out</Text>
-              </View>
-            </MenuRow>
-            <MenuRow
-              onPress={() => {
-                track('delete_account_started', { source: 'settings' })
-                setShowDeleteModal(true)
-              }}
-              showArrow={false}
-            >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-                <AlertTriangle size={20} color="#dc2626" />
-                <Text style={{ fontSize: 15, color: '#dc2626', fontWeight: '600' }}>
-                  Delete Account
+            <View style={{ marginTop: 18, gap: 10 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <BadgeCheck size={15} color={roleLabel ? '#C2410C' : faintColor} />
+                <Text style={{ fontSize: 13.5, color: roleLabel ? '#C2410C' : mutedTextColor }}>
+                  {roleLabel || 'Unverified account'}
                 </Text>
               </View>
-            </MenuRow>
-          </View>
-        </Section>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <MapPin size={15} color={iconColor} />
+                <Text style={{ fontSize: 13.5, color: mutedTextColor }}>{homeCenterLabel}</Text>
+              </View>
+            </View>
 
-        <View style={{ height: 40 }} />
+            {hasProfileDetails ? (
+              <View style={{ marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: borderColor, gap: 12 }}>
+                <DetailItem label="Bio" value={user?.bio} />
+                <DetailItem label="Email" value={user?.email} />
+                <DetailItem label="Phone" value={user?.phoneNumber} />
+                <DetailItem label="School" value={user?.school} />
+                <DetailItem label="Work" value={user?.work} />
+                <DetailItem label="Region" value={user?.region} />
+                <DetailItem label="Looking for" value={lookingFor} />
+                <DetailItem label="Interests" value={interests} />
+              </View>
+            ) : null}
+
+            <Pressable
+              onPress={() => {
+                track('nav_edit_profile', { source: 'settings_native_summary' })
+                router.push('/edit-profile')
+              }}
+              style={({ pressed }) => ({
+                marginTop: 18,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 8,
+                borderRadius: 12,
+                borderWidth: 1,
+                borderColor,
+                paddingVertical: 12,
+                backgroundColor: pressed ? pressedBg : cardBg,
+              })}
+            >
+              <Pencil size={16} color={textColor} />
+              <Text style={{ fontSize: 14, fontWeight: '600', color: textColor }}>Edit public profile</Text>
+            </Pressable>
+
+            {canInvite ? (
+              <View style={{ marginTop: 16, paddingTop: 16, borderTopWidth: 1, borderTopColor: borderColor, gap: 10 }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                  <Share2 size={16} color="#C2410C" />
+                  <Text style={{ fontSize: 14, fontWeight: '600', color: textColor }}>Invite link</Text>
+                </View>
+                {inviteLoading ? (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 8 }}>
+                    <ActivityIndicator color="#C2410C" />
+                    <Text style={{ fontSize: 13, color: mutedTextColor }}>Getting your link...</Text>
+                  </View>
+                ) : inviteFailed ? (
+                  <Pressable
+                    onPress={loadInviteLink}
+                    style={({ pressed }) => ({
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor,
+                      paddingVertical: 10,
+                      alignItems: 'center',
+                      backgroundColor: pressed ? pressedBg : 'transparent',
+                    })}
+                  >
+                    <Text style={{ fontSize: 13, color: '#C2410C', fontWeight: '600' }}>
+                      Retry invite link
+                    </Text>
+                  </Pressable>
+                ) : inviteUrl ? (
+                  <>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: 8,
+                        backgroundColor: surfaceBg,
+                        borderRadius: 10,
+                        paddingHorizontal: 10,
+                        paddingVertical: 10,
+                      }}
+                    >
+                      <LinkIcon size={15} color="#C2410C" />
+                      <Text style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: textColor }} numberOfLines={1}>
+                        {inviteUrl.replace(/^https?:\/\//, '')}
+                      </Text>
+                    </View>
+                    <Pressable
+                      onPress={shareInviteLink}
+                      style={({ pressed }) => ({
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 8,
+                        borderRadius: 12,
+                        paddingVertical: 12,
+                        backgroundColor: pressed ? '#D97520' : '#C2410C',
+                      })}
+                    >
+                      <Share2 size={16} color="#FFFFFF" />
+                      <Text style={{ fontSize: 14, fontWeight: '600', color: '#FFFFFF' }}>Share invite link</Text>
+                    </Pressable>
+                  </>
+                ) : null}
+              </View>
+            ) : null}
+          </View>
+        </Card>
+
+        {isSuperAdmin(user) ? (
+          <ActionCard
+            icon={<Shield size={18} color="#C2410C" />}
+            title="Admin dashboard"
+            detail="Manage centers, events, notifications, and moderation."
+            onPress={() => {
+              track('settings_admin_dashboard_opened', { source: 'settings_native' })
+              router.push('/admin' as any)
+            }}
+          />
+        ) : null}
+
+        <ActionCard
+          icon={<Bell size={18} color={iconColor} />}
+          title="Notification preferences"
+          detail="Events, center announcements, board replies, mentions, and push."
+          onPress={() => {
+            track('settings_notifications_pressed', { source: 'settings_native' })
+            router.push('/settings/notifications')
+          }}
+        />
+
+        <Card>
+          <View style={{ padding: 18 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14, marginBottom: 16 }}>
+              <View
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: 12,
+                  backgroundColor: surfaceBg,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Eye size={18} color={iconColor} />
+              </View>
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>Appearance</Text>
+                <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>
+                  Light, dark, or automatic theme.
+                </Text>
+              </View>
+            </View>
+            <ThemeSelector />
+          </View>
+        </Card>
+
+        <Card>
+          <View style={{ paddingHorizontal: 18, paddingVertical: 4 }}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityState={{ expanded: legalOpen }}
+              onPress={() => setLegalOpen((open) => !open)}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 12,
+                paddingVertical: 14,
+                borderBottomWidth: legalOpen ? 1 : 0,
+                borderBottomColor: borderColor,
+                backgroundColor: pressed ? pressedBg : 'transparent',
+              })}
+            >
+              <LockKeyhole size={18} color={iconColor} />
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>Legal and account</Text>
+                <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>
+                  Policies, version {APP_VERSION}, sign out, and account deletion.
+                </Text>
+              </View>
+              {legalOpen ? <ChevronDown size={18} color={iconColor} /> : <ChevronRight size={18} color={iconColor} />}
+            </Pressable>
+            {legalOpen ? (
+              <>
+                <LegalRow
+                  icon={<Shield size={18} color={iconColor} />}
+                  title="Privacy policy"
+                  onPress={() => {
+                    track('privacy_policy_viewed')
+                    router.push('/privacy')
+                  }}
+                />
+                <LegalRow
+                  icon={<FileText size={18} color={iconColor} />}
+                  title="Terms of service"
+                  onPress={() => {
+                    track('terms_viewed')
+                    router.push('/terms')
+                  }}
+                />
+                <LegalRow
+                  icon={<Info size={18} color={iconColor} />}
+                  title="Cookie policy"
+                  onPress={() => {
+                    track('cookie_policy_viewed')
+                    router.push('/cookies')
+                  }}
+                />
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                  <Text style={{ fontSize: 15, color: textColor }}>Version</Text>
+                  <Text style={{ fontSize: 14, color: mutedTextColor }}>{APP_VERSION}</Text>
+                </View>
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                  <Text style={{ fontSize: 15, color: textColor }}>Chinmaya Janata</Text>
+                  <Text style={{ fontSize: 14, color: mutedTextColor }}>{currentYear} Chinmaya Mission</Text>
+                </View>
+                <LegalRow
+                  icon={<LogOut size={18} color="#DC2626" />}
+                  title="Log out"
+                  onPress={handleLogout}
+                  destructive
+                />
+                <LegalRow
+                  icon={<AlertTriangle size={18} color="#DC2626" />}
+                  title="Delete account"
+                  onPress={() => {
+                    track('delete_account_started', { source: 'settings' })
+                    setShowDeleteModal(true)
+                  }}
+                  destructive
+                  isLast
+                />
+              </>
+            ) : null}
+          </View>
+        </Card>
       </ScrollView>
 
-      {/* Delete confirmation modal */}
       <Modal
         transparent
         visible={showDeleteModal}
@@ -371,9 +617,7 @@ export default function PreferencesNative() {
               >
                 Delete Account?
               </Text>
-              <Text
-                style={{ fontSize: 15, color: mutedTextColor, textAlign: 'center', lineHeight: 22 }}
-              >
+              <Text style={{ fontSize: 15, color: mutedTextColor, textAlign: 'center', lineHeight: 22 }}>
                 This action cannot be undone. All your data will be permanently deleted.
               </Text>
             </View>
@@ -405,13 +649,9 @@ export default function PreferencesNative() {
                   alignItems: 'center',
                 }}
               >
-                {isDeleting ? (
-                  <Text style={{ fontSize: 16, fontWeight: '600', color: '#fff' }}>
-                    Deleting...
-                  </Text>
-                ) : (
-                  <Text style={{ fontSize: 16, fontWeight: '600', color: '#fff' }}>Delete</Text>
-                )}
+                <Text style={{ fontSize: 16, fontWeight: '600', color: '#fff' }}>
+                  {isDeleting ? 'Deleting...' : 'Delete'}
+                </Text>
               </Pressable>
             </View>
           </View>

--- a/packages/frontend/app/settings/index.web.tsx
+++ b/packages/frontend/app/settings/index.web.tsx
@@ -1,33 +1,63 @@
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   ScrollView,
   View,
   Pressable,
-  Linking,
   Modal,
   Platform,
   Alert,
+  ActivityIndicator,
   useWindowDimensions,
 } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
-import { Eye, Shield, Info, ExternalLink, AlertTriangle, UserPlus, LogOut, ChevronRight, User, Bell } from 'lucide-react-native'
+import {
+  Eye,
+  Shield,
+  Info,
+  ExternalLink,
+  AlertTriangle,
+  UserPlus,
+  LogOut,
+  ChevronRight,
+  ChevronDown,
+  Bell,
+  BadgeCheck,
+  MapPin,
+  LockKeyhole,
+  Link as LinkIcon,
+  Copy,
+  Check,
+} from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { useRouter } from 'expo-router'
 import { DestructiveButton, SecondaryButton, Text, Avatar } from '../../components/ui'
 import ThemeSelector from '../../components/settings/ThemeSelector'
 import { useAnalytics } from '../../utils/analytics'
+import { isSuperAdmin } from '../../utils/admin'
+import { inviteClient } from '../../src/auth/inviteClient'
+import { fetchCenters, type CenterData } from '../../utils/api'
 import Constants from 'expo-constants'
 
 const APP_VERSION = Constants.expoConfig?.version || '0.2.0'
+const linkForCode = (code: string) => `https://chinmayajanata.org/i/${code}`
 
 export default function Preferences() {
   const { isDark } = useTheme()
-  const { deleteAccount, logout, user } = useUser()
+  const { deleteAccount, logout, user, getToken } = useUser()
   const router = useRouter()
+  const [accountOpen, setAccountOpen] = useState(false)
+  const [allCenters, setAllCenters] = useState<CenterData[]>([])
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null)
+  const [inviteLoading, setInviteLoading] = useState(false)
+  const [inviteFailed, setInviteFailed] = useState(false)
+  const [inviteCopied, setInviteCopied] = useState(false)
   const displayName =
     user?.firstName && user?.lastName
       ? `${user.firstName} ${user.lastName}`
       : user?.firstName || user?.username || 'You'
+  const accountIdentifier = user?.email || user?.username || null
+  const accountLabel = accountIdentifier
+    ? accountIdentifier.includes('@') ? accountIdentifier : `@${accountIdentifier}`
+    : null
   const vl = user?.verificationLevel ?? 0
   const roleLabel =
     vl >= 1000008 ? 'Global Head'
@@ -36,6 +66,9 @@ export default function Preferences() {
       : vl >= 54 ? 'Sevak'
       : vl >= 45 ? 'Verified member'
       : null
+  const canInvite = vl >= 45
+  const homeCenter = allCenters.find((center) => center.centerID === user?.centerID)
+  const homeCenterLabel = homeCenter?.name || (user?.centerID ? 'Home center selected' : 'No home center yet')
   const [isDeleting, setIsDeleting] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const { track } = useAnalytics()
@@ -48,9 +81,73 @@ export default function Preferences() {
   const cardBg = isDark ? '#262626' : '#FFFFFF'
   const pageBg = isDark ? '#1A1A1A' : '#F5F5F4'
   const iconColor = isDark ? '#A8A29E' : '#78716C'
+  const surfaceBg = isDark ? '#1F1F1F' : '#F7F4EF'
+  const rowPressedBg = isDark ? '#303030' : '#F0EDE8'
   const { width: viewportWidth } = useWindowDimensions()
   const isNarrowWeb = Platform.OS === 'web' && viewportWidth < 768
   const webPaddingH = isNarrowWeb ? 16 : viewportWidth < 1024 ? 32 : 60
+
+  useEffect(() => {
+    fetchCenters().then(setAllCenters).catch(() => {})
+  }, [])
+
+  const loadInviteLink = useCallback(async () => {
+    if (!user || !canInvite) {
+      setInviteUrl(null)
+      setInviteFailed(false)
+      return
+    }
+    setInviteLoading(true)
+    setInviteFailed(false)
+    try {
+      const token = await getToken()
+      if (!token) {
+        setInviteFailed(true)
+        return
+      }
+      const list = await inviteClient.listMyCodes(token)
+      if (list.success) {
+        const usable = list.data.codes.find((entry) => entry.isUsable) ?? list.data.codes[0]
+        if (usable?.code) {
+          setInviteUrl(usable.shareUrl || linkForCode(usable.code))
+          return
+        }
+      }
+      const minted = await inviteClient.mintCode(token)
+      if (minted.success) {
+        setInviteUrl(minted.data.shareUrl || linkForCode(minted.data.code))
+      } else {
+        setInviteFailed(true)
+      }
+    } catch {
+      setInviteFailed(true)
+    } finally {
+      setInviteLoading(false)
+    }
+  }, [canInvite, getToken, user])
+
+  useEffect(() => {
+    loadInviteLink()
+  }, [loadInviteLink])
+
+  const copyInviteLink = async () => {
+    if (!inviteUrl) return
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        await navigator.clipboard.writeText(inviteUrl)
+        setInviteCopied(true)
+        setTimeout(() => setInviteCopied(false), 2000)
+        track('invite_link_shared', {
+          source: 'settings_web_profile_card',
+          method: 'copy',
+        })
+      } else {
+        Alert.alert('Copy link', inviteUrl)
+      }
+    } catch {
+      Alert.alert('Copy failed', 'Please try again.')
+    }
+  }
 
   const handleLogout = async () => {
     track('nav_logout', { source: 'settings_web' })
@@ -78,300 +175,539 @@ export default function Preferences() {
     }
   }
 
+  const SettingsCard = ({
+    icon,
+    title,
+    summary,
+    children,
+  }: {
+    icon: React.ReactNode
+    title: string
+    summary: string
+    children: React.ReactNode
+  }) => (
+    <View
+      style={{
+        backgroundColor: cardBg,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor,
+        overflow: 'hidden',
+      }}
+    >
+      <View style={{ padding: isNarrowWeb ? 18 : 22 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 12,
+              backgroundColor: surfaceBg,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {icon}
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>{title}</Text>
+            <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }} numberOfLines={2}>
+              {summary}
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderTopColor: borderColor,
+          padding: isNarrowWeb ? 18 : 22,
+          paddingTop: isNarrowWeb ? 16 : 18,
+        }}
+      >
+        {children}
+      </View>
+    </View>
+  )
+
+  const DisclosureSection = ({
+    icon,
+    title,
+    summary,
+    children,
+  }: {
+    icon: React.ReactNode
+    title: string
+    summary: string
+    children: React.ReactNode
+  }) => (
+    <View
+      style={{
+        backgroundColor: cardBg,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor,
+        overflow: 'hidden',
+      }}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ expanded: accountOpen }}
+        onPress={() => setAccountOpen((value) => !value)}
+        style={({ pressed }) => ({
+          padding: isNarrowWeb ? 18 : 22,
+          backgroundColor: pressed ? rowPressedBg : cardBg,
+        })}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+          <View
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 12,
+              backgroundColor: surfaceBg,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {icon}
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>{title}</Text>
+            <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }} numberOfLines={2}>
+              {summary}
+            </Text>
+          </View>
+          {accountOpen ? <ChevronDown size={18} color={iconColor} /> : <ChevronRight size={18} color={iconColor} />}
+        </View>
+      </Pressable>
+      {accountOpen ? (
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderTopColor: borderColor,
+            padding: isNarrowWeb ? 18 : 22,
+            paddingTop: isNarrowWeb ? 16 : 18,
+          }}
+        >
+          {children}
+        </View>
+      ) : null}
+    </View>
+  )
+
+  const SettingsRow = ({
+    icon,
+    title,
+    detail,
+    onPress,
+    destructive,
+    external,
+    isLast,
+  }: {
+    icon: React.ReactNode
+    title: string
+    detail?: string
+    onPress: () => void
+    destructive?: boolean
+    external?: boolean
+    isLast?: boolean
+  }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingVertical: 14,
+        borderBottomWidth: isLast ? 0 : 1,
+        borderBottomColor: borderColor,
+        backgroundColor: pressed ? rowPressedBg : 'transparent',
+      })}
+    >
+      <View style={{ width: 22, alignItems: 'center' }}>{icon}</View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={{ fontSize: 15, color: destructive ? '#DC2626' : textColor, fontWeight: destructive ? '600' : '500' }}>
+          {title}
+        </Text>
+        {detail ? (
+          <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }} numberOfLines={2}>
+            {detail}
+          </Text>
+        ) : null}
+      </View>
+      {external ? <ExternalLink size={17} color={iconColor} /> : <ChevronRight size={17} color={destructive ? '#DC2626' : iconColor} />}
+    </Pressable>
+  )
+
+  const ActionCard = ({
+    icon,
+    title,
+    detail,
+    onPress,
+  }: {
+    icon: React.ReactNode
+    title: string
+    detail: string
+    onPress: () => void
+  }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        padding: isNarrowWeb ? 18 : 22,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor,
+        backgroundColor: pressed ? rowPressedBg : cardBg,
+      })}
+    >
+      <View
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 12,
+          backgroundColor: surfaceBg,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {icon}
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>{title}</Text>
+        <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }} numberOfLines={2}>
+          {detail}
+        </Text>
+      </View>
+      <ChevronRight size={18} color={iconColor} />
+    </Pressable>
+  )
+
+  const ProfileDetail = ({ label, value }: { label: string; value?: string | null }) => {
+    if (!value) return null
+    return (
+      <View style={{ gap: 2 }}>
+        <Text style={{ fontSize: 11, color: faintColor, textTransform: 'uppercase', letterSpacing: 0.6 }}>
+          {label}
+        </Text>
+        <Text style={{ fontSize: 13.5, color: textColor, lineHeight: 19 }} numberOfLines={2}>
+          {value}
+        </Text>
+      </View>
+    )
+  }
+
+  const lookingFor = user?.lookingFor?.filter(Boolean).join(', ')
+  const interests = user?.interests?.filter(Boolean).join(', ')
+  const hasProfileDetails = !!(
+    user?.bio ||
+    user?.email ||
+    user?.phoneNumber ||
+    user?.school ||
+    user?.work ||
+    user?.region ||
+    lookingFor ||
+    interests ||
+    homeCenter?.name
+  )
+
   return (
     <ScrollView style={{ flex: 1, backgroundColor: pageBg }}>
       <View
         style={{
-          maxWidth: 900,
+          maxWidth: 1080,
           width: '100%',
           alignSelf: 'center',
-          padding: isNarrowWeb ? 20 : 40,
+          paddingVertical: isNarrowWeb ? 20 : 36,
           paddingHorizontal: webPaddingH,
-          gap: isNarrowWeb ? 24 : 36,
+          gap: isNarrowWeb ? 18 : 24,
         }}
       >
-        {/* Profile — top section of the combined Settings page (#346/#330) */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <User size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Profile</Text>
-          </View>
+        <View style={{ gap: 6 }}>
+          <Text style={{ fontSize: isNarrowWeb ? 26 : 32, fontWeight: '700', color: textColor }}>
+            Account settings
+          </Text>
+          <Text style={{ fontSize: 15, lineHeight: 22, color: mutedTextColor, maxWidth: 660 }}>
+            Manage your public profile, access, notifications, and account controls from one place.
+          </Text>
+        </View>
+
+        <View
+          style={{
+            flexDirection: isNarrowWeb ? 'column' : 'row',
+            alignItems: 'flex-start',
+            gap: 24,
+          }}
+        >
           <View
             style={{
+              width: isNarrowWeb ? '100%' : 300,
               backgroundColor: cardBg,
-              borderRadius: 20,
+              borderRadius: 18,
               borderWidth: 1,
               borderColor,
-              padding: isNarrowWeb ? 20 : 28,
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: 16,
+              padding: 22,
+              ...(isNarrowWeb ? {} : { position: 'sticky' as 'absolute', top: 88 }),
             }}
           >
-            <Avatar image={user?.profileImage || undefined} name={displayName} size={isNarrowWeb ? 56 : 64} />
-            <View style={{ flex: 1, minWidth: 0 }}>
-              <Text style={{ fontSize: 18, color: textColor }} numberOfLines={1}>
-                {displayName}
-              </Text>
-              {user?.username ? (
-                <Text style={{ fontSize: 14, color: mutedTextColor, marginTop: 1 }} numberOfLines={1}>
-                  @{user.username}
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+              <Avatar image={user?.profileImage || undefined} name={displayName} size={56} />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ fontSize: 18, fontWeight: '600', color: textColor }} numberOfLines={1}>
+                  {displayName}
                 </Text>
-              ) : null}
-              {roleLabel ? (
-                <Text style={{ fontSize: 13, color: '#C2410C', marginTop: 3 }}>{roleLabel}</Text>
-              ) : null}
+                {accountLabel ? (
+                  <Text style={{ fontSize: 14, color: mutedTextColor, marginTop: 1 }} numberOfLines={1}>
+                    {accountLabel}
+                  </Text>
+                ) : null}
+              </View>
             </View>
+            <View style={{ marginTop: 18, gap: 10 }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <BadgeCheck size={15} color={roleLabel ? '#C2410C' : faintColor} />
+                <Text style={{ fontSize: 13.5, color: roleLabel ? '#C2410C' : mutedTextColor }}>
+                  {roleLabel || 'Unverified account'}
+                </Text>
+              </View>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <MapPin size={15} color={iconColor} />
+                <Text style={{ fontSize: 13.5, color: mutedTextColor }}>{homeCenterLabel}</Text>
+              </View>
+            </View>
+            {hasProfileDetails ? (
+              <View
+                style={{
+                  marginTop: 18,
+                  paddingTop: 16,
+                  borderTopWidth: 1,
+                  borderTopColor: borderColor,
+                  gap: 12,
+                }}
+              >
+                <ProfileDetail label="Bio" value={user?.bio} />
+                <ProfileDetail label="Email" value={user?.email} />
+                <ProfileDetail label="Phone" value={user?.phoneNumber} />
+                <ProfileDetail label="School" value={user?.school} />
+                <ProfileDetail label="Work" value={user?.work} />
+                <ProfileDetail label="Region" value={user?.region} />
+                <ProfileDetail label="Looking for" value={lookingFor} />
+                <ProfileDetail label="Interests" value={interests} />
+              </View>
+            ) : null}
             <SecondaryButton
+              style={{ marginTop: 18, width: '100%' }}
               onPress={() => {
-                track('nav_edit_profile', { source: 'settings_web' })
+                track('nav_edit_profile', { source: 'settings_web_summary' })
                 router.push('/edit-profile')
               }}
             >
-              Edit
+              Edit public profile
             </SecondaryButton>
+            {canInvite ? (
+              <View
+                style={{
+                  marginTop: 16,
+                  paddingTop: 16,
+                  borderTopWidth: 1,
+                  borderTopColor: borderColor,
+                  gap: 10,
+                }}
+              >
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                  <UserPlus size={16} color="#C2410C" />
+                  <Text style={{ fontSize: 14, fontWeight: '600', color: textColor }}>Invite link</Text>
+                </View>
+                {inviteLoading ? (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 8 }}>
+                    <ActivityIndicator color="#C2410C" />
+                    <Text style={{ fontSize: 13, color: mutedTextColor }}>Getting your link...</Text>
+                  </View>
+                ) : inviteFailed ? (
+                  <Pressable
+                    onPress={loadInviteLink}
+                    style={{
+                      borderRadius: 10,
+                      borderWidth: 1,
+                      borderColor,
+                      paddingVertical: 10,
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Text style={{ fontSize: 13, color: '#C2410C', fontWeight: '600' }}>
+                      Retry invite link
+                    </Text>
+                  </Pressable>
+                ) : inviteUrl ? (
+                  <>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: 8,
+                        backgroundColor: surfaceBg,
+                        borderRadius: 10,
+                        paddingHorizontal: 10,
+                        paddingVertical: 10,
+                      }}
+                    >
+                      <LinkIcon size={15} color="#C2410C" />
+                      <Text
+                        style={{ flex: 1, minWidth: 0, fontSize: 12.5, color: textColor }}
+                        numberOfLines={1}
+                      >
+                        {inviteUrl.replace(/^https?:\/\//, '')}
+                      </Text>
+                    </View>
+                    <Pressable
+                      onPress={copyInviteLink}
+                      style={({ pressed }) => ({
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 8,
+                        borderRadius: 12,
+                        paddingVertical: 12,
+                        backgroundColor: inviteCopied ? surfaceBg : pressed ? '#D97520' : '#C2410C',
+                      })}
+                    >
+                      {inviteCopied ? <Check size={16} color="#C2410C" /> : <Copy size={16} color="#FFFFFF" />}
+                      <Text style={{ fontSize: 14, fontWeight: '600', color: inviteCopied ? '#C2410C' : '#FFFFFF' }}>
+                        {inviteCopied ? 'Link copied' : 'Copy invite link'}
+                      </Text>
+                    </Pressable>
+                  </>
+                ) : null}
+              </View>
+            ) : null}
           </View>
-        </View>
 
-        {/* Account Section (invite + log out — parity with the native settings) */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <UserPlus size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Account</Text>
-          </View>
-          <View
-            style={{
-              backgroundColor: cardBg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor,
-              overflow: 'hidden',
-            }}
-          >
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-                borderBottomWidth: 1,
-                borderBottomColor: borderColor,
-              }}
+          <View style={{ flex: 1, width: '100%', gap: 14 }}>
+            {isSuperAdmin(user) ? (
+              <ActionCard
+                icon={<Shield size={18} color="#C2410C" />}
+                title="Admin dashboard"
+                detail="Manage centers, events, notifications, and moderation."
+                onPress={() => {
+                  track('settings_admin_dashboard_opened', { source: 'settings_web' })
+                  router.push('/admin' as never)
+                }}
+              />
+            ) : null}
+
+            <ActionCard
+              icon={<Bell size={18} color={iconColor} />}
+              title="Notification preferences"
+              detail="Events, center announcements, board replies, mentions, and push."
               onPress={() => {
-                track('settings_invite_pressed', { source: 'settings_web' })
-                router.push('/settings/invite')
+                track('settings_notifications_pressed', { source: 'settings_web' })
+                router.push('/settings/notifications')
               }}
-            >
-              <Text style={{ fontSize: 15, color: textColor }}>Invite Friends</Text>
-              <ChevronRight size={18} color={iconColor} />
-            </Pressable>
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-              }}
-              onPress={handleLogout}
-            >
-              <Text style={{ fontSize: 15, color: '#DC2626' }}>Log Out</Text>
-              <LogOut size={18} color="#DC2626" />
-            </Pressable>
-          </View>
-        </View>
+            />
 
-        {/* Notifications Section */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <Bell size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Notifications</Text>
-          </View>
-          <Pressable
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              padding: isNarrowWeb ? 20 : 28,
-              backgroundColor: cardBg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor,
-            }}
-            onPress={() => {
-              track('settings_notifications_pressed', { source: 'settings_web' })
-              router.push('/settings/notifications')
-            }}
-          >
-            <View style={{ flex: 1, marginRight: 12 }}>
-              <Text style={{ fontSize: 15, color: textColor }}>Notification preferences</Text>
-              <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 2 }}>Choose what you're notified about</Text>
-            </View>
-            <ChevronRight size={18} color={iconColor} />
-          </Pressable>
-        </View>
+            <SettingsCard
+              icon={<Eye size={18} color={iconColor} />}
+              title="Appearance"
+              summary="Light, dark, or automatic theme."
+            >
+              <ThemeSelector />
+            </SettingsCard>
 
-        {/* Appearance Section */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <Eye size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Appearance</Text>
-          </View>
-          <View
-            style={{
-              backgroundColor: cardBg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor,
-              padding: isNarrowWeb ? 20 : 28,
-            }}
-          >
-            <ThemeSelector />
-          </View>
-        </View>
-
-        {/* Privacy Section */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <Shield size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>Privacy</Text>
-          </View>
-          <View
-            style={{
-              backgroundColor: cardBg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor,
-              overflow: 'hidden',
-            }}
-          >
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-                borderBottomWidth: 1,
-                borderBottomColor: borderColor,
-              }}
-              onPress={() => {
-                track('privacy_policy_viewed')
-                router.push('/privacy')
-              }}
+            <DisclosureSection
+              icon={<LockKeyhole size={18} color={iconColor} />}
+              title="Legal and account"
+              summary={`Policies, version ${APP_VERSION}, sign out, and account deletion.`}
             >
-              <Text style={{ fontSize: 15, color: textColor }}>Privacy Policy</Text>
-              <ExternalLink size={18} color={iconColor} />
-            </Pressable>
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-                borderBottomWidth: 1,
-                borderBottomColor: borderColor,
-              }}
-              onPress={() => {
-                track('terms_viewed')
-                router.push('/terms')
-              }}
-            >
-              <Text style={{ fontSize: 15, color: textColor }}>Terms of Service</Text>
-              <ExternalLink size={18} color={iconColor} />
-            </Pressable>
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-              }}
-              onPress={() => {
-                track('cookie_policy_viewed')
-                router.push('/cookies')
-              }}
-            >
-              <Text style={{ fontSize: 15, color: textColor }}>Cookie Policy</Text>
-              <ExternalLink size={18} color={iconColor} />
-            </Pressable>
-          </View>
-        </View>
-
-        {/* About Section */}
-        <View>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-            <Info size={20} color={iconColor} />
-            <Text style={{ fontSize: 17, fontWeight: '600', color: textColor }}>About</Text>
-          </View>
-          <View
-            style={{
-              backgroundColor: cardBg,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor,
-              overflow: 'hidden',
-            }}
-          >
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-                borderBottomWidth: 1,
-                borderBottomColor: borderColor,
-              }}
-            >
-              <Text style={{ fontSize: 15, color: textColor }}>Version</Text>
-              <Text style={{ fontSize: 14, color: mutedTextColor, textAlign: 'right' }}>
-                {APP_VERSION}
-              </Text>
-            </View>
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: isNarrowWeb ? 20 : 28,
-              }}
-            >
-              <Text style={{ fontSize: 15, color: textColor }}>Chinmaya Janata</Text>
-              <Text style={{ fontSize: 14, color: mutedTextColor, textAlign: 'right' }}>
-                {currentYear} Chinmaya Mission
-              </Text>
-            </View>
-          </View>
-        </View>
-
-        {/* Danger Zone */}
-        <View>
-          <View
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              padding: isNarrowWeb ? 20 : 28,
-              borderRadius: 20,
-              borderWidth: 1,
-              borderColor: '#FECACA',
-              backgroundColor: isDark ? 'rgba(220,38,38,0.1)' : '#FEF2F2',
-            }}
-          >
-            <View style={{ gap: 4, flex: 1, marginRight: 16 }}>
-              <Text style={{ fontSize: 15, fontWeight: '600', color: '#DC2626' }}>
-                Danger Zone
-              </Text>
-              <Text style={{ fontSize: 13, color: mutedTextColor }}>
-                Permanently delete your account and all data
-              </Text>
-            </View>
-            <DestructiveButton
-              onPress={() => {
-                track('delete_account_started', { source: 'settings' })
-                setShowDeleteModal(true)
-              }}
-            >
-              Delete Account
-            </DestructiveButton>
+              <SettingsRow
+                icon={<Shield size={18} color={iconColor} />}
+                title="Privacy policy"
+                onPress={() => {
+                  track('privacy_policy_viewed')
+                  router.push('/privacy')
+                }}
+                external
+              />
+              <SettingsRow
+                icon={<Info size={18} color={iconColor} />}
+                title="Terms of service"
+                onPress={() => {
+                  track('terms_viewed')
+                  router.push('/terms')
+                }}
+                external
+              />
+              <SettingsRow
+                icon={<Info size={18} color={iconColor} />}
+                title="Cookie policy"
+                onPress={() => {
+                  track('cookie_policy_viewed')
+                  router.push('/cookies')
+                }}
+                external
+              />
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  paddingVertical: 14,
+                  borderBottomWidth: 1,
+                  borderBottomColor: borderColor,
+                }}
+              >
+                <Text style={{ fontSize: 15, color: textColor }}>Version</Text>
+                <Text style={{ fontSize: 14, color: mutedTextColor }}>{APP_VERSION}</Text>
+              </View>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  paddingVertical: 14,
+                  borderBottomWidth: 1,
+                  borderBottomColor: borderColor,
+                }}
+              >
+                <Text style={{ fontSize: 15, color: textColor }}>Chinmaya Janata</Text>
+                <Text style={{ fontSize: 14, color: mutedTextColor }}>{currentYear} Chinmaya Mission</Text>
+              </View>
+              <SettingsRow
+                icon={<LogOut size={18} color="#DC2626" />}
+                title="Log out"
+                onPress={handleLogout}
+                destructive
+              />
+              <View
+                style={{
+                  flexDirection: isNarrowWeb ? 'column' : 'row',
+                  alignItems: isNarrowWeb ? 'stretch' : 'center',
+                  justifyContent: 'space-between',
+                  gap: 14,
+                  paddingTop: 16,
+                }}
+              >
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text style={{ fontSize: 15, fontWeight: '600', color: '#DC2626' }}>
+                    Delete account
+                  </Text>
+                  <Text style={{ fontSize: 13, color: mutedTextColor, marginTop: 3 }}>
+                    Permanently delete your account and all data.
+                  </Text>
+                </View>
+                <DestructiveButton
+                  style={{ alignSelf: isNarrowWeb ? 'stretch' : 'auto' }}
+                  onPress={() => {
+                    track('delete_account_started', { source: 'settings' })
+                    setShowDeleteModal(true)
+                  }}
+                >
+                  Delete account
+                </DestructiveButton>
+              </View>
+            </DisclosureSection>
           </View>
         </View>
       </View>

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { Animated, Text, Pressable, View, Image, Easing } from 'react-native'
+import React, { useEffect, useRef } from 'react'
+import { Animated, Text, Pressable, View } from 'react-native'
 import { useUser, useTheme } from '../contexts'
-import { Settings, LogOut, Sun, Moon, User, Monitor, Shield } from 'lucide-react-native'
+import { Settings, LogOut, User, Shield } from 'lucide-react-native'
 import { router, usePathname } from 'expo-router'
-import ThemeSelector from './ThemeSelector'
 import { Avatar } from '../ui'
 import { isSuperAdmin } from '../../utils/admin'
 import { useAnalytics } from '../../utils/analytics'
@@ -13,14 +12,9 @@ function SettingsPanel({ visible, onClose, onLogout }) {
   const opacityAnim = useRef(new Animated.Value(0)).current
   const translateYAnim = useRef(new Animated.Value(-20)).current
   const { user } = useUser()
-  const { preference: themePreference, setPreference: setThemePreference, isDark } = useTheme()
+  const { isDark } = useTheme()
   const { track } = useAnalytics()
   const pathname = usePathname()
-  const themeOptions = ['light', 'dark', 'system']
-  const optionWidth = 70
-  const indicatorPadding = 8
-  const [selectedIndex, setSelectedIndex] = useState(themeOptions.indexOf(themePreference))
-  const slideAnim = useRef(new Animated.Value(selectedIndex * optionWidth)).current
   const previousTheme = useRef(isDark)
   const isMountedRef = useRef(true)
 
@@ -32,9 +26,8 @@ function SettingsPanel({ visible, onClose, onLogout }) {
       // Stop all animations immediately on unmount
       opacityAnim.stopAnimation()
       translateYAnim.stopAnimation()
-      slideAnim.stopAnimation()
     }
-  }, [opacityAnim, translateYAnim, slideAnim])
+  }, [opacityAnim, translateYAnim])
 
   useEffect(() => {
     if (visible) {
@@ -67,17 +60,6 @@ function SettingsPanel({ visible, onClose, onLogout }) {
     }
   }, [visible])
 
-  useEffect(() => {
-    const idx = themeOptions.indexOf(themePreference)
-    setSelectedIndex(idx)
-    Animated.timing(slideAnim, {
-      toValue: idx * optionWidth,
-      duration: 100,
-      useNativeDriver: supportsNativeDriver,
-      easing: Easing.inOut(Easing.ease),
-    }).start()
-  }, [themePreference])
-
   // Stop animations when theme changes
   useEffect(() => {
     if (previousTheme.current !== isDark) {
@@ -98,6 +80,10 @@ function SettingsPanel({ visible, onClose, onLogout }) {
     user?.firstName && user?.lastName
       ? `${user.firstName} ${user.lastName}`
       : user?.username || 'User'
+  const accountIdentifier = user?.email || user?.username || null
+  const accountLabel = accountIdentifier
+    ? accountIdentifier.includes('@') ? accountIdentifier : `@${accountIdentifier}`
+    : null
 
   const profileImage = user?.profileImage
   const getInitials = () => {
@@ -182,7 +168,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              {user?.username}
+              {accountLabel}
             </Text>
           </View>
         </View>
@@ -190,10 +176,33 @@ function SettingsPanel({ visible, onClose, onLogout }) {
         {/* Separator Line */}
         <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-3" />
 
-        {/* Profile Button */}
+        {/* Account navigation */}
         <Pressable
           className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings/profile'
+            pathname === '/settings'
+              ? 'bg-primary'
+              : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
+          }`}
+          onPress={() => {
+            track('nav_settings_opened', { source: 'settings_panel', destination: 'account_settings' })
+            onClose()
+            router.push('/settings')
+          }}
+        >
+          <Settings size={16} color={pathname === '/settings' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
+          <Text
+            className={`font-sans ${
+              pathname === '/settings'
+                ? 'text-white font-sans'
+                : 'text-content dark:text-content-dark'
+            }`}
+          >
+            Settings
+          </Text>
+        </Pressable>
+        <Pressable
+          className={`flex-row items-center mb-2 p-2 rounded-lg ${
+            pathname === '/profile'
               ? 'bg-primary'
               : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
           }`}
@@ -203,46 +212,15 @@ function SettingsPanel({ visible, onClose, onLogout }) {
             router.push('/profile')
           }}
         >
-          <User
-            size={16}
-            color={pathname === '/settings/profile' ? '#fff' : isDark ? '#fff' : '#374151'}
-            className="mr-3"
-          />
+          <User size={16} color={pathname === '/profile' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
           <Text
             className={`font-sans ${
-              pathname === '/settings/profile'
+              pathname === '/profile'
                 ? 'text-white font-sans'
                 : 'text-content dark:text-content-dark'
             }`}
           >
             Profile
-          </Text>
-        </Pressable>
-        <Pressable
-          className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings'
-              ? 'bg-primary'
-              : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
-          }`}
-          onPress={() => {
-            track('nav_settings_opened', { source: 'settings_panel', destination: 'preferences' })
-            onClose()
-            router.push('/settings')
-          }}
-        >
-          <Settings
-            size={16}
-            color={pathname === '/settings' ? '#fff' : isDark ? '#fff' : '#374151'}
-            className="mr-3"
-          />
-          <Text
-            className={`font-sans ${
-              pathname === '/settings'
-                ? 'text-white font-sans'
-                : 'text-content dark:text-content-dark'
-            }`}
-          >
-            Preferences
           </Text>
         </Pressable>
         {isSuperAdmin(user) && (
@@ -264,21 +242,10 @@ function SettingsPanel({ visible, onClose, onLogout }) {
           </>
         )}
 
-        {/* Appearance Slider */}
-        <View className="mb-3">
-          <Text className="text-sm font-sans text-content dark:text-content-dark mb-2">
-            Appearance
-          </Text>
-          <ThemeSelector
-            className="relative flex-row bg-gray-100 dark:bg-neutral-800 rounded-lg p-1"
-            style={{ width: 218 }}
-          />
-        </View>
-
         {user && (
           <>
             {/* Separator Line */}
-            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2 mt-2" />
+            <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
 
             {/* Log Out Button */}
             <Pressable

--- a/packages/frontend/components/settings/ThemeSelector.tsx
+++ b/packages/frontend/components/settings/ThemeSelector.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import { View, Text, Pressable } from 'react-native'
-import { Sun, Moon, Monitor } from 'lucide-react-native'
 import { useTheme } from '../contexts'
 
 const themeOptions = ['light', 'dark', 'system'] as const
-const optionWidth = 70
 
 export default function ThemeSelector({ style, className }: { style?: any; className?: string }) {
   const { preference: themePreference, setPreference: setThemePreference, isDark } = useTheme()
@@ -25,7 +23,6 @@ export default function ThemeSelector({ style, className }: { style?: any; class
     >
       {themeOptions.map((option) => {
         const isSelected = themePreference === option
-        const iconColor = isSelected ? accentColor : mutedColor
         const labelColor = isSelected ? textColor : mutedColor
 
         return (
@@ -37,7 +34,6 @@ export default function ThemeSelector({ style, className }: { style?: any; class
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'center',
-              gap: 6,
               paddingVertical: 12,
               paddingHorizontal: 12,
               borderRadius: 10,
@@ -45,9 +41,6 @@ export default function ThemeSelector({ style, className }: { style?: any; class
               borderColor: isSelected ? accentColor : 'transparent',
             }}
           >
-            {option === 'light' && <Sun size={16} color={iconColor} />}
-            {option === 'dark' && <Moon size={16} color={iconColor} />}
-            {option === 'system' && <Monitor size={16} color={iconColor} />}
             <Text
               style={{
                 color: labelColor,


### PR DESCRIPTION
## Summary
- Reworks web and native settings into a single profile/settings hub with a profile summary card, surfaced invite link, direct admin/notification/appearance controls, and progressive disclosure for legal/account actions.
- Cleans public profile surfaces on web and native by removing redundant account/invite rows, email-like username display, empty bio placeholder, empty activity stats, and duplicate center display.
- Simplifies the account dropdown to Settings/Profile/Admin/Logout and removes icons from the theme selector options.

## Validation
- `git diff --check` on the touched profile/settings files.
- `curl -I http://localhost:8081/settings` returned 200 in the active workspace.
- `curl -I http://localhost:8081/profile` returned 200 in the active workspace.
- `npx tsc --noEmit --pretty false` was run in the active workspace; it still fails on pre-existing unrelated errors in explore, invite landing, notifications, onboarding, event card icons, mobile discover fallback, and a nav test. No errors came from these touched profile/settings files.

## Notes
- This PR was built from a clean worktree based on `origin/v2` so it does not include the separate auth/login dirty work from the active workspace.