### PR TITLE
[codex] Send landing guests to explore

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -315,7 +315,7 @@ export default function DiscoverScreen() {
   // Four positions (as translateY values from the expanded state):
   //   expanded  = 0           → 100% sheet visible (full screen, header hidden)
   //   mid       = sheet * 0.2 → ~80% sheet visible (most content, map peeking)
-  //   collapsed = sheet * 0.6 → ~40% sheet visible (peek + a few rows)
+  //   collapsed = sheet * 2/3 → ~33% sheet visible (peek + a few rows)
   //   peek      = sheet - 100 → just handle + search bar visible (100px)
 
   const EXPANDED_TOP = 60 // px from top of container when fully expanded
@@ -325,7 +325,7 @@ export default function DiscoverScreen() {
 
   const SNAP_EXPANDED = 0
   const SNAP_MID = Math.max(0, sheetHeight * 0.2)        // ~80% sheet visible
-  const SNAP_COLLAPSED = Math.max(0, sheetHeight * 0.6)  // ~40% sheet visible
+  const SNAP_COLLAPSED = Math.max(0, sheetHeight * (2 / 3))  // ~33% sheet visible
   const SNAP_PEEK = Math.max(0, sheetHeight - 100)       // 100px sheet visible (handle + search)
 
   const snapsRef = useRef({ expanded: SNAP_EXPANDED, mid: SNAP_MID, collapsed: SNAP_COLLAPSED, peek: SNAP_PEEK })

--- a/packages/frontend/components/explore/MobileDiscoverFallback.web.tsx
+++ b/packages/frontend/components/explore/MobileDiscoverFallback.web.tsx
@@ -85,7 +85,7 @@ export function MobileDiscoverFallback() {
   )
 
   // Bottom sheet state
-  const [sheetSnap, setSheetSnap] = useState<SheetSnap>('mid')
+  const [sheetSnap, setSheetSnap] = useState<SheetSnap>('collapsed')
   const [sheetTranslateY, setSheetTranslateY] = useState<number | null>(null)
   const dragStartY = useRef(0)
   const dragStartTranslate = useRef(0)
@@ -94,14 +94,14 @@ export function MobileDiscoverFallback() {
   // Sheet snap positions matching iOS native (4 stops):
   //   expanded  = 0          -> 100% sheet visible (full)
   //   mid       = h * 0.2    -> 80% sheet visible
-  //   collapsed = h * 0.6    -> 40% sheet visible
+  //   collapsed = h * 2/3    -> 33% sheet visible
   //   peek      = h - 100    -> 100px sheet visible (handle + search)
   const getSnapPositions = useCallback(() => {
     const h = containerRef.current?.clientHeight || window.innerHeight
     return {
       expanded: 0,
       mid: h * 0.2,
-      collapsed: h * 0.6,
+      collapsed: h * (2 / 3),
       peek: Math.max(0, h - 100),
     }
   }, [])

--- a/packages/frontend/components/landing/FinalCTA.tsx
+++ b/packages/frontend/components/landing/FinalCTA.tsx
@@ -260,7 +260,7 @@ export function FinalCTA() {
           <Pressable
             onPress={() => {
               posthog?.capture('landing_cta_pressed', { variant: 'final', label: 'browse_events' })
-              router.push('/(tabs)')
+              router.push('/explore')
             }}
             className="bg-primary active:bg-primary-press rounded-full"
             style={{

--- a/packages/frontend/components/landing/Hero.tsx
+++ b/packages/frontend/components/landing/Hero.tsx
@@ -674,7 +674,7 @@ export function Hero() {
           <Pressable
             onPress={() => {
               posthog?.capture('landing_cta_pressed', { variant: 'hero', label: 'start_exploring' })
-              router.push('/(tabs)')
+              router.push('/explore')
             }}
             className="bg-primary active:bg-primary-press rounded-full"
             style={{

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -9,38 +9,35 @@ test.describe('Landing Page', () => {
     await expect(page.getByText('Grow together')).toBeVisible()
   })
 
-  test('shows navigation bar with Get Started button', async ({ page }) => {
+  test('shows navigation bar with hero CTA', async ({ page }) => {
     await page.goto('/landing')
-    await page.waitForLoadState('networkidle')
 
     const brand = page.locator('text=Janata >> visible=true').first()
     await expect(brand).toBeVisible({ timeout: 10000 })
 
-    const getStartedBtn = page.getByText('Get Started', { exact: true }).first()
-    await expect(getStartedBtn).toBeVisible({ timeout: 10000 })
+    const startExploring = page.getByText(/Start Exploring/i).first()
+    await expect(startExploring).toBeVisible({ timeout: 10000 })
   })
 
-  test('Join the Community button navigates to auth', async ({ page }) => {
+  test('hero Start Exploring button navigates to Explore', async ({ page }) => {
     await page.goto('/landing')
-    await page.waitForLoadState('networkidle')
 
-    // "Join the Community →" is a Pressable (role=button)
-    const joinBtn = page.getByText(/join the community/i)
-    await expect(joinBtn).toBeVisible({ timeout: 10000 })
-    await joinBtn.click()
+    const startExploring = page.getByText(/Start Exploring/i).first()
+    await expect(startExploring).toBeVisible({ timeout: 10000 })
+    await startExploring.click()
 
-    await page.waitForURL(/\/auth/, { timeout: 10000 })
+    await page.waitForURL(/\/explore/, { timeout: 10000 })
   })
 
-  test('Get Started button navigates to auth', async ({ page }) => {
+  test('final browse button navigates to Explore', async ({ page }) => {
     await page.goto('/landing')
-    await page.waitForLoadState('networkidle')
 
-    const getStartedBtn = page.getByText('Get Started', { exact: true }).first()
-    await expect(getStartedBtn).toBeVisible({ timeout: 10000 })
-    await getStartedBtn.click()
+    const browse = page.getByText(/Browse events nearby/i).first()
+    await browse.scrollIntoViewIfNeeded()
+    await expect(browse).toBeVisible({ timeout: 10000 })
+    await browse.click()
 
-    await page.waitForURL(/\/auth/, { timeout: 10000 })
+    await page.waitForURL(/\/explore/, { timeout: 10000 })
   })
 
   test('page has no critical console errors (excluding WebGL)', async ({ page }) => {


### PR DESCRIPTION
## Summary
- route landing hero and final CTAs to /explore instead of the tab root
- start the mobile Explore sheet at roughly one-third height
- update landing navigation tests around the new destination

## Validation
- npm run typecheck:frontend