### PR TITLE
Pass Expo token to EAS build

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -88,6 +88,7 @@ jobs:
         working-directory: packages/frontend
         env:
           EXPO_NO_TELEMETRY: '1'
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           echo "::notice::Building platform=${{ steps.resolve.outputs.platform }} profile=${{ steps.resolve.outputs.profile }}"
           eas build \


### PR DESCRIPTION
## Summary
- Passes `EXPO_TOKEN` into the EAS build command step.
- The previous iOS tag build failed before starting EAS because the CLI was unauthenticated.

## Validation
- `git diff --check`

After this lands, I will push a new `ios-v*` tag on v2 to start the TestFlight-ready production iOS build.