### PR TITLE
fix(profile): trim empty profile and settings menu noise

### DIFF
--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -1,13 +1,13 @@
 // Profile tab — native (iOS/Android). Direction B, stacked single column.
 // Mirrors the web Profile (app/(tabs)/profile.web.tsx): a display-only social
 // profile (identity + interests, then engagement: stats, upcoming events,
-// centers). Editing lives on /edit-profile; account management on /settings.
+// centers). Editing lives on /edit-profile.
 // The "You" header + settings gear are provided by the navigator (TabHeader).
 import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share } from 'react-native'
 import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  Pencil, Share2, ChevronRight, BadgeCheck, MapPin, UserPlus,
+  Pencil, Share2, ChevronRight, BadgeCheck, MapPin,
   Megaphone, CalendarDays, Building2,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
@@ -69,7 +69,9 @@ export default function Profile() {
       : vl >= 45 ? 'Verified member'
       : null
   const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
+  const showHomeCenterInProfile = !!homeCenter && groups.length === 0
   const interests = user?.interests || []
+  const showActivityStats = createdCount > 0 || events.length > 0
 
   const today = new Date().toISOString().split('T')[0]
   const upcoming = [...events]
@@ -84,7 +86,6 @@ export default function Profile() {
       track('profile_shared', { source: 'profile', username: user?.username })
     } catch { /* dismissed */ }
   }
-  const onInvite = () => { track('settings_invite_pressed', { source: 'profile' }); router.push('/settings/invite') }
   const onExplore = () => { track('profile_explore_cta', { source: 'profile' }); router.push('/explore') }
 
   const card = { backgroundColor: c.card, borderWidth: 1, borderColor: c.border, borderRadius: 20 } as const
@@ -146,7 +147,7 @@ export default function Profile() {
               <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
             </View>
           ) : null}
-          {homeCenter ? (
+          {showHomeCenterInProfile ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
               <MapPin size={13} color={c.textFaint} />
               <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
@@ -156,11 +157,7 @@ export default function Profile() {
 
         {user?.bio ? (
           <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
-        ) : (
-          <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
-            No bio yet — tap Edit to introduce yourself.
-          </Text>
-        )}
+        ) : null}
 
         <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
           <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 11, borderRadius: 12, backgroundColor: c.text }}>
@@ -183,24 +180,15 @@ export default function Profile() {
           </View>
         ) : null}
 
-        <Pressable
-          onPress={onInvite}
-          style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 18, paddingTop: 16, borderTopWidth: 1, borderTopColor: c.border }}
-        >
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            <UserPlus size={16} color={c.textSecondary} />
-            <Text style={{ fontSize: 14, color: c.textSecondary }}>Invite Friends</Text>
-          </View>
-          <ChevronRight size={18} color={c.iconMuted} />
-        </Pressable>
       </View>
 
       {/* Stats */}
-      <View style={{ flexDirection: 'row', gap: 12, marginTop: 18 }}>
-        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
-        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
-        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
-      </View>
+      {showActivityStats ? (
+        <View style={{ flexDirection: 'row', gap: 12, marginTop: 18 }}>
+          <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+          <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        </View>
+      ) : null}
 
       {/* Upcoming events */}
       <SectionLabel>Upcoming events</SectionLabel>

--- a/packages/frontend/app/(tabs)/profile.web.tsx
+++ b/packages/frontend/app/(tabs)/profile.web.tsx
@@ -1,7 +1,6 @@
 // Profile tab — web (desktop two-column / mobile stacked). Direction B.
 // Display-only social profile: identity + interests on the left, engagement
-// (stats, upcoming events, centers) on the right. Editing lives on /edit-profile;
-// account management lives on /settings (reached via "Account & Settings").
+// (stats, upcoming events, centers) on the right. Editing lives on /edit-profile.
 import React, { useState, useCallback } from 'react'
 import { ScrollView, View, Pressable, Image, Share, Platform, useWindowDimensions } from 'react-native'
 import { useRouter, useFocusEffect } from 'expo-router'
@@ -69,7 +68,9 @@ export default function Profile() {
       : vl >= 45 ? 'Verified member'
       : null
   const homeCenter = allCenters.find((cc) => cc.centerID === user?.centerID)
+  const showHomeCenterInProfile = !!homeCenter && groups.length === 0
   const interests = user?.interests || []
+  const showActivityStats = createdCount > 0 || events.length > 0
 
   const today = new Date().toISOString().split('T')[0]
   const upcoming = [...events]
@@ -108,7 +109,7 @@ export default function Profile() {
             <Text style={{ fontSize: 12.5, fontWeight: '600', color: '#C2410C' }}>{roleLabel}</Text>
           </View>
         ) : null}
-        {homeCenter ? (
+        {showHomeCenterInProfile ? (
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
             <MapPin size={13} color={c.textFaint} />
             <Text style={{ fontSize: 12.5, color: c.textMuted, textAlign: 'center' }}>{homeCenter.name}</Text>
@@ -118,11 +119,7 @@ export default function Profile() {
 
       {user?.bio ? (
         <Text style={{ fontSize: 14, lineHeight: 21, color: c.textSecondary, marginTop: 16 }}>{user.bio}</Text>
-      ) : (
-        <Text style={{ fontSize: 14, lineHeight: 21, color: c.textFaint, marginTop: 16 }}>
-          No bio yet — tap Edit to introduce yourself.
-        </Text>
-      )}
+      ) : null}
 
       <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
         <Pressable onPress={onEdit} style={{ flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 7, paddingVertical: 10, borderRadius: 12, backgroundColor: c.text }}>
@@ -169,11 +166,12 @@ export default function Profile() {
 
   const RightColumn = (
     <View>
-      <View style={{ flexDirection: 'row', gap: 14 }}>
-        <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
-        <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
-        <StatCard icon={<Building2 size={16} color="#C2410C" />} value={groups.length} label="Centers" />
-      </View>
+      {showActivityStats ? (
+        <View style={{ flexDirection: 'row', gap: 14 }}>
+          <StatCard icon={<Megaphone size={16} color="#C2410C" />} value={createdCount} label="Posts" />
+          <StatCard icon={<CalendarDays size={16} color="#C2410C" />} value={events.length} label="Events" />
+        </View>
+      ) : null}
 
       <SectionLabel>Upcoming events</SectionLabel>
       {upcoming.length > 0 ? (

--- a/packages/frontend/components/settings/SettingsPanel.tsx
+++ b/packages/frontend/components/settings/SettingsPanel.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { Animated, Text, Pressable, View, Image, Easing } from 'react-native'
+import React, { useEffect, useRef } from 'react'
+import { Animated, Text, Pressable, View } from 'react-native'
 import { useUser, useTheme } from '../contexts'
-import { Settings, LogOut, Sun, Moon, User, Monitor, Shield } from 'lucide-react-native'
+import { Settings, LogOut, User, Shield } from 'lucide-react-native'
 import { router, usePathname } from 'expo-router'
-import ThemeSelector from './ThemeSelector'
 import { Avatar } from '../ui'
 import { isSuperAdmin } from '../../utils/admin'
 import { useAnalytics } from '../../utils/analytics'
@@ -13,14 +12,9 @@ function SettingsPanel({ visible, onClose, onLogout }) {
   const opacityAnim = useRef(new Animated.Value(0)).current
   const translateYAnim = useRef(new Animated.Value(-20)).current
   const { user } = useUser()
-  const { preference: themePreference, setPreference: setThemePreference, isDark } = useTheme()
+  const { isDark } = useTheme()
   const { track } = useAnalytics()
   const pathname = usePathname()
-  const themeOptions = ['light', 'dark', 'system']
-  const optionWidth = 70
-  const indicatorPadding = 8
-  const [selectedIndex, setSelectedIndex] = useState(themeOptions.indexOf(themePreference))
-  const slideAnim = useRef(new Animated.Value(selectedIndex * optionWidth)).current
   const previousTheme = useRef(isDark)
   const isMountedRef = useRef(true)
 
@@ -32,9 +26,8 @@ function SettingsPanel({ visible, onClose, onLogout }) {
       // Stop all animations immediately on unmount
       opacityAnim.stopAnimation()
       translateYAnim.stopAnimation()
-      slideAnim.stopAnimation()
     }
-  }, [opacityAnim, translateYAnim, slideAnim])
+  }, [opacityAnim, translateYAnim])
 
   useEffect(() => {
     if (visible) {
@@ -67,17 +60,6 @@ function SettingsPanel({ visible, onClose, onLogout }) {
     }
   }, [visible])
 
-  useEffect(() => {
-    const idx = themeOptions.indexOf(themePreference)
-    setSelectedIndex(idx)
-    Animated.timing(slideAnim, {
-      toValue: idx * optionWidth,
-      duration: 100,
-      useNativeDriver: supportsNativeDriver,
-      easing: Easing.inOut(Easing.ease),
-    }).start()
-  }, [themePreference])
-
   // Stop animations when theme changes
   useEffect(() => {
     if (previousTheme.current !== isDark) {
@@ -98,15 +80,12 @@ function SettingsPanel({ visible, onClose, onLogout }) {
     user?.firstName && user?.lastName
       ? `${user.firstName} ${user.lastName}`
       : user?.username || 'User'
+  const accountIdentifier = user?.email || user?.username || null
+  const accountLabel = accountIdentifier
+    ? accountIdentifier.includes('@') ? accountIdentifier : `@${accountIdentifier}`
+    : null
 
   const profileImage = user?.profileImage
-  const getInitials = () => {
-    if (user?.firstName && user?.lastName)
-      return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
-    if (user?.firstName) return user.firstName[0].toUpperCase()
-    if (user?.username) return user.username[0].toUpperCase()
-    return '?'
-  }
 
   return (
     <>
@@ -182,7 +161,7 @@ function SettingsPanel({ visible, onClose, onLogout }) {
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              {user?.username}
+              {accountLabel}
             </Text>
           </View>
         </View>
@@ -190,10 +169,33 @@ function SettingsPanel({ visible, onClose, onLogout }) {
         {/* Separator Line */}
         <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-3" />
 
-        {/* Profile Button */}
+        {/* Account navigation */}
         <Pressable
           className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings/profile'
+            pathname === '/settings'
+              ? 'bg-primary'
+              : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
+          }`}
+          onPress={() => {
+            track('nav_settings_opened', { source: 'settings_panel', destination: 'account_settings' })
+            onClose()
+            router.push('/settings')
+          }}
+        >
+          <Settings size={16} color={pathname === '/settings' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
+          <Text
+            className={`font-sans ${
+              pathname === '/settings'
+                ? 'text-white font-sans'
+                : 'text-content dark:text-content-dark'
+            }`}
+          >
+            Settings
+          </Text>
+        </Pressable>
+        <Pressable
+          className={`flex-row items-center mb-2 p-2 rounded-lg ${
+            pathname === '/profile'
               ? 'bg-primary'
               : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
           }`}
@@ -203,46 +205,15 @@ function SettingsPanel({ visible, onClose, onLogout }) {
             router.push('/profile')
           }}
         >
-          <User
-            size={16}
-            color={pathname === '/settings/profile' ? '#fff' : isDark ? '#fff' : '#374151'}
-            className="mr-3"
-          />
+          <User size={16} color={pathname === '/profile' ? '#fff' : isDark ? '#fff' : '#374151'} className="mr-3" />
           <Text
             className={`font-sans ${
-              pathname === '/settings/profile'
+              pathname === '/profile'
                 ? 'text-white font-sans'
                 : 'text-content dark:text-content-dark'
             }`}
           >
             Profile
-          </Text>
-        </Pressable>
-        <Pressable
-          className={`flex-row items-center mb-2 p-2 rounded-lg ${
-            pathname === '/settings'
-              ? 'bg-primary'
-              : 'hover:bg-gray-100 dark:hover:bg-neutral-800'
-          }`}
-          onPress={() => {
-            track('nav_settings_opened', { source: 'settings_panel', destination: 'preferences' })
-            onClose()
-            router.push('/settings')
-          }}
-        >
-          <Settings
-            size={16}
-            color={pathname === '/settings' ? '#fff' : isDark ? '#fff' : '#374151'}
-            className="mr-3"
-          />
-          <Text
-            className={`font-sans ${
-              pathname === '/settings'
-                ? 'text-white font-sans'
-                : 'text-content dark:text-content-dark'
-            }`}
-          >
-            Preferences
           </Text>
         </Pressable>
         {isSuperAdmin(user) && (
@@ -263,17 +234,6 @@ function SettingsPanel({ visible, onClose, onLogout }) {
         <View className="h-[1px] bg-gray-200 dark:bg-neutral-800 mb-2" />
           </>
         )}
-
-        {/* Appearance Slider */}
-        <View className="mb-3">
-          <Text className="text-sm font-sans text-content dark:text-content-dark mb-2">
-            Appearance
-          </Text>
-          <ThemeSelector
-            className="relative flex-row bg-gray-100 dark:bg-neutral-800 rounded-lg p-1"
-            style={{ width: 218 }}
-          />
-        </View>
 
         {user && (
           <>


### PR DESCRIPTION
## Summary
- hide empty profile filler copy and zero-count stats on profile screens
- avoid showing the home center twice when the user's center list already renders it
- simplify the web account dropdown to Settings/Profile/Admin/Logout and keep appearance controls on the settings page

## What this intentionally does not include
- no inline invite-link generation in Settings
- no changes to the role-aware Invite Friends screen
- no native share changes, so the iOS duplicate-link fix stays intact

## Validation
- git diff --check
- npm run test --workspace=@janata/frontend
- npm run typecheck
- npm run build --workspace=@janata/frontend
- authenticated Chrome smoke for /profile and /settings on localhost