### PR TITLE
[codex] Fix iOS splash theme handoff

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -10,7 +10,7 @@
     "splash": {
       "image": "./assets/images/logo_with_text.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#FAFAF7"
     },
     "android": {
       "adaptiveIcon": {
@@ -184,10 +184,11 @@
         {
           "image": "./assets/images/logo_with_text.png",
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#FAFAF7",
+          "imageWidth": 280,
           "dark": {
             "image": "./assets/images/logo_with_text.png",
-            "backgroundColor": "#121212"
+            "backgroundColor": "#0F0F0F"
           }
         }
       ],

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -21,7 +21,8 @@ import {
   ThemeProvider as NavigationThemeProvider,
 } from '@react-navigation/native'
 import { useFonts } from 'expo-font'
-import { SplashScreen, Stack, usePathname, useRouter } from 'expo-router'
+import * as SplashScreen from 'expo-splash-screen'
+import { Stack, usePathname, useRouter } from 'expo-router'
 import { PostHogProvider, PostHogSurveyProvider } from 'posthog-react-native'
 import {
   UserProvider,
@@ -42,6 +43,7 @@ export const unstable_settings = {
 }
 
 SplashScreen.preventAutoHideAsync()
+SplashScreen.setOptions({ duration: 350, fade: true })
 
 const posthogHost = process.env.EXPO_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com'
 const posthogKey = process.env.EXPO_PUBLIC_POSTHOG_KEY
@@ -266,6 +268,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
   }, [user, loading, pathname, isAuthenticated, introShown])
 
   const navTheme = isDark ? DarkTheme : DefaultTheme
+  const rootBackground = isDark ? '#1A1A1A' : '#FAFAF7'
   const prevIsDark = useRef(isDark)
   const fadeAnim = useRef(new Animated.Value(1)).current
 
@@ -282,9 +285,9 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
   if (loading) return null
 
   return (
-    <Animated.View style={{ flex: 1, opacity: fadeAnim }}>
+    <Animated.View style={{ flex: 1, backgroundColor: rootBackground, opacity: fadeAnim }}>
       <NavigationThemeProvider value={navTheme}>
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, backgroundColor: rootBackground }}>
         <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="auth" options={{ headerShown: false }} />


### PR DESCRIPTION
## Summary
- Configure the Expo splash screen with a light-mode background and dark-mode override.
- Size the launch wordmark explicitly and enable the native fade when hiding the splash.
- Match the first React root background to the resolved app theme to avoid a white handoff frame.

## Validation
- `cd packages/frontend && npm run typecheck`

## Notes
- iOS native splash changes require a new native/TestFlight build; they will not ship through OTA alone.