### PR TITLE
[codex] Align logged-out home and feed

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -416,10 +416,10 @@ export default function FeedScreen() {
   }, [router, track])
 
   // Hard-gate path (new-15): the not-yet-invited paste an invite link/code.
-  // /auth's invite step validates it; #403's Door 1 takes over post-#440.
+  // /join validates it; #403's Door 1 takes over post-#440.
   const handlePasteInvite = useCallback(() => {
     track('feed_paste_invite_pressed', { source: 'feed_setup' })
-    router.push('/auth' as never)
+    router.push('/join' as never)
   }, [router, track])
 
   // Inline "join your center" from the empty-state rail. A guest can't persist a

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -13,9 +13,12 @@ import { extractCityState } from '../../utils/addressParsing'
 import { FeaturedEventCard, type FeaturedSource } from '../../components/home/FeaturedEventCard'
 import { MiniEventRow, type WeekItem } from '../../components/home/MiniEventRow'
 import { BoardPostCard, SignInCallout, boardPostToMessage, type BoardMessage } from '../../components/boards'
+import { FeedSetupRail } from '../../components/feed'
 import { DesktopColumns, desktopScrollContent, useDesktopLayout } from '../../components/layout/DesktopColumns'
 import AuthPromptModal from '../../components/ui/AuthPromptModal'
 import type { AppColors } from '../../tokens'
+
+const compassImage = require('../../assets/images/onboarding/compass.png')
 
 function formatDatePill(dateStr: string): { month: string; day: string } {
   const parsed = new Date(`${dateStr}T00:00:00`)
@@ -160,8 +163,10 @@ export default function HomeScreen() {
   // A signed-in, verified member (vl >= 45). Guests and unverified users get the
   // stripped home: Explore + sign-in nudge, no personalized event/board lists.
   const isVerifiedMember = !!user && vl >= 45
+  const isLoggedOutWeb = Platform.OS === 'web' && !user
 
-  if (discoverLoading || (user ? myEventsLoading : false)) {
+  const shouldWaitForHomeData = user ? (discoverLoading || myEventsLoading) : (!isLoggedOutWeb && discoverLoading)
+  if (shouldWaitForHomeData) {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: c.bg }}>
         <ActivityIndicator size="large" color={c.accent} />
@@ -195,6 +200,29 @@ export default function HomeScreen() {
         track('home_signin_pressed', { source: 'home_nudge' })
         setShowAuthPrompt(true)
       }}
+    />
+  ) : null
+
+  const guestSetupRail = !user ? (
+    <FeedSetupRail
+      colors={c}
+      isSignedIn={false}
+      onSignIn={() => {
+        track('home_signin_pressed', { source: 'home_desktop_rail' })
+        setShowAuthPrompt(true)
+      }}
+      onJoinCenter={() => undefined}
+      onBrowseEvents={() => {
+        track('home_guest_browse_events_pressed', { source: 'home_desktop_rail' })
+        router.push('/explore' as never)
+      }}
+      onPasteInvite={() => {
+        track('home_paste_invite_pressed', { source: 'home_desktop_rail' })
+        router.push('/join' as never)
+      }}
+      artworkSource={compassImage}
+      signedOutTitle="Log in to make Janata yours."
+      signedOutSubtitle="Your center, events, and community updates will show up here."
     />
   ) : null
 
@@ -390,9 +418,26 @@ export default function HomeScreen() {
   // stranding a narrow column in empty gray. Reuses the exact same section
   // blocks as mobile; only their arrangement differs.
   if (isWideDesktop) {
-    // Guests: live events in the main column, the compact log-in callout as
-    // the rail (new-30). Members keep first-run overview / boards there.
-    const rail = !user ? guestNudge : isNewUser ? firstRunOverview : (
+    if (isLoggedOutWeb) {
+      return (
+        <>
+          <ScrollView
+            style={{ flex: 1, backgroundColor: c.bg }}
+            contentContainerStyle={desktopScrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            <DesktopColumns
+              main={<HomeGhostPreview c={c} />}
+              rail={guestSetupRail}
+            />
+          </ScrollView>
+          {authPrompt}
+        </>
+      )
+    }
+
+    // Members keep first-run overview / boards in the rail.
+    const rail = isNewUser ? firstRunOverview : (
       <View style={{ gap: 22 }}>{boardsSection}</View>
     )
     return (
@@ -418,6 +463,27 @@ export default function HomeScreen() {
             }
             rail={rail}
           />
+        </ScrollView>
+        {authPrompt}
+      </>
+    )
+  }
+
+  if (isLoggedOutWeb) {
+    return (
+      <>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: c.bg }}
+          contentContainerStyle={{
+            paddingHorizontal: 16,
+            paddingTop: 20,
+            paddingBottom: 40,
+          }}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center' }}>
+            {guestSetupRail}
+          </View>
         </ScrollView>
         {authPrompt}
       </>
@@ -491,6 +557,113 @@ function WelcomeBanner({ c, onExplore, centerName }: { c: AppColors; onExplore: 
       >
         <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13.5, color: c.textInverse }}>Explore</Text>
       </Pressable>
+    </View>
+  )
+}
+
+function GhostBlock({
+  c,
+  width,
+  height,
+  opacity = 1,
+}: {
+  c: AppColors
+  width: number | string
+  height: number
+  opacity?: number
+}) {
+  return (
+    <View
+      style={{
+        width: width as any,
+        height,
+        opacity,
+        borderRadius: height / 2,
+        backgroundColor: c.panel,
+      }}
+    />
+  )
+}
+
+function HomeGhostPreview({ c }: { c: AppColors }) {
+  const rowOpacities = [0.58, 0.38, 0.22]
+  return (
+    <View style={{ gap: 14 }} pointerEvents="none">
+      <View
+        style={{
+          borderRadius: 22,
+          borderWidth: 1,
+          borderColor: c.border,
+          backgroundColor: c.card,
+          overflow: 'hidden',
+          opacity: 0.72,
+        }}
+      >
+        <View style={{ height: 124, backgroundColor: c.panel }} />
+        <View style={{ padding: 16, gap: 12 }}>
+          <GhostBlock c={c} width={84} height={18} />
+          <View style={{ gap: 8 }}>
+            <GhostBlock c={c} width="70%" height={18} />
+            <GhostBlock c={c} width="46%" height={13} />
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <View style={{ flexDirection: 'row' }}>
+              {Array.from({ length: 4 }).map((_, index) => (
+                <View
+                  key={index}
+                  style={{
+                    width: 24,
+                    height: 24,
+                    marginLeft: index === 0 ? 0 : -7,
+                    borderRadius: 12,
+                    borderWidth: 2,
+                    borderColor: c.card,
+                    backgroundColor: c.panel,
+                  }}
+                />
+              ))}
+            </View>
+            <GhostBlock c={c} width={88} height={16} />
+          </View>
+        </View>
+      </View>
+
+      <View style={{ gap: 10 }}>
+        {rowOpacities.map((opacity, index) => (
+          <View
+            key={index}
+            style={{
+              opacity,
+              flexDirection: 'row',
+              gap: 12,
+              padding: 12,
+              borderRadius: 14,
+              borderWidth: 1,
+              borderColor: c.border,
+              backgroundColor: c.card,
+            }}
+          >
+            <View
+              style={{
+                width: 44,
+                height: 50,
+                borderRadius: 10,
+                backgroundColor: c.surface,
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 5,
+              }}
+            >
+              <GhostBlock c={c} width={22} height={7} />
+              <GhostBlock c={c} width={18} height={14} />
+            </View>
+            <View style={{ flex: 1, minWidth: 0, justifyContent: 'center', gap: 8 }}>
+              <GhostBlock c={c} width={index === 1 ? '58%' : '74%'} height={14} />
+              <GhostBlock c={c} width={index === 2 ? '42%' : '52%'} height={11} />
+            </View>
+          </View>
+        ))}
+      </View>
     </View>
   )
 }

--- a/packages/frontend/components/feed/FeedEmptyState.tsx
+++ b/packages/frontend/components/feed/FeedEmptyState.tsx
@@ -56,6 +56,7 @@ export function FeedEmptyState({
       variant={state === 'firstPost' ? 'firstPost' : 'welcome'}
       centerName={centerName}
       onCompose={onCompose}
+      showWelcomeCard={!(isDesktop && state === 'guest')}
     />
   )
 

--- a/packages/frontend/components/feed/FeedSetupRail.tsx
+++ b/packages/frontend/components/feed/FeedSetupRail.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Image, Pressable, Text, View } from 'react-native'
+import { Image, Pressable, Text, View, type ImageSourcePropType } from 'react-native'
 import { Check } from 'lucide-react-native'
 import type { AppColors } from '../../tokens'
 import { CenterSearch } from '../center/CenterSearch'
@@ -56,6 +56,9 @@ export function FeedSetupRail({
   onJoinCenter,
   onBrowseEvents,
   onPasteInvite,
+  artworkSource,
+  signedOutTitle = 'Log in to see your feed.',
+  signedOutSubtitle = 'Posts from your center and events will show up here.',
 }: {
   colors: AppColors
   isSignedIn: boolean
@@ -65,8 +68,12 @@ export function FeedSetupRail({
   onBrowseEvents: () => void
   /** Hard-gate path for the not-yet-invited: paste an invite link or code. */
   onPasteInvite?: () => void
+  artworkSource?: ImageSourcePropType
+  signedOutTitle?: string
+  signedOutSubtitle?: string
 }) {
   const [joiningId, setJoiningId] = useState<string | null>(null)
+  const setupArtwork = artworkSource ?? diyaImage
 
   const handleJoin = async (centerId: string) => {
     setJoiningId(centerId)
@@ -96,16 +103,16 @@ export function FeedSetupRail({
       >
         <View style={{ alignItems: 'center', gap: 12 }}>
           <Image
-            source={diyaImage}
+            source={setupArtwork}
             accessibilityIgnoresInvertColors
             style={{ width: 72, height: 72 }}
             resizeMode="contain"
           />
           <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 22, lineHeight: 28, color: colors.text, textAlign: 'center' }}>
-            Log in to see your feed.
+            {signedOutTitle}
           </Text>
           <Text style={{ fontSize: 14, lineHeight: 20, color: colors.textMuted, textAlign: 'center' }}>
-            Posts from your center and events will show up here.
+            {signedOutSubtitle}
           </Text>
         </View>
 

--- a/packages/frontend/components/feed/GhostFeed.tsx
+++ b/packages/frontend/components/feed/GhostFeed.tsx
@@ -170,20 +170,24 @@ export function GhostFeed({
   variant,
   centerName,
   onCompose,
+  showWelcomeCard = true,
 }: {
   colors: AppColors
   variant: 'welcome' | 'firstPost'
   centerName?: string
   onCompose?: () => void
+  showWelcomeCard?: boolean
 }) {
-  const ghostOpacities = [0.5, 0.32, 0.18]
+  const ghostOpacities = showWelcomeCard ? [0.5, 0.32, 0.18] : [0.66, 0.46, 0.28, 0.16]
   return (
     <View style={{ gap: 14 }}>
-      {variant === 'welcome' ? (
-        <WelcomeCard colors={colors} />
-      ) : (
-        <FirstPostCard colors={colors} centerName={centerName} onCompose={onCompose} />
-      )}
+      {showWelcomeCard ? (
+        variant === 'welcome' ? (
+          <WelcomeCard colors={colors} />
+        ) : (
+          <FirstPostCard colors={colors} centerName={centerName} onCompose={onCompose} />
+        )
+      ) : null}
 
       <View style={{ position: 'relative', gap: 12 }} pointerEvents="none">
         {ghostOpacities.map((opacity, i) => (

--- a/tests/v2/guest.spec.ts
+++ b/tests/v2/guest.spec.ts
@@ -32,7 +32,7 @@ test.describe('v2 guest', () => {
 
   test('guest Home shows the sign-in nudge', async ({ page }, testInfo) => {
     await gotoApp(page, '/')
-    await expect(vtext(page, /Make Janata yours|Sign in/i)).toBeVisible()
+    await expect(vtext(page, /Log in to make Janata yours|Make Janata yours/i)).toBeVisible()
     await shot(page, testInfo, 'home-guest')
   })
 
@@ -45,14 +45,14 @@ test.describe('v2 guest', () => {
 
   test('guest Feed shows the setup rail', async ({ page }, testInfo) => {
     await gotoApp(page, '/feed')
-    await expect(vtext(page, /Finish setting up your feed/i)).toBeVisible()
-    await expect(vtext(page, /Sign in/i)).toBeVisible()
+    await expect(vtext(page, /Log in to see your feed/i)).toBeVisible()
+    await expect(vtext(page, /Log in/i)).toBeVisible()
     await shot(page, testInfo, 'feed-setup-rail')
   })
 
-  test('guest Feed previews what the feed is (ghost card)', async ({ page }, testInfo) => {
+  test('guest Feed keeps the preview quiet', async ({ page }, testInfo) => {
     await gotoApp(page, '/feed')
-    await expect(vtext(page, /Your community feed/i)).toBeVisible()
+    await expect(page.getByText(/Your community feed/i)).toHaveCount(0)
     await shot(page, testInfo, 'feed-ghost-card')
   })
 

--- a/tests/v2/guest.spec.ts
+++ b/tests/v2/guest.spec.ts
@@ -16,12 +16,13 @@ test.describe('v2 guest', () => {
     await shot(page, testInfo, 'intro')
   })
 
-  test('auth screen shows the value proposition', async ({ page }, testInfo) => {
+  test('auth screen shows the welcome heading + invite affordance', async ({ page }, testInfo) => {
     await gotoApp(page, '/auth')
     await expect(page.getByRole('heading', { name: /Welcome/i })).toBeVisible()
-    // The value list that gives new users insight before signing in (#373).
-    await expect(vtext(page, /RSVP in a tap/i)).toBeVisible()
-    await shot(page, testInfo, 'auth-value-prop')
+    // The value-prop bullet list was removed (#488); the invite-only entry now
+    // leads with the email field + a "Have an invite? Paste it" affordance (#491).
+    await expect(vtext(page, /Have an invite/i)).toBeVisible()
+    await shot(page, testInfo, 'auth-welcome')
   })
 
   test('auth screen has the email entry', async ({ page }, testInfo) => {

--- a/tests/v2/guest.spec.ts
+++ b/tests/v2/guest.spec.ts
@@ -39,9 +39,12 @@ test.describe('v2 guest', () => {
 
   test('guest Home hides personalized event lists (#399)', async ({ page }) => {
     await gotoApp(page, '/')
-    // Personalized lists must NOT show for a logged-out visitor.
-    await expect(page.getByText(/UP NEXT FOR YOU/i)).toHaveCount(0)
-    await expect(page.getByText(/COMING UP/i)).toHaveCount(0)
+    // Personalized section headers must NOT be VISIBLE to a logged-out visitor.
+    // RN-web leaves hidden duplicate text nodes (responsive variants + the
+    // off-screen AuthPromptModal copy "…see what is coming up"), so filter to
+    // visible — a plain getByText would count those hidden copies.
+    await expect(page.getByText(/UP NEXT FOR YOU/i).filter({ visible: true })).toHaveCount(0)
+    await expect(page.getByText(/COMING UP/i).filter({ visible: true })).toHaveCount(0)
   })
 
   test('guest Feed shows the setup rail', async ({ page }, testInfo) => {
@@ -53,7 +56,9 @@ test.describe('v2 guest', () => {
 
   test('guest Feed keeps the preview quiet', async ({ page }, testInfo) => {
     await gotoApp(page, '/feed')
-    await expect(page.getByText(/Your community feed/i)).toHaveCount(0)
+    // The welcome ghost card is hidden for desktop guests; assert no VISIBLE
+    // copy (RN-web keeps the hidden mobile-variant node in the DOM).
+    await expect(page.getByText(/Your community feed/i).filter({ visible: true })).toHaveCount(0)
     await shot(page, testInfo, 'feed-ghost-card')
   })
 


### PR DESCRIPTION
## Summary
- make logged-out desktop Home use the same setup rail pattern as Feed
- remove mobile-web logged-out Home ghost content so the login card is the primary surface
- quiet the desktop guest Feed preview and update guest expectations
- route feed/home invite paste affordances to /join

## Validation
- npm run typecheck:frontend