### PR TITLE
[codex] Add safe public member profiles

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -10,6 +10,7 @@ import { SignJWT } from 'jose'
 import { applyMigration, dropAllTables, TEST_INVITE_CODE } from './setup'
 import { app } from '../app'
 import { hashPassword } from '../auth'
+import * as db from '../db'
 import { clearRateLimits } from '../middleware'
 import { ADMIN_EMAIL, NORMAL_USER } from '../constants'
 
@@ -2343,6 +2344,100 @@ describe('event routes', () => {
       expect(body.events).toHaveLength(1)
       expect(body.events[0].title).toBe('User Event')
     })
+  })
+})
+
+describe('GET /api/public-profiles/:userId', () => {
+  it('requires authentication', async () => {
+    const { res } = await fetchJSON('/api/public-profiles/user-123')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns a safe public profile by user id without email-backed usernames', async () => {
+    const target = await registerAndLogin('profile-target@example.com', 'password123')
+    const viewer = await registerAndLogin('profile-viewer@example.com', 'password123')
+
+    await env.DB.prepare(
+      `UPDATE users
+       SET first_name = ?1,
+           last_name = ?2,
+           phone_number = ?3,
+           date_of_birth = ?4,
+           points = ?5,
+           interests = ?6,
+           school = ?7,
+           work = ?8,
+           region = ?9,
+           looking_for = ?10,
+           suspended_at = ?11,
+           suspended_reason = ?12
+       WHERE id = ?13`,
+    )
+      .bind(
+        'Public',
+        'Member',
+        '555-111-2222',
+        '1999-01-02',
+        108,
+        JSON.stringify(['Gita', 'Seva']),
+        'State University',
+        'Community Organizer',
+        'Bay Area',
+        JSON.stringify(['mentor']),
+        '2026-01-01T00:00:00.000Z',
+        'private moderation note',
+        target.user.id,
+      )
+      .run()
+
+    const eventId = 'hosted-profile-event'
+    await db.createEvent(env.DB, {
+      id: eventId,
+      title: 'Hosted Satsang',
+      date: '2026-07-01T10:00:00Z',
+      latitude: 37.0,
+      longitude: -121.0,
+      created_by: target.user.id,
+    })
+
+    const { res, body } = await fetchJSON(
+      `/api/public-profiles/${encodeURIComponent(target.user.id)}`,
+      { headers: authHeader(viewer.token) },
+    )
+
+    expect(res.status).toBe(200)
+    expect(body.profile).toMatchObject({
+      id: target.user.id,
+      firstName: 'Public',
+      lastName: 'Member',
+      centerName: null,
+      interests: ['Gita', 'Seva'],
+      school: 'State University',
+      work: 'Community Organizer',
+      region: 'Bay Area',
+    })
+    expect(body.profile.hostedEvents).toHaveLength(1)
+    expect(body.profile.hostedEvents[0].eventID).toBe(eventId)
+    expect(body.profile.hostedEvents[0].title).toBe('Hosted Satsang')
+
+    expect(body.profile).not.toHaveProperty('username')
+    expect(body.profile).not.toHaveProperty('email')
+    expect(body.profile).not.toHaveProperty('phoneNumber')
+    expect(body.profile).not.toHaveProperty('dateOfBirth')
+    expect(body.profile).not.toHaveProperty('points')
+    expect(body.profile).not.toHaveProperty('lookingFor')
+    expect(body.profile).not.toHaveProperty('suspendedAt')
+    expect(body.profile).not.toHaveProperty('suspendedUntil')
+    expect(body.profile).not.toHaveProperty('suspendedReason')
+  })
+
+  it('returns 404 for an unknown member id', async () => {
+    const { token } = await registerAndLogin('profile-viewer@example.com', 'password123')
+    const { res, body } = await fetchJSON('/api/public-profiles/missing-user', {
+      headers: authHeader(token),
+    })
+    expect(res.status).toBe(404)
+    expect(body.message).toBe('User not found')
   })
 })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -13,6 +13,7 @@ import { cors } from 'hono/cors'
 import type { Env, UserRow, EventRow, CenterRow, BoardPostApiResponse, BoardType } from './types'
 import {
   userRowToApi,
+  userRowToPublicProfile,
   centerRowToApi,
   eventRowToApi,
   boardRowToApi,
@@ -1272,6 +1273,25 @@ app.post('/getUserEvents', authMiddleware, async (c) => {
 // ═══════════════════════════════════════════════════════════════════════
 // PROFILE ROUTES
 // ═══════════════════════════════════════════════════════════════════════
+
+app.get('/public-profiles/:userId', authMiddleware, async (c) => {
+  const userId = c.req.param('userId')
+  const targetUser = await db.getUserById(c.env.DB, userId)
+  if (!targetUser) return c.json({ message: 'User not found' }, 404)
+
+  const center = targetUser.center_id
+    ? await db.getCenterById(c.env.DB, targetUser.center_id)
+    : null
+  const hostedEvents = await db.getUserCreatedEvents(c.env.DB, targetUser.id)
+
+  return c.json({
+    profile: userRowToPublicProfile(
+      targetUser,
+      center?.name ?? null,
+      hostedEvents.map(eventRowToApi),
+    ),
+  })
+})
 
 app.get('/profile/:username/events', authMiddleware, async (c) => {
   const { username } = c.req.param()

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -225,6 +225,24 @@ export interface UserApiResponse {
   updatedAt: string
 }
 
+export interface PublicProfileApiResponse {
+  id: string
+  firstName: string
+  lastName: string
+  profileImage: string | null
+  bio: string | null
+  centerID: string | null
+  centerName: string | null
+  verificationLevel: number
+  isVerified: boolean
+  interests: string[] | null
+  school: string | null
+  work: string | null
+  region: string | null
+  hostedEvents: EventApiResponse[]
+  createdAt: string
+}
+
 export interface CenterApiResponse {
   centerID: string
   name: string
@@ -351,6 +369,35 @@ export function userRowToApi(row: UserRow): UserApiResponse {
     suspendedReason: row.suspended_reason,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  }
+}
+
+/**
+ * Safe public member profile. Deliberately omits username/email because this
+ * app's usernames are email addresses, plus phone, DOB, points, lookingFor, and
+ * suspension internals.
+ */
+export function userRowToPublicProfile(
+  row: UserRow,
+  centerName: string | null,
+  hostedEvents: EventApiResponse[],
+): PublicProfileApiResponse {
+  return {
+    id: row.id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    profileImage: row.profile_image,
+    bio: row.bio,
+    centerID: row.center_id,
+    centerName,
+    verificationLevel: row.verification_level,
+    isVerified: row.verification_level >= NORMAL_USER,
+    interests: safeParseJsonArray(row.interests),
+    school: row.school,
+    work: row.work,
+    region: row.region,
+    hostedEvents,
+    createdAt: row.created_at,
   }
 }
 

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -470,6 +470,12 @@ export default function FeedScreen() {
     setSelectedPostId(id)
   }
 
+  const openAuthorProfile = (authorId: string) => {
+    if (!authorId || authorId === user?.id) return
+    track('feed_author_profile_pressed', { author_id: authorId, source: 'feed' })
+    router.push(`/members/${encodeURIComponent(authorId)}` as never)
+  }
+
   const openGroup = (group: GroupBoard) => {
     if (!group.routeHref) return
     track('connect_empty_board_opened', { groupId: group.id, kind: group.kind, source: 'feed' })
@@ -557,6 +563,7 @@ export default function FeedScreen() {
             mobilePostOpen={mobilePostOpen}
             onOpenGroup={openGroup}
             onSelectPost={openPost}
+            onAuthorPress={openAuthorProfile}
             onCompose={() => {
               track('feed_compose_pressed', { source: 'feed_empty_panel' })
               setCreatePostOpen(true)
@@ -616,6 +623,7 @@ export default function FeedScreen() {
                     colors={colors}
                     fullScreen
                     bottomInset={insets.bottom}
+                    onAuthorPress={openAuthorProfile}
                     onPostChanged={loadBoards}
                     onPostDeleted={() => {
                       closeDetail()

--- a/packages/frontend/app/members/[id].tsx
+++ b/packages/frontend/app/members/[id].tsx
@@ -1,0 +1,341 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ArrowLeft, CalendarDays, MapPin } from 'lucide-react-native'
+import { Avatar } from '../../components/ui'
+import { useColors } from '../../hooks/useColors'
+import { useAnalytics } from '../../utils/analytics'
+import { fetchPublicProfile, type EventData, type PublicProfileData } from '../../utils/api'
+
+function roleLabel(level: number): string | null {
+  if (level >= 1000008) return 'Global Head'
+  if (level >= 1008) return 'Swami'
+  if (level >= 107) return 'Brahmachari'
+  if (level >= 54) return 'Sevak'
+  if (level >= 45) return 'Verified member'
+  return null
+}
+
+function displayName(profile: PublicProfileData | null): string {
+  if (!profile) return 'Member'
+  return [profile.firstName, profile.lastName].filter(Boolean).join(' ').trim() || 'Member'
+}
+
+function formatEventDate(value?: string | null): string {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function PublicMemberProfileScreen() {
+  const colors = useColors()
+  const router = useRouter()
+  const { track } = useAnalytics()
+  const { id: rawId } = useLocalSearchParams<{ id: string }>()
+  const userId = typeof rawId === 'string' ? rawId : ''
+  const [profile, setProfile] = useState<PublicProfileData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!userId) {
+      setLoading(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setLoading(true)
+    fetchPublicProfile(userId)
+      .then((nextProfile) => {
+        if (cancelled) return
+        setProfile(nextProfile)
+        if (nextProfile) {
+          track('public_profile_viewed', {
+            user_id: nextProfile.id,
+            verification_level: nextProfile.verificationLevel,
+          })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [track, userId])
+
+  const name = useMemo(() => displayName(profile), [profile])
+  const role = profile ? roleLabel(profile.verificationLevel) : null
+  const hostedEvents = profile?.hostedEvents ?? []
+
+  const openEvent = useCallback(
+    (event: EventData) => {
+      track('event_list_item_pressed', {
+        eventId: event.eventID,
+        source: 'public_member_profile',
+      })
+      router.push(`/events/${event.eventID}` as never)
+    },
+    [router, track],
+  )
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: 16,
+          paddingTop: 14,
+          paddingBottom: 8,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={10}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ArrowLeft size={21} color={colors.accent} strokeWidth={2.3} />
+        </Pressable>
+        <Text
+          style={{
+            flex: 1,
+            textAlign: 'center',
+            fontFamily: 'Inclusive Sans',
+            fontSize: 16,
+            color: colors.text,
+          }}
+          numberOfLines={1}
+        >
+          Profile
+        </Text>
+        <View style={{ width: 36 }} />
+      </View>
+
+      {loading ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={colors.accent} />
+        </View>
+      ) : !profile ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8, padding: 24 }}>
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 20, color: colors.text }}>
+            Member not found
+          </Text>
+          <Text style={{ fontSize: 14, lineHeight: 20, color: colors.textMuted, textAlign: 'center' }}>
+            This profile is not available.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={{
+            width: '100%',
+            maxWidth: 720,
+            alignSelf: 'center',
+            paddingHorizontal: 20,
+            paddingTop: 24,
+            paddingBottom: 48,
+          }}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={{ alignItems: 'center' }}>
+            <Avatar image={profile.profileImage ?? undefined} name={name} size={92} />
+            <Text
+              style={{
+                marginTop: 14,
+                fontFamily: 'Inclusive Sans',
+                fontSize: 26,
+                color: colors.text,
+                textAlign: 'center',
+              }}
+            >
+              {name}
+            </Text>
+            {role ? (
+              <View
+                style={{
+                  marginTop: 9,
+                  borderRadius: 999,
+                  backgroundColor: colors.accentSoft,
+                  paddingHorizontal: 13,
+                  paddingVertical: 6,
+                }}
+              >
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12.5, color: colors.accent }}>
+                  {role}
+                </Text>
+              </View>
+            ) : null}
+            {profile.centerName ? (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: 10 }}>
+                <MapPin size={14} color={colors.textMuted} strokeWidth={2.2} />
+                <Text style={{ fontSize: 14, color: colors.textMuted }} numberOfLines={1}>
+                  {profile.centerName}
+                </Text>
+              </View>
+            ) : null}
+            {profile.bio ? (
+              <Text
+                style={{
+                  maxWidth: 540,
+                  marginTop: 16,
+                  fontSize: 15,
+                  lineHeight: 23,
+                  color: colors.text,
+                  textAlign: 'center',
+                }}
+              >
+                {profile.bio}
+              </Text>
+            ) : null}
+          </View>
+
+          {profile.interests?.length ? (
+            <Section title="Interests" colors={colors}>
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+                {profile.interests.map((interest) => (
+                  <View
+                    key={interest}
+                    style={{
+                      borderRadius: 999,
+                      backgroundColor: colors.panel,
+                      paddingHorizontal: 12,
+                      paddingVertical: 7,
+                    }}
+                  >
+                    <Text style={{ fontSize: 13, color: colors.text }}>{interest}</Text>
+                  </View>
+                ))}
+              </View>
+            </Section>
+          ) : null}
+
+          {profile.school || profile.work || profile.region ? (
+            <Section title="About" colors={colors}>
+              <View style={{ gap: 10 }}>
+                {profile.school ? <InfoRow label="School" value={profile.school} colors={colors} /> : null}
+                {profile.work ? <InfoRow label="Work" value={profile.work} colors={colors} /> : null}
+                {profile.region ? <InfoRow label="Region" value={profile.region} colors={colors} /> : null}
+              </View>
+            </Section>
+          ) : null}
+
+          {hostedEvents.length ? (
+            <Section title="Hosted Events" colors={colors}>
+              <View style={{ gap: 10 }}>
+                {hostedEvents.map((event) => (
+                  <Pressable
+                    key={event.eventID}
+                    onPress={() => openEvent(event)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open ${event.title}`}
+                    style={{
+                      borderWidth: 1,
+                      borderColor: colors.border,
+                      borderRadius: 12,
+                      backgroundColor: colors.card,
+                      padding: 14,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: 12,
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 10,
+                        backgroundColor: colors.accentSoft,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <CalendarDays size={17} color={colors.accent} strokeWidth={2.3} />
+                    </View>
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: colors.text }} numberOfLines={1}>
+                        {event.title}
+                      </Text>
+                      <Text style={{ marginTop: 2, fontSize: 13, color: colors.textMuted }} numberOfLines={1}>
+                        {[formatEventDate(event.date), event.address].filter(Boolean).join(' · ')}
+                      </Text>
+                    </View>
+                  </Pressable>
+                ))}
+              </View>
+            </Section>
+          ) : null}
+        </ScrollView>
+      )}
+    </View>
+  )
+}
+
+function Section({
+  title,
+  colors,
+  children,
+}: {
+  title: string
+  colors: ReturnType<typeof useColors>
+  children: React.ReactNode
+}) {
+  return (
+    <View style={{ marginTop: 28 }}>
+      <Text
+        style={{
+          marginBottom: 10,
+          fontSize: 11.5,
+          letterSpacing: 0.8,
+          textTransform: 'uppercase',
+          color: colors.textFaint,
+        }}
+      >
+        {title}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+function InfoRow({
+  label,
+  value,
+  colors,
+}: {
+  label: string
+  value: string
+  colors: ReturnType<typeof useColors>
+}) {
+  return (
+    <View
+      style={{
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 12,
+        backgroundColor: colors.card,
+        paddingHorizontal: 14,
+        paddingVertical: 12,
+      }}
+    >
+      <Text style={{ fontSize: 12, color: colors.textFaint }}>{label}</Text>
+      <Text style={{ marginTop: 3, fontSize: 15, color: colors.text }}>{value}</Text>
+    </View>
+  )
+}

--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -38,6 +38,7 @@ export function ThreadPanel({
   bottomInset = 0,
   visibleLabel,
   onMessagePress,
+  onAuthorPress,
   onSubmitPost,
   showComposer = true,
   showSource = false,
@@ -58,6 +59,7 @@ export function ThreadPanel({
   bottomInset?: number
   visibleLabel?: string
   onMessagePress?: (message: BoardMessage) => void
+  onAuthorPress?: (authorId: string) => void
   onSubmitPost?: (body: string) => Promise<void> | void
   showComposer?: boolean
   showSource?: boolean
@@ -100,6 +102,9 @@ export function ThreadPanel({
               colors={colors}
               showSource={showSource}
               onPress={onMessagePress ? () => onMessagePress(message) : undefined}
+              onAuthorPress={
+                onAuthorPress && message.author.id ? () => onAuthorPress(message.author.id) : undefined
+              }
             />
           ))}
         </View>
@@ -303,12 +308,14 @@ export function BoardPostCard({
   message,
   colors,
   onPress,
+  onAuthorPress,
   showSource = false,
   asCard = false,
 }: {
   message: BoardMessage
   colors: ThreadPanelColors
   onPress?: () => void
+  onAuthorPress?: () => void
   showSource?: boolean
   // Render the white rounded card chrome without forcing the source line.
   // (showSource still controls the board/event label; asCard just gives the
@@ -386,12 +393,23 @@ export function BoardPostCard({
       ) : null}
 
       <View style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12 }}>
-        <Avatar
-          name={message.author.name}
-          initials={message.author.initials}
-          size={42}
-          backgroundColor={message.author.accentColor}
-        />
+        <Pressable
+          disabled={!onAuthorPress}
+          onPress={(event) => {
+            event.stopPropagation()
+            onAuthorPress?.()
+          }}
+          accessibilityRole={onAuthorPress ? 'button' : undefined}
+          accessibilityLabel={onAuthorPress ? `Open ${message.author.name}'s profile` : undefined}
+          hitSlop={6}
+        >
+          <Avatar
+            name={message.author.name}
+            initials={message.author.initials}
+            size={42}
+            backgroundColor={message.author.accentColor}
+          />
+        </Pressable>
 
         <View style={{ flex: 1, gap: 8 }}>
           <View
@@ -403,8 +421,15 @@ export function BoardPostCard({
             }}
           >
             <View style={{ flex: 1 }}>
-              <View
-                style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}
+              <Pressable
+                disabled={!onAuthorPress}
+                onPress={(event) => {
+                  event.stopPropagation()
+                  onAuthorPress?.()
+                }}
+                accessibilityRole={onAuthorPress ? 'button' : undefined}
+                accessibilityLabel={onAuthorPress ? `Open ${message.author.name}'s profile` : undefined}
+                style={{ alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}
               >
                 <Text
                   style={{
@@ -432,7 +457,7 @@ export function BoardPostCard({
                   </Text>
                 ) : null}
                 {!isFeedCard && message.pinned ? <Pill label="Pinned" colors={colors} /> : null}
-              </View>
+              </Pressable>
               <Text
                 style={{
                   fontSize: 13,

--- a/packages/frontend/components/boards/liveBoard.ts
+++ b/packages/frontend/components/boards/liveBoard.ts
@@ -5,14 +5,14 @@ const AVATAR_COLORS = ['#0F766E', '#1D4ED8', '#7C3AED', '#C2410C', '#0369A1', '#
 
 function displayName(user: UserData) {
   const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ').trim()
-  return fullName || user.username
+  return fullName || 'Member'
 }
 
 function initialsFor(user: UserData) {
   if (user.firstName) {
     return `${user.firstName[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase()
   }
-  return user.username.slice(0, 2).toUpperCase()
+  return 'M'
 }
 
 function verificationFor(user: UserData): VerificationKind | undefined {
@@ -43,7 +43,7 @@ export function boardPostToMessage(post: BoardPostData): BoardMessage {
       initials: initialsFor(post.author),
       subtitle: post.author.centerID ? 'Verified member' : undefined,
       verification: verificationFor(post.author),
-      accentColor: colorFor(post.author.id || post.author.username),
+      accentColor: colorFor(post.author.id || 'member'),
     },
     timestamp: formatTimestamp(post.createdAt),
     body: post.body,

--- a/packages/frontend/components/feed/FeedList.tsx
+++ b/packages/frontend/components/feed/FeedList.tsx
@@ -12,16 +12,20 @@ export function FeedList({
   colors,
   feedColors,
   hasQuery = false,
+  currentUserId,
   onOpenGroup,
   onSelectPost,
+  onAuthorPress,
 }: {
   posts: FeedPost[]
   groups: GroupBoard[]
   colors: ThreadPanelColors
   feedColors: AppColors
   hasQuery?: boolean
+  currentUserId?: string
   onOpenGroup: (group: GroupBoard) => void
   onSelectPost: (id: string) => void
+  onAuthorPress?: (authorId: string) => void
 }) {
   const [visibleCount, setVisibleCount] = useState(25)
   const visiblePosts = posts.slice(0, visibleCount)
@@ -84,6 +88,9 @@ export function FeedList({
           post={post}
           colors={feedColors}
           onPress={() => onSelectPost(post.id)}
+          onAuthorPress={
+            onAuthorPress && post.author.id !== currentUserId ? onAuthorPress : undefined
+          }
         />
       ))}
       {hasMore ? (

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -9,10 +9,12 @@ export function FeedPostCard({
   post,
   colors,
   onPress,
+  onAuthorPress,
 }: {
   post: FeedPost
   colors: AppColors
   onPress?: () => void
+  onAuthorPress?: (authorId: string) => void
 }) {
   const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
   const replies = post.replyCount ?? 2
@@ -55,14 +57,34 @@ export function FeedPostCard({
       </View>
 
       <View style={{ flexDirection: 'row', gap: 12 }}>
-        <Avatar
-          name={post.author.name}
-          initials={post.author.initials}
-          size={38}
-          backgroundColor={post.author.accentColor}
-        />
+        <Pressable
+          disabled={!onAuthorPress}
+          onPress={(event) => {
+            event.stopPropagation()
+            if (post.author.id) onAuthorPress?.(post.author.id)
+          }}
+          accessibilityRole={onAuthorPress ? 'button' : undefined}
+          accessibilityLabel={onAuthorPress ? `Open ${post.author.name}'s profile` : undefined}
+          hitSlop={6}
+        >
+          <Avatar
+            name={post.author.name}
+            initials={post.author.initials}
+            size={38}
+            backgroundColor={post.author.accentColor}
+          />
+        </Pressable>
         <View style={{ flex: 1, gap: 6 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <Pressable
+            disabled={!onAuthorPress}
+            onPress={(event) => {
+              event.stopPropagation()
+              if (post.author.id) onAuthorPress?.(post.author.id)
+            }}
+            accessibilityRole={onAuthorPress ? 'button' : undefined}
+            accessibilityLabel={onAuthorPress ? `Open ${post.author.name}'s profile` : undefined}
+            style={{ alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}
+          >
             <Text style={{ fontSize: 14, color: colors.text }}>{post.author.name}</Text>
             {post.author.verification === 'sevak' ? (
               <View
@@ -76,7 +98,7 @@ export function FeedPostCard({
                 <Text style={{ fontSize: 10, color: colors.accent }}>SEVAK</Text>
               </View>
             ) : null}
-          </View>
+          </Pressable>
 
           <Text style={{ fontSize: 14, lineHeight: 20, color: colors.text }}>{post.body}</Text>
 

--- a/packages/frontend/components/feed/FeedWorkspace.tsx
+++ b/packages/frontend/components/feed/FeedWorkspace.tsx
@@ -25,6 +25,7 @@ export function FeedWorkspace({
   mobilePostOpen,
   onOpenGroup,
   onSelectPost,
+  onAuthorPress,
   onChangeQuery,
   onBack,
   onPostChanged,
@@ -43,12 +44,15 @@ export function FeedWorkspace({
   mobilePostOpen: boolean
   onOpenGroup: (group: GroupBoard) => void
   onSelectPost: (id: string) => void
+  onAuthorPress?: (authorId: string) => void
   onChangeQuery?: (value: string) => void
   onBack?: () => void
   onPostChanged?: () => void
   onPostDeleted?: () => void
   onCompose?: () => void
 }) {
+  const { user } = useUser()
+
   // Guests and empty no-query states are handled upstream by FeedEmptyState, so
   // FeedWorkspace only renders for signed-in members with posts or a search.
   if (isDesktop) {
@@ -80,6 +84,7 @@ export function FeedWorkspace({
                 onCollapse={onBack}
                 onPostChanged={onPostChanged}
                 onPostDeleted={onPostDeleted}
+                onAuthorPress={onAuthorPress}
               />
             ) : (
               <BoardPostCard
@@ -89,6 +94,11 @@ export function FeedWorkspace({
                 asCard
                 showSource={multiSource}
                 onPress={() => onSelectPost(post.id)}
+                onAuthorPress={
+                  onAuthorPress && post.author.id !== user?.id
+                    ? () => onAuthorPress(post.author.id)
+                    : undefined
+                }
               />
             )
           )}
@@ -117,6 +127,7 @@ export function FeedWorkspace({
       <PostThread
         post={selectedPost}
         colors={colors}
+        onAuthorPress={onAuthorPress}
         onPostChanged={onPostChanged}
         onPostDeleted={onPostDeleted}
       />
@@ -130,8 +141,10 @@ export function FeedWorkspace({
       colors={threadColors}
       feedColors={colors}
       hasQuery={hasQuery}
+      currentUserId={user?.id}
       onOpenGroup={onOpenGroup}
       onSelectPost={onSelectPost}
+      onAuthorPress={onAuthorPress}
     />
   )
 }

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -44,6 +44,7 @@ export function PostThread({
   bottomInset = 0,
   hideSourceChip = false,
   onCollapse,
+  onAuthorPress,
   onPostChanged,
   onPostDeleted,
 }: {
@@ -57,6 +58,7 @@ export function PostThread({
   // When set, the thread is an inline-expanded feed card: render a "Hide"
   // control so the user can collapse it back to a normal post card.
   onCollapse?: () => void
+  onAuthorPress?: (authorId: string) => void
   // Refresh the feed list after a pin/edit/reaction so it reflects the change.
   onPostChanged?: () => void
   // Close the detail surface after the post is deleted.
@@ -88,6 +90,10 @@ export function PostThread({
   const canPin = post.groupKind !== 'public' && canPinPosts(user)
   const isAuthor = canModifyPost(user, post.author.id)
   const hasMenu = canPin || isAuthor
+  const authorProfilePress =
+    onAuthorPress && post.author.id !== user?.id
+      ? () => onAuthorPress(post.author.id)
+      : undefined
 
   const handleTogglePin = async () => {
     if (actionBusy) return
@@ -261,6 +267,7 @@ export function PostThread({
           reactions={reactions}
           colors={colors}
           hasMenu={hasMenu}
+          onAuthorPress={authorProfilePress}
           onOpenMenu={() => { setMenuOpen(true); track('feed_post_menu_opened', { post_id: post.postId, source: 'post_thread' }) }}
           onReact={handleReact}
         />
@@ -322,7 +329,16 @@ export function PostThread({
       ) : (
         <View style={{ gap: 16 }}>
           {replies.map((reply) => (
-            <PostMessageBlock key={reply.id} message={reply} colors={colors} />
+            <PostMessageBlock
+              key={reply.id}
+              message={reply}
+              colors={colors}
+              onAuthorPress={
+                onAuthorPress && reply.author.id !== user?.id
+                  ? () => onAuthorPress(reply.author.id)
+                  : undefined
+              }
+            />
           ))}
         </View>
       )}
@@ -470,23 +486,39 @@ function PostMessageBlock({
   message,
   colors,
   original = false,
+  onAuthorPress,
 }: {
   message: BoardMessage
   colors: AppColors
   original?: boolean
+  onAuthorPress?: () => void
 }) {
   const reactions = message.reactions ?? []
 
   return (
     <View style={{ flexDirection: 'row', gap: original ? 12 : 10 }}>
-      <Avatar
-        name={message.author.name}
-        initials={message.author.initials}
-        size={original ? 42 : 34}
-        backgroundColor={message.author.accentColor}
-      />
+      <Pressable
+        disabled={!onAuthorPress}
+        onPress={onAuthorPress}
+        accessibilityRole={onAuthorPress ? 'button' : undefined}
+        accessibilityLabel={onAuthorPress ? `Open ${message.author.name}'s profile` : undefined}
+        hitSlop={6}
+      >
+        <Avatar
+          name={message.author.name}
+          initials={message.author.initials}
+          size={original ? 42 : 34}
+          backgroundColor={message.author.accentColor}
+        />
+      </Pressable>
       <View style={{ flex: 1, minWidth: 0 }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+        <Pressable
+          disabled={!onAuthorPress}
+          onPress={onAuthorPress}
+          accessibilityRole={onAuthorPress ? 'button' : undefined}
+          accessibilityLabel={onAuthorPress ? `Open ${message.author.name}'s profile` : undefined}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}
+        >
           <Text
             style={{
               fontFamily: 'Inclusive Sans',
@@ -514,7 +546,7 @@ function PostMessageBlock({
           <Text style={{ marginLeft: 'auto', fontSize: 12, color: colors.textFaint }}>
             {message.timestamp}
           </Text>
-        </View>
+        </Pressable>
 
         <Text
           style={{
@@ -597,6 +629,7 @@ function OriginalPost({
   reactions,
   colors,
   hasMenu,
+  onAuthorPress,
   onOpenMenu,
   onReact,
 }: {
@@ -606,6 +639,7 @@ function OriginalPost({
   reactions: Array<{ emoji: string; count: number }>
   colors: AppColors
   hasMenu: boolean
+  onAuthorPress?: () => void
   onOpenMenu: () => void
   onReact: (emoji: string) => void
 }) {
@@ -614,32 +648,48 @@ function OriginalPost({
   const [lightboxOpen, setLightboxOpen] = useState(false)
   return (
     <View style={{ flexDirection: 'row', gap: 12 }}>
-      <Avatar
-        name={post.author.name}
-        initials={post.author.initials}
-        size={42}
-        backgroundColor={post.author.accentColor}
-      />
+      <Pressable
+        disabled={!onAuthorPress}
+        onPress={onAuthorPress}
+        accessibilityRole={onAuthorPress ? 'button' : undefined}
+        accessibilityLabel={onAuthorPress ? `Open ${post.author.name}'s profile` : undefined}
+        hitSlop={6}
+      >
+        <Avatar
+          name={post.author.name}
+          initials={post.author.initials}
+          size={42}
+          backgroundColor={post.author.accentColor}
+        />
+      </Pressable>
       <View style={{ flex: 1, minWidth: 0 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
-          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: colors.text }}>
-            {post.author.name}
-          </Text>
-          {post.author.verification === 'sevak' ? (
-            <Text style={{ fontSize: 12, color: '#C2410C' }}>SEVAK</Text>
-          ) : null}
-          {pinned ? (
-            <View
-              style={{
-                borderRadius: 999,
-                backgroundColor: colors.panel,
-                paddingHorizontal: 8,
-                paddingVertical: 3,
-              }}
-            >
-              <Text style={{ fontSize: 11, color: colors.textMuted }}>Pinned</Text>
-            </View>
-          ) : null}
+          <Pressable
+            disabled={!onAuthorPress}
+            onPress={onAuthorPress}
+            accessibilityRole={onAuthorPress ? 'button' : undefined}
+            accessibilityLabel={onAuthorPress ? `Open ${post.author.name}'s profile` : undefined}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}
+          >
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: colors.text }}>
+              {post.author.name}
+            </Text>
+            {post.author.verification === 'sevak' ? (
+              <Text style={{ fontSize: 12, color: '#C2410C' }}>SEVAK</Text>
+            ) : null}
+            {pinned ? (
+              <View
+                style={{
+                  borderRadius: 999,
+                  backgroundColor: colors.panel,
+                  paddingHorizontal: 8,
+                  paddingVertical: 3,
+                }}
+              >
+                <Text style={{ fontSize: 11, color: colors.textMuted }}>Pinned</Text>
+              </View>
+            ) : null}
+          </Pressable>
           <Text style={{ marginLeft: 'auto', fontSize: 12, color: colors.textFaint }}>
             {post.timestamp}
           </Text>

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -26,16 +26,16 @@ export function authorFromUser(user: User | null): PersonSummary {
   if (!user) {
     return { id: 'me', name: 'You', initials: 'You' }
   }
-  const name = [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || user.username
+  const name = [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || 'You'
   const initials = user.firstName
     ? `${user.firstName[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase()
-    : user.username.slice(0, 2).toUpperCase()
+    : 'You'
   return {
     id: user.id || 'me',
     name,
     initials,
     verification: verificationFor(user),
-    accentColor: colorFor(user.id || user.username),
+    accentColor: colorFor(user.id || 'me'),
   }
 }
 

--- a/packages/frontend/src/__tests__/feedData.test.ts
+++ b/packages/frontend/src/__tests__/feedData.test.ts
@@ -103,10 +103,10 @@ describe('authorFromUser', () => {
     expect(author.initials).toBe('RK')
   })
 
-  it('falls back to username when no name is set', () => {
+  it('does not fall back to username when no name is set', () => {
     const author = authorFromUser({ username: 'rkrishna' } as any)
-    expect(author.name).toBe('rkrishna')
-    expect(author.initials).toBe('RK')
+    expect(author.name).toBe('You')
+    expect(author.initials).toBe('You')
   })
 
   it('maps verification level to a badge tier', () => {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -74,6 +74,24 @@ export interface UserData {
   updatedAt?: string
 }
 
+export interface PublicProfileData {
+  id: string
+  firstName: string
+  lastName: string
+  profileImage: string | null
+  bio: string | null
+  centerID: string | null
+  centerName: string | null
+  verificationLevel: number
+  isVerified: boolean
+  interests: string[] | null
+  school: string | null
+  work: string | null
+  region: string | null
+  hostedEvents: EventData[]
+  createdAt: string
+}
+
 export interface MapPoint {
   id: string
   type: 'center' | 'event'
@@ -744,6 +762,18 @@ export async function fetchUserPosts(username: string): Promise<EventData[]> {
   } catch (err: any) {
     if (__DEV__) console.warn('[fetchUserPosts]', err?.message || err)
     return []
+  }
+}
+
+export async function fetchPublicProfile(userId: string): Promise<PublicProfileData | null> {
+  try {
+    const response = await authFetch(`/public-profiles/${encodeURIComponent(userId)}`)
+    if (!response.ok) return null
+    const data = await response.json()
+    return data.profile || null
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchPublicProfile]', err?.message || err)
+    return null
   }
 }
 


### PR DESCRIPTION
Closes #441

## Summary
- Rebuilds the useful part of #464 on current v2 without the stacked invite changes.
- Adds an authenticated `GET /api/public-profiles/:userId` endpoint keyed by user id, not username/email.
- Adds `/members/[id]` for public member profiles and wires feed author taps to it.
- Keeps public profile payloads from exposing username, email, phone, DOB, points, lookingFor, or suspension fields.
- Changes feed author fallbacks from username to `Member`/`You` so email-backed usernames do not leak when names are missing.

## Validation
- `git diff --check`
- `npm run typecheck`
- `npm run test:backend`
- `npm run test --workspace=@janata/frontend`
- `npm run build --workspace=@janata/frontend`

## Supersedes
- Supersedes #464, which used `/profile/[username]` and username-based backend lookup. In this app usernames are emails, so the rebuild uses member IDs instead.
