### PR TITLE
[codex] Simplify invite entry in auth flows

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -188,6 +188,8 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
     width < 768 &&
     !pathname.startsWith('/auth') &&
     !pathname.startsWith('/onboarding') &&
+    pathname !== '/join' &&
+    !pathname.startsWith('/i/') &&
     pathname !== '/landing' &&
     pathname !== '/intro'
 

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -17,6 +17,8 @@ import { useTheme } from '../components/contexts'
 import { PasswordStrength } from '../components'
 import DevPanel from '../components/DevPanel'
 import { useAuthFlow } from '../components/auth/useAuthFlow'
+import { InviteCodeInput } from '../components/invite/InviteCodeField'
+import { extractInviteCode } from '../utils/validation'
 
 // __DEV__ is a React Native/Expo global — always false in production builds.
 // EXPO_PUBLIC_SHOW_DEV_TOOLS=1 also enables the dev/demo tools (set on the
@@ -59,7 +61,47 @@ export default function AuthScreen() {
   } = useAuthFlow()
 
   const [showDevPanel, setShowDevPanel] = useState(false)
+  const [showInviteField, setShowInviteField] = useState(false)
+  const [inviteValue, setInviteValue] = useState('')
+  const [inviteError, setInviteError] = useState('')
 
+  const revealInviteField = () => {
+    track('auth_have_invite_pressed', { source: 'auth' })
+    setShowInviteField(true)
+  }
+
+  const hideInviteField = () => {
+    track('auth_invite_entry_cancelled', { source: 'auth' })
+    setShowInviteField(false)
+    setInviteValue('')
+    setInviteError('')
+  }
+
+  const openInvite = (code: string) => {
+    track('auth_invite_code_submitted', { source: 'auth' })
+    router.push(`/i/${encodeURIComponent(code)}` as never)
+  }
+
+  const submitInvite = () => {
+    const code = extractInviteCode(inviteValue)
+    if (!code) {
+      setInviteError('Paste a valid invite link or code.')
+      return
+    }
+    setInviteError('')
+    openInvite(code)
+  }
+
+  const handlePrimaryPress = () => {
+    if (showInviteField && inviteValue.trim()) {
+      submitInvite()
+      return
+    }
+    handleSubmit()
+  }
+
+  const inviteHasText = showInviteField && inviteValue.trim().length > 0
+  const primaryDisabled = inviteHasText ? loading : isButtonDisabled
   const rootStyle: ViewStyle = { flex: 1, backgroundColor: pageBg }
 
   return (
@@ -167,7 +209,7 @@ export default function AuthScreen() {
             )}
 
             {/* Form */}
-            <View className="gap-4">
+            <View style={{ gap: showInviteField ? 8 : 16 }}>
               <View>
                 <AuthInput
                   placeholder="Email"
@@ -216,12 +258,25 @@ export default function AuthScreen() {
                 </>
               )}
 
+              {authStep === 'initial' && !hasInvite && showInviteField && (
+                <InviteCodeInput
+                  compact
+                  value={inviteValue}
+                  onChangeText={(next) => {
+                    setInviteValue(next)
+                    if (inviteError) setInviteError('')
+                  }}
+                  error={inviteError}
+                  onSubmitEditing={submitInvite}
+                />
+              )}
+
               {/* Submit Button */}
               <PrimaryButton
-                onPress={handleSubmit}
-                disabled={isButtonDisabled}
+                onPress={handlePrimaryPress}
+                disabled={primaryDisabled}
                 loading={loading}
-                style={{ marginTop: 8 }}
+                style={{ marginTop: showInviteField ? 0 : 8 }}
               >
                 {authStep === 'login'
                   ? 'Log In'
@@ -231,6 +286,17 @@ export default function AuthScreen() {
                       : 'Sign Up'
                     : 'Continue'}
               </PrimaryButton>
+
+              {authStep === 'initial' && !hasInvite && showInviteField && (
+                <Pressable
+                  className="items-center"
+                  onPress={hideInviteField}
+                >
+                  <Text className="font-sans" style={{ fontSize: 14, color: mutedColor }}>
+                    No invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Use email instead</Text>
+                  </Text>
+                </Pressable>
+              )}
 
               {/* Forgot Password (only on login) */}
               {authStep === 'login' && (
@@ -242,17 +308,18 @@ export default function AuthScreen() {
                 </Pressable>
               )}
 
-              {/* Have an invite? — manual code entry now that the typed step is
-                  cut (form-03). Routes to the neutral paste screen (new-25). */}
+              {/* Have an invite? — reveal the same paste field used by /join and the modal. */}
               {authStep === 'initial' && !hasInvite && (
-                <Pressable
-                  className="items-center mt-2"
-                  onPress={() => { track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') }}
-                >
-                  <Text className="font-sans" style={{ fontSize: 14, color: mutedColor }}>
-                    Have an invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Paste it</Text>
-                  </Text>
-                </Pressable>
+                !showInviteField && (
+                  <Pressable
+                    className="items-center mt-4"
+                    onPress={revealInviteField}
+                  >
+                    <Text className="font-sans" style={{ fontSize: 14, color: mutedColor }}>
+                      Have an invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Paste it</Text>
+                    </Text>
+                  </Pressable>
+                )
               )}
             </View>
 

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import { useRouter } from 'expo-router'
 import { useAnalytics } from '../utils/analytics'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
 import { useAuthFlow } from '../components/auth/useAuthFlow'
+import { InviteCodeInput } from '../components/invite/InviteCodeField'
+import { extractInviteCode } from '../utils/validation'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const swamiChinmayanandaJpg = require('../assets/images/landing/Swami Chinmayananda.jpg')
 const swamiChinmayanandaAlt = require('../assets/images/landing/Swami Chinmayananda (1).jpg')
@@ -74,6 +76,9 @@ export default function AuthScreen() {
   const [emailFocused, setEmailFocused] = useState(false)
   const [passwordFocused, setPasswordFocused] = useState(false)
   const [confirmPasswordFocused, setConfirmPasswordFocused] = useState(false)
+  const [showInviteField, setShowInviteField] = useState(false)
+  const [inviteValue, setInviteValue] = useState('')
+  const [inviteError, setInviteError] = useState('')
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth : 1280,
   )
@@ -125,6 +130,40 @@ export default function AuthScreen() {
         : 'Continue'
   const isNarrowWeb = viewportWidth < 1024
   const isMobile = viewportWidth < 640
+  const revealInviteField = useCallback(() => {
+    track('auth_have_invite_pressed', { source: 'auth' })
+    setShowInviteField(true)
+  }, [track])
+  const hideInviteField = useCallback(() => {
+    track('auth_invite_entry_cancelled', { source: 'auth' })
+    setShowInviteField(false)
+    setInviteValue('')
+    setInviteError('')
+  }, [track])
+  const openInvite = useCallback((code: string) => {
+    track('auth_invite_code_submitted', { source: 'auth' })
+    router.push(`/i/${encodeURIComponent(code)}` as never)
+  }, [router, track])
+  const submitInvite = useCallback(() => {
+    const code = extractInviteCode(inviteValue)
+    if (!code) {
+      setInviteError('Paste a valid invite link or code.')
+      return
+    }
+    setInviteError('')
+    openInvite(code)
+  }, [inviteValue, openInvite])
+  const handlePrimarySubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+    if (showInviteField && inviteValue.trim()) {
+      event.preventDefault()
+      event.stopPropagation()
+      submitInvite()
+      return
+    }
+    handleSubmit(event)
+  }, [handleSubmit, inviteValue, showInviteField, submitInvite])
+  const inviteHasText = showInviteField && inviteValue.trim().length > 0
+  const primaryDisabled = inviteHasText ? loading : isButtonDisabled
 
   return (
     <div
@@ -327,7 +366,10 @@ export default function AuthScreen() {
           )}
 
           {/* Form */}
-          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <form
+            onSubmit={handlePrimarySubmit}
+            style={{ display: 'flex', flexDirection: 'column', gap: showInviteField ? 8 : 16 }}
+          >
             {/* Email input */}
             <input
               className="auth-input"
@@ -387,11 +429,24 @@ export default function AuthScreen() {
               </>
             )}
 
+            {authStep === 'initial' && !hasInvite && showInviteField && (
+              <InviteCodeInput
+                compact
+                value={inviteValue}
+                onChangeText={(next) => {
+                  setInviteValue(next)
+                  if (inviteError) setInviteError('')
+                }}
+                error={inviteError}
+                onSubmitEditing={submitInvite}
+              />
+            )}
+
             {/* Submit button */}
             <button
               className="auth-submit"
               type="submit"
-              disabled={isButtonDisabled}
+              disabled={primaryDisabled}
               style={{
                 width: '100%',
                 height: 48,
@@ -403,9 +458,9 @@ export default function AuthScreen() {
                 fontSize: 16,
                 fontFamily: 'Inclusive Sans, sans-serif',
                 fontWeight: '500',
-                cursor: isButtonDisabled ? 'not-allowed' : 'pointer',
-                marginTop: 8,
-                opacity: isButtonDisabled ? 0.4 : 1,
+                cursor: primaryDisabled ? 'not-allowed' : 'pointer',
+                marginTop: showInviteField ? 0 : 8,
+                opacity: primaryDisabled ? 0.4 : 1,
                 WebkitTapHighlightColor: 'transparent',
                 touchAction: 'manipulation',
               }}
@@ -414,29 +469,53 @@ export default function AuthScreen() {
             </button>
           </form>
 
-          {/* Have an invite? — manual code entry now that the typed step is cut
-              (form-03). Routes to the neutral paste screen (new-25). */}
-          {authStep === 'initial' && !hasInvite && (
+          {authStep === 'initial' && !hasInvite && showInviteField && (
             <p
               style={{
                 fontSize: 14,
                 color: '#78716C',
                 textAlign: 'center',
-                marginTop: 4,
+                marginTop: 12,
                 fontFamily: 'Inclusive Sans, sans-serif',
               }}
             >
-              Have an invite?{' '}
+              No invite?{' '}
               <span
                 role="button"
                 tabIndex={0}
-                onClick={() => { track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') }}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); track('auth_have_invite_pressed', { source: 'auth' }); router.push('/join') } }}
+                onClick={hideInviteField}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); hideInviteField() } }}
                 style={{ color: '#E8862A', cursor: 'pointer', fontWeight: 600, padding: '8px 4px', margin: '-8px -4px', display: 'inline-block' }}
               >
-                Paste it
+                Use email instead
               </span>
             </p>
+          )}
+
+          {/* Have an invite? — reveal the same paste field used by /join and the mobile modal. */}
+          {authStep === 'initial' && !hasInvite && (
+            !showInviteField && (
+              <p
+                style={{
+                  fontSize: 14,
+                  color: '#78716C',
+                  textAlign: 'center',
+                  marginTop: 16,
+                  fontFamily: 'Inclusive Sans, sans-serif',
+                }}
+              >
+                Have an invite?{' '}
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onClick={revealInviteField}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); revealInviteField() } }}
+                  style={{ color: '#E8862A', cursor: 'pointer', fontWeight: 600, padding: '8px 4px', margin: '-8px -4px', display: 'inline-block' }}
+                >
+                  Paste it
+                </span>
+              </p>
+            )
           )}
 
           {authStep === 'login' && (

--- a/packages/frontend/app/join.tsx
+++ b/packages/frontend/app/join.tsx
@@ -4,6 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useColors } from '../hooks/useColors'
 import { extractInviteCode } from '../utils/validation'
 import PasteInvite from '../components/invite/PasteInvite'
+import Logo from '../components/ui/Logo'
 
 /**
  * /join — neutral "Have an invite?" paste screen (new-25). The target of every
@@ -35,11 +36,14 @@ export default function JoinScreen() {
         paddingHorizontal: 24,
       }}
     >
-      <PasteInvite
-        title="Have an invite?"
-        subtitle="Paste your invite link or code."
-        showBrowse
-      />
+      <View style={{ width: '100%', maxWidth: 440, alignItems: 'center', gap: 34 }}>
+        <Logo size={32} />
+        <PasteInvite
+          title="Welcome"
+          subtitle="Paste your invite link or code to continue."
+          showBrowse
+        />
+      </View>
     </View>
   )
 }

--- a/packages/frontend/components/auth/useAuthFlow.ts
+++ b/packages/frontend/components/auth/useAuthFlow.ts
@@ -267,7 +267,7 @@ export function useAuthFlow() {
         : 'Welcome back.'
       : authStep === 'signup'
         ? 'Join the community.'
-        : 'Welcome to Janata'
+        : 'Welcome'
 
   const subtitle =
     authStep === 'login'

--- a/packages/frontend/components/invite/InviteCodeField.tsx
+++ b/packages/frontend/components/invite/InviteCodeField.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useState } from 'react'
+import { Pressable, Text, TextInput, View } from 'react-native'
+import { useColors } from '../../hooks/useColors'
+import { extractInviteCode } from '../../utils/validation'
+
+type InviteCodeInputProps = {
+  value: string
+  onChangeText: (value: string) => void
+  error?: string
+  helperText?: string
+  compact?: boolean
+  onSubmitEditing?: () => void
+}
+
+type InviteCodeFieldProps = {
+  onSubmit: (code: string) => void
+  buttonLabel?: string
+  helperText?: string
+  compact?: boolean
+}
+
+export function InviteCodeInput({
+  value,
+  onChangeText,
+  error,
+  helperText = 'Paste the full invite link or just the code.',
+  compact = false,
+  onSubmitEditing,
+}: InviteCodeInputProps) {
+  const c = useColors()
+
+  return (
+    <View style={{ width: '100%', gap: compact ? 6 : 8 }}>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder="Invite link or code"
+        placeholderTextColor={c.textFaint}
+        autoCapitalize="none"
+        autoCorrect={false}
+        onSubmitEditing={onSubmitEditing}
+        style={{
+          width: '100%',
+          minHeight: compact ? 46 : 48,
+          backgroundColor: c.surface,
+          borderWidth: 1,
+          borderColor: error ? c.error : c.border,
+          borderRadius: 12,
+          paddingVertical: 11,
+          paddingHorizontal: 14,
+          fontSize: 16,
+          fontFamily: 'Inclusive Sans',
+          color: c.text,
+        }}
+      />
+      <Text
+        style={{
+          fontSize: 13,
+          lineHeight: 18,
+          fontFamily: 'Inclusive Sans',
+          color: error ? c.error : c.textMuted,
+        }}
+      >
+        {error || helperText}
+      </Text>
+    </View>
+  )
+}
+
+export default function InviteCodeField({
+  onSubmit,
+  buttonLabel = 'Open invite',
+  helperText,
+  compact = false,
+}: InviteCodeFieldProps) {
+  const c = useColors()
+  const [value, setValue] = useState('')
+  const [error, setError] = useState('')
+  const hasText = value.trim().length > 0
+
+  const open = useCallback(() => {
+    const code = extractInviteCode(value)
+    if (!code) {
+      setError('Paste a valid invite link or code.')
+      return
+    }
+    setError('')
+    onSubmit(code)
+  }, [onSubmit, value])
+
+  return (
+    <View style={{ width: '100%', gap: compact ? 8 : 10 }}>
+      <InviteCodeInput
+        value={value}
+        onChangeText={(next) => {
+          setValue(next)
+          if (error) setError('')
+        }}
+        onSubmitEditing={open}
+        error={error}
+        helperText={helperText}
+        compact={compact}
+      />
+      <Pressable
+        onPress={open}
+        disabled={!hasText}
+        accessibilityRole="button"
+        style={({ pressed }) => ({
+          minHeight: compact ? 44 : 48,
+          borderRadius: 12,
+          backgroundColor: !hasText ? c.surface : pressed ? c.accentPress : c.accent,
+          alignItems: 'center',
+          justifyContent: 'center',
+          opacity: hasText ? 1 : 0.7,
+        })}
+      >
+        <Text
+          style={{
+            color: hasText ? c.textInverse : c.textFaint,
+            fontSize: 15,
+            fontFamily: 'Inclusive Sans',
+            fontWeight: '600',
+          }}
+        >
+          {buttonLabel}
+        </Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/packages/frontend/components/invite/PasteInvite.tsx
+++ b/packages/frontend/components/invite/PasteInvite.tsx
@@ -1,8 +1,8 @@
-import { useState, useCallback } from 'react'
-import { View, Text, TextInput, Pressable } from 'react-native'
+import { useCallback } from 'react'
+import { View, Text, Pressable } from 'react-native'
 import { useRouter } from 'expo-router'
 import { useColors } from '../../hooks/useColors'
-import { extractInviteCode } from '../../utils/validation'
+import InviteCodeField from './InviteCodeField'
 
 type PasteInviteProps = {
   /** Headline — neutral ("Have an invite?") or error ("This invite isn't active"). */
@@ -23,13 +23,10 @@ type PasteInviteProps = {
 export default function PasteInvite({ title, subtitle, showBrowse }: PasteInviteProps) {
   const c = useColors()
   const router = useRouter()
-  const [pasted, setPasted] = useState('')
-  const canOpen = !!extractInviteCode(pasted)
 
-  const open = useCallback(() => {
-    const code = extractInviteCode(pasted)
-    if (code) router.replace(`/i/${encodeURIComponent(code)}`)
-  }, [pasted, router])
+  const open = useCallback((code: string) => {
+    router.replace(`/i/${encodeURIComponent(code)}` as never)
+  }, [router])
 
   return (
     <View style={{ width: '100%', maxWidth: 440, alignItems: 'center', gap: 16 }}>
@@ -44,39 +41,7 @@ export default function PasteInvite({ title, subtitle, showBrowse }: PasteInvite
         </Text>
       </View>
 
-      <View style={{ width: '100%', gap: 10 }}>
-        <TextInput
-          value={pasted}
-          onChangeText={setPasted}
-          placeholder="Paste an invite link or code"
-          placeholderTextColor={c.textFaint}
-          autoCapitalize="none"
-          autoCorrect={false}
-          onSubmitEditing={open}
-          style={{
-            backgroundColor: c.surface,
-            borderRadius: 8,
-            paddingVertical: 12,
-            paddingHorizontal: 14,
-            fontSize: 15,
-            color: c.text,
-          }}
-        />
-        <Pressable
-          onPress={open}
-          disabled={!canOpen}
-          style={{
-            backgroundColor: canOpen ? c.accent : c.surface,
-            borderRadius: 12,
-            paddingVertical: 15,
-            alignItems: 'center',
-          }}
-        >
-          <Text style={{ color: canOpen ? c.textInverse : c.textFaint, fontSize: 16, fontWeight: '600' }}>
-            Open invite
-          </Text>
-        </Pressable>
-      </View>
+      <InviteCodeField onSubmit={open} />
 
       {showBrowse && (
         <Pressable onPress={() => router.replace('/(tabs)')} style={{ paddingVertical: 8 }}>

--- a/packages/frontend/components/ui/AuthPromptModal.tsx
+++ b/packages/frontend/components/ui/AuthPromptModal.tsx
@@ -4,7 +4,9 @@ import { useRouter } from 'expo-router'
 import { useUser } from '../contexts'
 import { useAnalytics } from '../../utils/analytics'
 import { validateEmail } from '../../utils'
+import { extractInviteCode } from '../../utils/validation'
 import { useDetailColors } from '../../hooks/useDetailColors'
+import { InviteCodeInput } from '../invite/InviteCodeField'
 import PrimaryButton from './buttons/PrimaryButton'
 import SecondaryButton from './buttons/SecondaryButton'
 
@@ -58,6 +60,9 @@ export default function AuthPromptModal({
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  const [showInviteField, setShowInviteField] = useState(false)
+  const [inviteValue, setInviteValue] = useState('')
+  const [inviteError, setInviteError] = useState('')
 
   const trimmedEmail = email.trim()
 
@@ -66,6 +71,9 @@ export default function AuthPromptModal({
     setEmail('')
     setPassword('')
     setErrors({})
+    setShowInviteField(false)
+    setInviteValue('')
+    setInviteError('')
   }, [])
 
   const closePrompt = useCallback(() => {
@@ -84,20 +92,54 @@ export default function AuthPromptModal({
       return
     }
     track('auth_login_started', { source: 'auth_modal' })
+    setShowInviteField(false)
     setAuthStep('login')
   }, [track, trimmedEmail])
 
   const handlePasteInvite = useCallback(() => {
     track('invite_wall_paste_pressed', { source: 'auth_modal' })
+    setShowInviteField(true)
+  }, [track])
+
+  const handleHideInvite = useCallback(() => {
+    track('invite_wall_paste_cancelled', { source: 'auth_modal' })
+    setShowInviteField(false)
+    setInviteValue('')
+    setInviteError('')
+  }, [track])
+
+  const handleOpenInvite = useCallback((code: string) => {
+    track('invite_wall_code_submitted', { source: 'auth_modal' })
     closePrompt()
-    router.push('/join')
+    router.push(`/i/${encodeURIComponent(code)}` as never)
   }, [closePrompt, router, track])
+
+  const submitInvite = useCallback(() => {
+    const code = extractInviteCode(inviteValue)
+    if (!code) {
+      setInviteError('Paste a valid invite link or code.')
+      return
+    }
+    setInviteError('')
+    handleOpenInvite(code)
+  }, [handleOpenInvite, inviteValue])
+
+  const handleInitialSubmit = useCallback(() => {
+    if (showInviteField && inviteValue.trim()) {
+      submitInvite()
+      return
+    }
+    handleStartLogin()
+  }, [handleStartLogin, inviteValue, showInviteField, submitInvite])
 
   const handleBack = useCallback(() => {
     track('auth_back_pressed', { source: 'auth_modal', from_step: authStep })
     setAuthStep('initial')
     setPassword('')
     setErrors({})
+    setShowInviteField(false)
+    setInviteValue('')
+    setInviteError('')
   }, [authStep, track])
 
   const handleLogin = useCallback(async () => {
@@ -176,6 +218,8 @@ export default function AuthPromptModal({
     const modalWidth = isDesktop ? 860 : 380
     const stepTitle = authStep === 'login' ? 'Welcome back.' : wallTitle
     const stepCopy = authStep === 'login' ? 'Enter your password to continue.' : wallCopy
+    const inviteHasText = showInviteField && inviteValue.trim().length > 0
+    const initialDisabled = inviteHasText ? loading : (!trimmedEmail || loading)
 
     return (
       <View
@@ -302,7 +346,7 @@ export default function AuthPromptModal({
                 </View>
               )}
 
-              <View style={{ gap: 12, marginTop: 4 }}>
+              <View style={{ gap: showInviteField ? 8 : 12, marginTop: 4 }}>
                 {authStep === 'login' && (
                   <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
                     <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#E8862A' }}>Back</Text>
@@ -334,6 +378,19 @@ export default function AuthPromptModal({
                   }}
                 />
                 {errors.email ? <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#B91C1C' }}>{errors.email}</Text> : null}
+
+                {authStep === 'initial' && showInviteField && (
+                  <InviteCodeInput
+                    compact
+                    value={inviteValue}
+                    onChangeText={(next) => {
+                      setInviteValue(next)
+                      if (inviteError) setInviteError('')
+                    }}
+                    error={inviteError}
+                    onSubmitEditing={submitInvite}
+                  />
+                )}
 
                 {authStep === 'login' && (
                   <>
@@ -367,12 +424,21 @@ export default function AuthPromptModal({
 
                 {authStep === 'initial' ? (
                   <>
-                    <PrimaryButton onPress={handleStartLogin} disabled={!trimmedEmail || loading} style={{ borderRadius: 8 }}>
-                      Log In
+                    <PrimaryButton onPress={handleInitialSubmit} disabled={initialDisabled} style={{ borderRadius: 8 }}>
+                      {showInviteField ? 'Continue' : 'Log In'}
                     </PrimaryButton>
-                    <SecondaryButton onPress={handlePasteInvite} style={{ borderRadius: 8, backgroundColor: '#FFFFFF' }}>
-                      Have an invite? Paste it
-                    </SecondaryButton>
+                    {showInviteField && (
+                      <Pressable onPress={handleHideInvite} style={{ alignItems: 'center', paddingTop: 2 }}>
+                        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#78716C' }}>
+                          No invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Use email instead</Text>
+                        </Text>
+                      </Pressable>
+                    )}
+                    {!showInviteField && (
+                      <SecondaryButton onPress={handlePasteInvite} style={{ borderRadius: 8, backgroundColor: '#FFFFFF' }}>
+                        Have an invite? Paste it
+                      </SecondaryButton>
+                    )}
                   </>
                 ) : (
                   <PrimaryButton onPress={handleLogin} disabled={!password || loading} style={{ borderRadius: 8 }}>
@@ -390,6 +456,8 @@ export default function AuthPromptModal({
   // Native modal
   const nativeTitle = authStep === 'login' ? 'Welcome back' : wallTitle
   const nativeCopy = authStep === 'login' ? 'Enter your password to continue.' : wallCopy
+  const nativeInviteHasText = showInviteField && inviteValue.trim().length > 0
+  const nativeInitialDisabled = nativeInviteHasText ? loading : (!trimmedEmail || loading)
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={closePrompt}>
@@ -411,7 +479,7 @@ export default function AuthPromptModal({
           <Text style={{ fontSize: 15, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 22 }}>
             {nativeCopy}
           </Text>
-          <View style={{ gap: 10, marginTop: 4 }}>
+          <View style={{ gap: showInviteField ? 8 : 10, marginTop: 4 }}>
             {authStep === 'login' && (
               <Pressable onPress={handleBack} style={{ alignSelf: 'flex-start', paddingVertical: 2 }}>
                 <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: '#E8862A' }}>Back</Text>
@@ -443,6 +511,19 @@ export default function AuthPromptModal({
               }}
             />
             {errors.email ? <Text style={{ fontSize: 13, fontFamily: 'Inclusive Sans', color: '#B91C1C' }}>{errors.email}</Text> : null}
+
+            {authStep === 'initial' && showInviteField && (
+              <InviteCodeInput
+                compact
+                value={inviteValue}
+                onChangeText={(next) => {
+                  setInviteValue(next)
+                  if (inviteError) setInviteError('')
+                }}
+                error={inviteError}
+                onSubmitEditing={submitInvite}
+              />
+            )}
 
             {authStep === 'login' && (
               <>
@@ -476,12 +557,21 @@ export default function AuthPromptModal({
 
             {authStep === 'initial' ? (
               <>
-                <PrimaryButton onPress={handleStartLogin} disabled={!trimmedEmail || loading}>
-                  Log In
+                <PrimaryButton onPress={handleInitialSubmit} disabled={nativeInitialDisabled}>
+                  {showInviteField ? 'Continue' : 'Log In'}
                 </PrimaryButton>
-                <SecondaryButton onPress={handlePasteInvite}>
-                  Have an invite? Paste it
-                </SecondaryButton>
+                {showInviteField && (
+                  <Pressable onPress={handleHideInvite} style={{ alignItems: 'center', paddingTop: 2 }}>
+                    <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textMuted }}>
+                      No invite? <Text style={{ color: '#E8862A', fontWeight: '600' }}>Use email instead</Text>
+                    </Text>
+                  </Pressable>
+                )}
+                {!showInviteField && (
+                  <SecondaryButton onPress={handlePasteInvite}>
+                    Have an invite? Paste it
+                  </SecondaryButton>
+                )}
               </>
             ) : (
               <PrimaryButton onPress={handleLogin} disabled={!password || loading}>


### PR DESCRIPTION
## Summary
- add a shared invite-code input with validation
- make /auth and the mobile auth modal reveal invite entry inline while keeping one primary action
- make /join visually align with auth and hide mobile web bottom nav on invite entry pages

## Validation
- npm run typecheck:frontend