### PR TITLE
feat(ux): header icon spacing, admin on iOS, invite-into-auth

### DIFF
--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -416,10 +416,11 @@ export default function FeedScreen() {
   }, [router, track])
 
   // Hard-gate path (new-15): the not-yet-invited paste an invite link/code.
-  // /join validates it; #403's Door 1 takes over post-#440.
+  // Opens the combined /auth screen with the invite field revealed (no separate
+  // /join page); #403's Door 1 takes over post-#440.
   const handlePasteInvite = useCallback(() => {
     track('feed_paste_invite_pressed', { source: 'feed_setup' })
-    router.push('/join' as never)
+    router.push('/auth?invite=1' as never)
   }, [router, track])
 
   // Inline "join your center" from the empty-state rail. A guest can't persist a

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { ActivityIndicator, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
+import { ActivityIndicator, Linking, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
 import { ChevronRight, Compass, MapPin, Shield } from 'lucide-react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useAnalytics } from '../../utils/analytics'
@@ -204,7 +204,7 @@ export default function HomeScreen() {
       }}
       onPasteInvite={() => {
         track('home_paste_invite_pressed', { source: 'home_setup_card' })
-        router.push('/join' as never)
+        router.push('/auth?invite=1' as never)
       }}
       artworkSource={compassImage}
       signedOutTitle="Log in to make Janata yours."
@@ -231,8 +231,16 @@ export default function HomeScreen() {
   const adminShortcut = isSuperAdmin(user) ? (
     <Pressable
       onPress={() => {
-        track('home_admin_pressed', { source: 'home' })
-        router.push('/admin' as never)
+        track('home_admin_pressed', { source: 'home', platform: Platform.OS })
+        // The admin dashboard is web-only (app/admin.web.tsx); the native route
+        // is just a redirect. On native, open the live web dashboard in the
+        // system browser so admins/sevaks can manage from iOS instead of
+        // hitting a dead-end. Web keeps the in-app route.
+        if (Platform.OS === 'web') {
+          router.push('/admin' as never)
+        } else {
+          Linking.openURL('https://chinmayajanata.org/admin').catch(() => {})
+        }
       }}
       accessibilityRole="button"
       style={{ flexDirection: 'row', alignItems: 'center', gap: 12, borderRadius: 16, borderWidth: 1, borderColor: c.border, backgroundColor: c.card, padding: 14 }}

--- a/packages/frontend/app/auth.tsx
+++ b/packages/frontend/app/auth.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   ViewStyle,
 } from 'react-native'
-import { useRouter } from 'expo-router'
+import { useRouter, useLocalSearchParams } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { ArrowLeft } from 'lucide-react-native'
 import { useAnalytics } from '../utils/analytics'
@@ -61,7 +61,10 @@ export default function AuthScreen() {
   } = useAuthFlow()
 
   const [showDevPanel, setShowDevPanel] = useState(false)
-  const [showInviteField, setShowInviteField] = useState(false)
+  // `?invite=1` opens this screen straight to the paste-invite field, so the
+  // invite flow lives inside /auth instead of a separate /join page.
+  const { invite: inviteParam } = useLocalSearchParams<{ invite?: string }>()
+  const [showInviteField, setShowInviteField] = useState(inviteParam === '1')
   const [inviteValue, setInviteValue] = useState('')
   const [inviteError, setInviteError] = useState('')
 

--- a/packages/frontend/app/auth.web.tsx
+++ b/packages/frontend/app/auth.web.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react'
-import { useRouter } from 'expo-router'
+import { useRouter, useLocalSearchParams } from 'expo-router'
 import { useAnalytics } from '../utils/analytics'
 import PasswordStrength from '../components/auth/PasswordStrength'
 import { ImageCarousel } from '../components/auth/ImageCarousel'
@@ -76,7 +76,9 @@ export default function AuthScreen() {
   const [emailFocused, setEmailFocused] = useState(false)
   const [passwordFocused, setPasswordFocused] = useState(false)
   const [confirmPasswordFocused, setConfirmPasswordFocused] = useState(false)
-  const [showInviteField, setShowInviteField] = useState(false)
+  // `?invite=1` opens straight to the paste-invite field (shared with native).
+  const { invite: inviteParam } = useLocalSearchParams<{ invite?: string }>()
+  const [showInviteField, setShowInviteField] = useState(inviteParam === '1')
   const [inviteValue, setInviteValue] = useState('')
   const [inviteError, setInviteError] = useState('')
   const [viewportWidth, setViewportWidth] = useState(() =>

--- a/packages/frontend/components/events/GuestRsvpSheet.tsx
+++ b/packages/frontend/components/events/GuestRsvpSheet.tsx
@@ -169,7 +169,7 @@ export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }
                 Members join Janata by invite. Have one? Paste it to get in.
               </Text>
               <PrimaryButton
-                onPress={() => { close(); router.push('/join') }}
+                onPress={() => { close(); router.push('/auth?invite=1') }}
                 style={{ alignSelf: 'stretch' }}
               >
                 Have an invite? Paste it

--- a/packages/frontend/components/ui/TabHeader.tsx
+++ b/packages/frontend/components/ui/TabHeader.tsx
@@ -115,7 +115,7 @@ export default function TabHeader({
         ) : null}
       </View>
 
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
         {rightContent}
         {action && (
           <Pressable


### PR DESCRIPTION
Three small UX changes from design feedback (mobile/native):

1. **Header icon spacing** — `TabHeader` right-side icons `gap` 8 → 14, so Home/Feed/You header buttons aren't cramped.
2. **Admin on iOS** — the home admin shortcut now opens the web admin dashboard (`chinmayajanata.org/admin`) in the system browser on native (was a dead-end `/admin` redirect). Web keeps the in-app route. Pairs well with the admin mobile-responsive work in the sibling PR.
3. **Invite-into-auth (native)** — the 'Have an invite? Paste it' CTAs (home setup card, feed, guest RSVP sheet) now open `/auth?invite=1` with the invite field revealed, matching the web combined flow, instead of the separate `/join` page. `/join` stays only for invalid invite-link recovery.

Validation: typecheck ✓, frontend tests 197/197 ✓.