### PR TITLE
chore(release): bump marketing version to 2.0.0

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Janata",
     "slug": "chinmaya-janata",
-    "version": "0.3.0",
+    "version": "2.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "janata",


### PR DESCRIPTION
Sets app.json version 0.3.0 → 2.0.0 for the v2 relaunch. buildNumber stays 31 (the next build auto-increments to 32 under the new 2.0.0 version). Resolves the 1.0.0→0.3.0 downgrade.