### PR TITLE
fix(deploy): correct prod Pages project name → chinmaya-janata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
         # chinmayajanata.org CNAMEs to project-janatha.pages.dev.
         # The old `chinmaya-janata` Pages project is frozen; deploys here
         # would silently no-op due to API token scoping. See #165.
-        run: npx wrangler pages deploy dist --project-name project-janatha --branch __release
+        run: npx wrangler pages deploy dist --project-name chinmaya-janata --branch __release
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 


### PR DESCRIPTION
Prod frontend deploy failed with `Project not found [8000007]` — `deploy.yml` hardcoded `--project-name project-janatha`, which doesn't exist in the deploy token's account. The real Pages project is **chinmaya-janata** (its `.pages.dev` domain is `project-janatha.pages.dev`), per `scripts/ci/deploy-v2preview.sh`. One-line fix to unblock the production deploy.