### PR TITLE
chore(ios): bump build number to 31

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -157,7 +157,7 @@
     "ios": {
       "icon": "./assets/images/logo.png",
       "supportsTablet": true,
-      "buildNumber": "30",
+      "buildNumber": "31",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",


### PR DESCRIPTION
Keeps git in sync with EAS build #31 (ac021c16), built from v2 with all 6 merged PRs (incl #492). Supersedes build 30.