### PR TITLE
chore(ios): bump build number to 30

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -157,7 +157,7 @@
     "ios": {
       "icon": "./assets/images/logo.png",
       "supportsTablet": true,
-      "buildNumber": "29",
+      "buildNumber": "30",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",


### PR DESCRIPTION
Keeps git in sync with EAS build #30 (a6feb2a6), built from v2. Prevents the next `autoIncrement` from re-bumping 29→30 and colliding in TestFlight.