### PR TITLE
Bump iOS build number to 29

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -157,7 +157,7 @@
     "ios": {
       "icon": "./assets/images/logo.png",
       "supportsTablet": true,
-      "buildNumber": "27",
+      "buildNumber": "29",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",


### PR DESCRIPTION
## Summary
- Syncs `ios.buildNumber` to 29 after the successful EAS iOS production build.

## Context
- Build URL: https://expo.dev/accounts/chinmaya-janata/projects/chinmaya-janata/builds/c7617e15-d027-425d-a1ad-b9472c83c4c2
- Version/build: `0.3.0 (29)`

## Validation
- Metadata-only change. The EAS production build completed successfully.