### PR TITLE
Polish auth invite entry flow

### DIFF
--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -42,6 +42,7 @@ export default function AuthScreen() {
     loading,
     inviterName,
     hasInvite,
+    isInviteWallEntry,
     emailEditable,
     isButtonDisabled,
     heading,
@@ -65,16 +66,16 @@ export default function AuthScreen() {
         className="flex-1 bg-[#FAFAF7] dark:bg-background-dark"
         keyboardShouldPersistTaps="handled"
       >
-        {/* Discover link, top-right, initial step only. Lets a logged-out
+        {/* Guest browse link, top-right, initial step only. Lets a logged-out
             user browse the app before signing up (mirrors the web version). */}
         {authStep === 'initial' && (
           <Pressable
-            onPress={() => { track('auth_discover_pressed', { source: 'auth' }); router.push('/(tabs)') }}
+            onPress={() => { track('auth_browse_as_guest_pressed', { source: 'auth' }); router.push('/(tabs)') }}
             className="absolute right-5"
             style={{ top: insets.top + 12, paddingHorizontal: 4, paddingVertical: 8 }}
           >
             <Text className="font-sans" style={{ fontSize: 14.5, fontWeight: '500', color: '#E8862A' }}>
-              Discover →
+              Browse as guest
             </Text>
           </Pressable>
         )}
@@ -115,7 +116,7 @@ export default function AuthScreen() {
 
               {/* What Janata is — first step only, so a new member knows what
                   they're signing into before entering an email. */}
-              {authStep === 'initial' && !hasInvite && (
+              {authStep === 'initial' && !hasInvite && !isInviteWallEntry && (
                 <View style={{ marginTop: 12, gap: 9 }}>
                   {[
                     'Discover satsangs, camps, and classes near you',
@@ -251,7 +252,7 @@ export default function AuthScreen() {
 
               {/* Have an invite? — manual code entry now that the typed step is
                   cut (form-03). Routes to the neutral paste screen (new-25). */}
-              {authStep === 'initial' && (
+              {authStep === 'initial' && !hasInvite && (
                 <Pressable
                   className="items-center mt-2"
                   onPress={() => { track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') }}

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -115,12 +115,12 @@ export default function AuthScreen() {
 
               {/* What Janata is — first step only, so a new member knows what
                   they're signing into before entering an email. */}
-              {authStep === 'initial' && (
+              {authStep === 'initial' && !hasInvite && (
                 <View style={{ marginTop: 12, gap: 9 }}>
                   {[
                     'Discover satsangs, camps, and classes near you',
                     'RSVP in a tap and see who else is going',
-                    'Stay connected with your center and sangha',
+                    'Send messages to members in centers and your events.',
                   ].map((line) => (
                     <View key={line} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
                       <Text style={{ color: '#E8862A', fontSize: 14, lineHeight: 22 }}>✓</Text>
@@ -230,7 +230,13 @@ export default function AuthScreen() {
                 loading={loading}
                 style={{ marginTop: 8 }}
               >
-                {authStep === 'login' ? 'Log In' : authStep === 'signup' ? 'Sign Up' : 'Continue'}
+                {authStep === 'login'
+                  ? 'Log In'
+                  : authStep === 'signup'
+                    ? hasInvite
+                      ? 'Accept Invite'
+                      : 'Sign Up'
+                    : 'Continue'}
               </PrimaryButton>
 
               {/* Forgot Password (only on login) */}

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -119,7 +119,9 @@ export default function AuthScreen() {
     : authStep === 'login'
       ? 'Sign In'
       : authStep === 'signup'
-        ? 'Create Account'
+        ? hasInvite
+          ? 'Accept invite and create account'
+          : 'Create Account'
         : 'Continue'
   const isNarrowWeb = viewportWidth < 1024
   const isMobile = viewportWidth < 640
@@ -153,7 +155,7 @@ export default function AuthScreen() {
           flex: 1,
         }}
       >
-        {/* Top nav: back to landing (left) + Discover (right) */}
+        {/* Top nav: home mark (left) + guest browse (right) */}
         <nav
           style={{
             display: 'flex',
@@ -164,41 +166,40 @@ export default function AuthScreen() {
           }}
         >
           <button
-            onClick={() => { track('auth_back_to_home_pressed', { source: 'auth' }); router.push('/landing') }}
+            onClick={() => { track('auth_logo_pressed', { source: 'auth' }); router.push('/landing') }}
+            aria-label="Go to Janata home"
             style={{
               background: 'none',
               border: 'none',
               cursor: 'pointer',
-              padding: '8px 4px',
-              margin: '-8px -4px',
-              fontSize: 14,
-              fontFamily: 'Inclusive Sans, sans-serif',
-              color: '#78716C',
+              padding: 0,
+              margin: 0,
               minHeight: 44,
               display: 'flex',
               alignItems: 'center',
             }}
           >
-            &larr; Back to home
+            <Logo size={isMobile ? 28 : 32} />
           </button>
           <button
-            onClick={() => { track('auth_discover_pressed', { source: 'auth' }); router.push('/(tabs)') }}
+            onClick={() => { track('auth_browse_as_guest_pressed', { source: 'auth' }); router.push('/(tabs)') }}
             style={{
-              background: 'none',
-              border: 'none',
+              backgroundColor: '#FAFAF7',
+              border: '1px solid #D6D3D1',
+              borderRadius: 8,
               cursor: 'pointer',
-              padding: '8px 4px',
-              margin: '-8px -4px',
+              padding: '0 16px',
               fontSize: 14,
               fontFamily: 'Inclusive Sans, sans-serif',
               fontWeight: '500',
-              color: '#E8862A',
+              color: '#57534E',
+              height: 44,
               minHeight: 44,
               display: 'flex',
               alignItems: 'center',
             }}
           >
-            Discover &rarr;
+            Browse as guest
           </button>
         </nav>
 
@@ -236,15 +237,6 @@ export default function AuthScreen() {
             </button>
           )}
 
-          {/* Janata logo */}
-          <div
-            onClick={() => { track('auth_logo_pressed', { source: 'auth' }); router.push('/landing') }}
-            role="link"
-            style={{ marginBottom: isMobile ? 32 : 48, cursor: 'pointer' }}
-          >
-            <Logo size={isMobile ? 28 : 32} />
-          </div>
-
           {/* Heading */}
           <h1
             style={{
@@ -262,12 +254,12 @@ export default function AuthScreen() {
           {/* What Janata is — only on the first step, so a new beta tester knows
               what they're signing into before entering an email. On mobile the
               brand carousel is hidden, making this the only context shown. */}
-          {authStep === 'initial' && (
+          {authStep === 'initial' && !hasInvite && (
             <div style={{ marginTop: 4, marginBottom: 24 }}>
               {[
                 'Discover satsangs, camps, and classes near you',
                 'RSVP in a tap and see who else is going',
-                'Stay connected with your center and sangha',
+                'Send messages to members in centers and your events.',
               ].map((line) => (
                 <div key={line} style={{ display: 'flex', gap: 10, alignItems: 'flex-start', marginBottom: 9 }}>
                   <span style={{ color: '#E8862A', fontSize: 14, lineHeight: '22px' }}>✓</span>
@@ -283,8 +275,9 @@ export default function AuthScreen() {
               fontFamily: 'Inclusive Sans, sans-serif',
               fontSize: 16,
               color: '#78716C',
-              marginBottom: 32,
+              marginBottom: 8,
               marginTop: 0,
+              lineHeight: '24px',
             }}
           >
             {subtitle}
@@ -438,7 +431,7 @@ export default function AuthScreen() {
           </form>
 
           {/* Toggle links */}
-          {authStep === 'initial' && (
+          {authStep === 'initial' && !hasInvite && (
             <p
               style={{
                 fontSize: 14,
@@ -469,7 +462,7 @@ export default function AuthScreen() {
 
           {/* Have an invite? — manual code entry now that the typed step is cut
               (form-03). Routes to the neutral paste screen (new-25). */}
-          {authStep === 'initial' && (
+          {authStep === 'initial' && !hasInvite && (
             <p
               style={{
                 fontSize: 14,

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -57,6 +57,7 @@ export default function AuthScreen() {
     loading,
     inviterName,
     hasInvite,
+    isInviteWallEntry,
     emailEditable,
     isButtonDisabled,
     heading,
@@ -254,7 +255,7 @@ export default function AuthScreen() {
           {/* What Janata is — only on the first step, so a new beta tester knows
               what they're signing into before entering an email. On mobile the
               brand carousel is hidden, making this the only context shown. */}
-          {authStep === 'initial' && !hasInvite && (
+          {authStep === 'initial' && !hasInvite && !isInviteWallEntry && (
             <div style={{ marginTop: 4, marginBottom: 24 }}>
               {[
                 'Discover satsangs, camps, and classes near you',
@@ -431,7 +432,7 @@ export default function AuthScreen() {
           </form>
 
           {/* Toggle links */}
-          {authStep === 'initial' && !hasInvite && (
+          {authStep === 'initial' && !hasInvite && !isInviteWallEntry && (
             <p
               style={{
                 fontSize: 14,

--- a/packages/frontend/components/auth/useAuthFlow.ts
+++ b/packages/frontend/components/auth/useAuthFlow.ts
@@ -34,14 +34,12 @@ export function useAuthFlow() {
   // the vouch without a second lookup. Absent → nameless.
   const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
 
-  // mode=login needs a prefilled email. mode=signup works with only an invite
-  // code because the email field stays editable in that flow.
+  // mode=login needs a prefilled email. Invite links still start email-first so
+  // a new member only sees password fields after we know the email is new.
   const initialStep = (): AuthStep =>
     params.mode === 'login' && urlEmail
       ? 'login'
-      : params.mode === 'signup' && urlInviteCode
-        ? 'signup'
-        : 'initial'
+      : 'initial'
 
   const [authStep, setAuthStep] = useState<AuthStep>(initialStep)
   const [username, setUsername] = useState(urlEmail)
@@ -248,6 +246,8 @@ export function useAuthFlow() {
 
   const errorMessages = Object.values(errors).filter(Boolean)
 
+  const inviteEmailStep = authStep === 'initial' && hasInvite
+
   const heading =
     authStep === 'login'
       ? collisionFlip
@@ -255,7 +255,9 @@ export function useAuthFlow() {
         : 'Welcome back.'
       : authStep === 'signup'
         ? 'Join the community.'
-        : 'Welcome.'
+        : inviteEmailStep
+          ? "You've been invited."
+          : 'Welcome.'
 
   const subtitle =
     authStep === 'login'
@@ -263,8 +265,12 @@ export function useAuthFlow() {
         ? "Log in and we'll apply the invite to it."
         : 'Enter your password to continue'
       : authStep === 'signup'
-        ? 'Create your account to get started'
-        : 'Enter your email to get started'
+        ? hasInvite
+          ? 'Create your account to accept this invite'
+          : 'Create your account to get started'
+        : inviteEmailStep
+          ? 'Enter your email to accept this Janata invite.'
+          : 'Enter your email to get started'
 
   return {
     // state

--- a/packages/frontend/components/auth/useAuthFlow.ts
+++ b/packages/frontend/components/auth/useAuthFlow.ts
@@ -26,10 +26,12 @@ export function useAuthFlow() {
     inviteCode?: string
     email?: string
     inviter?: string
+    gated?: string
   }>()
   const urlInviteCode = typeof params.inviteCode === 'string' ? params.inviteCode : ''
   const urlEmail = typeof params.email === 'string' ? params.email : ''
   const returnTo = typeof params.returnTo === 'string' ? params.returnTo : null
+  const isInviteWallEntry = params.gated === '1'
   // Door 1 carries the resolved inviter name forward, so the applied bar shows
   // the vouch without a second lookup. Absent → nameless.
   const inviterName = typeof params.inviter === 'string' && params.inviter ? params.inviter : null
@@ -97,6 +99,11 @@ export function useAuthFlow() {
         track('auth_user_exists', { source: 'auth' })
         setAuthStep('login')
       } else {
+        if (isInviteWallEntry && !hasInvite) {
+          track('auth_invite_required', { source: 'auth' })
+          setErrors({ form: 'Janata is invite-only. Paste an invite to create an account.' })
+          return
+        }
         // form-03 cut (#403): the invite is the door, so a new email goes
         // straight to account creation. Manual codes enter via /join (new-25).
         track('auth_user_new', { source: 'auth' })
@@ -106,7 +113,7 @@ export function useAuthFlow() {
       track('auth_check_failed', { source: 'auth' })
       setErrors({ form: e.message || 'Failed to connect to server.' })
     }
-  }, [username, checkUserExists, track])
+  }, [username, checkUserExists, track, isInviteWallEntry, hasInvite])
 
   const handleLogin = useCallback(async () => {
     setErrors({})
@@ -224,6 +231,10 @@ export function useAuthFlow() {
       setErrors({ username: 'You must enter a valid email address.' })
       return
     }
+    if (isInviteWallEntry && !hasInvite) {
+      setErrors({ form: 'Janata is invite-only. Paste an invite to create an account.' })
+      return
+    }
     track('auth_create_account_pressed', { source: 'auth' })
     try {
       const exists = await checkUserExists(username)
@@ -236,7 +247,7 @@ export function useAuthFlow() {
     } catch (e: any) {
       setErrors({ form: e.message || 'Failed to connect to server.' })
     }
-  }, [username, checkUserExists, track])
+  }, [username, checkUserExists, track, isInviteWallEntry, hasInvite])
 
   const isButtonDisabled =
     loading ||
@@ -247,6 +258,7 @@ export function useAuthFlow() {
   const errorMessages = Object.values(errors).filter(Boolean)
 
   const inviteEmailStep = authStep === 'initial' && hasInvite
+  const inviteWallStep = authStep === 'initial' && isInviteWallEntry && !hasInvite
 
   const heading =
     authStep === 'login'
@@ -257,6 +269,8 @@ export function useAuthFlow() {
         ? 'Join the community.'
         : inviteEmailStep
           ? "You've been invited."
+          : inviteWallStep
+            ? 'Janata is invite-only'
           : 'Welcome.'
 
   const subtitle =
@@ -270,6 +284,8 @@ export function useAuthFlow() {
           : 'Create your account to get started'
         : inviteEmailStep
           ? 'Enter your email to accept this Janata invite.'
+          : inviteWallStep
+            ? "Log in with your member account, or paste an invite if you're new."
           : 'Enter your email to get started'
 
   return {
@@ -285,6 +301,7 @@ export function useAuthFlow() {
     // derived
     inviterName,
     hasInvite,
+    isInviteWallEntry,
     emailEditable,
     isButtonDisabled,
     heading,

--- a/packages/frontend/components/ui/AuthPromptModal.tsx
+++ b/packages/frontend/components/ui/AuthPromptModal.tsx
@@ -149,9 +149,9 @@ export default function AuthPromptModal({
     if (!visible || !isDesktopWeb) return
     track('auth_prompt_desktop_redirected', { source: 'auth_modal' })
     closePrompt()
-    const destination = returnTo
-      ? `/auth?returnTo=${encodeURIComponent(returnTo)}`
-      : '/auth'
+    const search = new URLSearchParams({ gated: '1' })
+    if (returnTo) search.set('returnTo', returnTo)
+    const destination = `/auth?${search.toString()}`
     router.push(destination as never)
   }, [closePrompt, isDesktopWeb, returnTo, router, track, visible])
 

--- a/packages/frontend/components/ui/AuthPromptModal.tsx
+++ b/packages/frontend/components/ui/AuthPromptModal.tsx
@@ -143,7 +143,20 @@ export default function AuthPromptModal({
     return () => window.removeEventListener('resize', onResize)
   }, [])
 
+  const isDesktopWeb = Platform.OS === 'web' && viewportWidth >= 820
+
+  useEffect(() => {
+    if (!visible || !isDesktopWeb) return
+    track('auth_prompt_desktop_redirected', { source: 'auth_modal' })
+    closePrompt()
+    const destination = returnTo
+      ? `/auth?returnTo=${encodeURIComponent(returnTo)}`
+      : '/auth'
+    router.push(destination as never)
+  }, [closePrompt, isDesktopWeb, returnTo, router, track, visible])
+
   if (!visible) return null
+  if (isDesktopWeb) return null
 
   const wallTitle = title ?? 'Janata is invite-only'
   const wallCopy =


### PR DESCRIPTION
## Summary
- redirect desktop web auth prompts to the standalone `/auth` page while keeping the modal flow for mobile web/native
- polish the standalone web auth header: Janata logo at top-left, secondary `Browse as guest` action, no duplicate centered logo
- make invite auth links email-first with invite-specific copy before showing password fields
- update the auth checklist copy to mention messaging members in centers and events

## Validation
- `npm run build:frontend`
- Browser smoke tested `http://localhost:8092/auth`
- Browser smoke tested `http://localhost:8092/auth?mode=signup&inviteCode=TESTCODE&inviter=Kish`
- Browser smoke tested desktop gated `Log in` redirect from `/` to `/auth?returnTo=%2F`

## Notes
- PR #440 is already merged into `v2`; this PR is based directly on current `origin/v2` and contains only the auth polish delta.
- Existing profile/settings workspace edits were intentionally excluded.
