### PR TITLE
fix(ios): real Apple Team ID in AASA so invite links open the app

### DIFF
--- a/packages/frontend/public/.well-known/apple-app-site-association
+++ b/packages/frontend/public/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "TEAMID.org.chinmayamission.janata",
+        "appID": "GN3TH9WD6W.org.chinmayamission.janata",
         "paths": [
           "/center/*",
           "/events/*",


### PR DESCRIPTION
## Why
iOS invite links (`/i/*`) don't open the app. The AASA file shipped with a `TEAMID` placeholder, so Apple never registers universal links for the app.

## What
- `apple-app-site-association`: `TEAMID.org.chinmayamission.janata` → `GN3TH9WD6W.org.chinmayamission.janata` (the real Apple Developer Team ID used by the production EAS build).

## Note / follow-up
This only takes effect after a **production web deploy** (manual `Deploy` workflow → environment=production). A fresh build also fixes a second issue found in prod: `/.well-known/apple-app-site-association` is currently served as the HTML SPA shell instead of JSON, because the live prod build predates the `.well-known` assets. The prod `_headers` already sets `Content-Type: application/json`, so a fresh deploy serves it correctly.

## Related
Part of the TestFlight posting/links fixes. (Separately, prod D1 was missing migrations 0019–0028 — `board_posts` etc. — now applied directly, fixing post creation.)