### PR TITLE
feat(admin): mobile-responsive admin dashboard

### DIFF
--- a/packages/frontend/app/admin.web.tsx
+++ b/packages/frontend/app/admin.web.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, useWindowDimensions } from 'react-native'
 import { useUser, useTheme } from '../components/contexts'
 import { router } from 'expo-router'
 import AdminSidebar, { type AdminTab } from '../components/admin/AdminSidebar'
@@ -15,6 +15,7 @@ import { useAnalytics } from '../utils/analytics'
 export default function AdminPage() {
   const { user, loading } = useUser()
   const { isDark } = useTheme()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
   // canEnter: sevak+ may open the app (Moderation). isAdmin: full admin (all
   // tabs). Admin-only endpoints 403 for a sevak token, so we gate by isAdmin —
@@ -55,10 +56,16 @@ export default function AdminPage() {
   }
 
   const pageBg = isDark ? '#0d0d0d' : '#FAFAF9'
+  const isCompact = width < 768
 
   return (
-    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: pageBg }}>
-      <AdminSidebar activeTab={activeTab} onTabChange={handleTabChange} isAdmin={isAdmin} />
+    <View style={{ flex: 1, flexDirection: isCompact ? 'column' : 'row', backgroundColor: pageBg }}>
+      <AdminSidebar
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        isAdmin={isAdmin}
+        compact={isCompact}
+      />
       {/* Admin-only tabs are gated by isAdmin so a sevak never mounts a tab
           whose endpoint 403s. Moderation is available to sevak+. */}
       {isAdmin && activeTab === 'Centers' && <CentersTab />}

--- a/packages/frontend/components/admin/AdminDetailPanel.tsx
+++ b/packages/frontend/components/admin/AdminDetailPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Text, Pressable, ScrollView, StyleSheet } from 'react-native'
+import { View, Text, Pressable, ScrollView, StyleSheet, useWindowDimensions } from 'react-native'
 import { X } from 'lucide-react-native'
 import { useDetailColors } from '../../hooks/useDetailColors'
 
@@ -11,14 +11,16 @@ type AdminDetailPanelProps = {
 
 export default function AdminDetailPanel({ title, onClose, children }: AdminDetailPanelProps) {
   const colors = useDetailColors()
+  const { width } = useWindowDimensions()
+  const isCompact = width < 768
 
   return (
     <View
       style={[
-        styles.container,
+        isCompact ? styles.compactContainer : styles.container,
         {
           backgroundColor: colors.panelBg,
-          borderLeftColor: colors.border,
+          borderLeftColor: isCompact ? 'transparent' : colors.border,
         },
       ]}
     >
@@ -40,6 +42,14 @@ const styles = StyleSheet.create({
   container: {
     width: 320,
     borderLeftWidth: 1,
+  },
+  compactContainer: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    zIndex: 20,
   },
   header: {
     flexDirection: 'row',

--- a/packages/frontend/components/admin/AdminSidebar.tsx
+++ b/packages/frontend/components/admin/AdminSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { View, Text, Pressable, ScrollView, StyleSheet } from 'react-native'
 import { Bell, Building2, CalendarDays, Users, Ticket, ShieldAlert } from 'lucide-react-native'
 import { useTheme } from '../contexts'
 
@@ -16,6 +16,7 @@ type AdminSidebarProps = {
   onTabChange: (tab: AdminTab) => void
   // Full admins see every tab; sevaks (moderation-only) see just Moderation.
   isAdmin: boolean
+  compact?: boolean
 }
 
 const tabs: { key: AdminTab; label: string; Icon: typeof Building2 }[] = [
@@ -27,7 +28,7 @@ const tabs: { key: AdminTab; label: string; Icon: typeof Building2 }[] = [
   { key: 'Notifications', label: 'Notifications', Icon: Bell },
 ]
 
-export default function AdminSidebar({ activeTab, onTabChange, isAdmin }: AdminSidebarProps) {
+export default function AdminSidebar({ activeTab, onTabChange, isAdmin, compact = false }: AdminSidebarProps) {
   const { isDark } = useTheme()
 
   const inactiveColor = isDark ? '#A8A29E' : '#78716C'
@@ -36,33 +37,42 @@ export default function AdminSidebar({ activeTab, onTabChange, isAdmin }: AdminS
   return (
     <View
       style={[
-        styles.container,
+        compact ? styles.compactContainer : styles.container,
         {
           backgroundColor: isDark ? '#1a1a1a' : '#F5F5F4',
-          borderRightColor: isDark ? '#262626' : '#E7E5E4',
+          borderRightColor: compact ? 'transparent' : isDark ? '#262626' : '#E7E5E4',
+          borderBottomColor: compact ? isDark ? '#262626' : '#E7E5E4' : 'transparent',
         },
       ]}
     >
-      <Text style={styles.header}>Admin</Text>
+      <Text style={compact ? styles.compactHeader : styles.header}>Admin</Text>
 
-      {visibleTabs.map(({ key, label, Icon }) => {
-        const isActive = activeTab === key
-        const color = isActive ? '#E8862A' : inactiveColor
+      <ScrollView
+        horizontal={compact}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={compact ? styles.compactTabs : undefined}
+      >
+        {visibleTabs.map(({ key, label, Icon }) => {
+          const isActive = activeTab === key
+          const color = isActive ? '#E8862A' : inactiveColor
 
-        return (
-          <Pressable
-            key={key}
-            onPress={() => onTabChange(key)}
-            style={[
-              styles.tab,
-              isActive && styles.tabActive,
-            ]}
-          >
-            <Icon size={18} color={color} />
-            <Text style={[styles.tabLabel, { color }]}>{label}</Text>
-          </Pressable>
-        )
-      })}
+          return (
+            <Pressable
+              key={key}
+              onPress={() => onTabChange(key)}
+              style={[
+                compact ? styles.compactTab : styles.tab,
+                isActive && styles.tabActive,
+              ]}
+            >
+              <Icon size={18} color={color} />
+              <Text style={[styles.tabLabel, compact && styles.compactTabLabel, { color }]} numberOfLines={1}>
+                {label}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </ScrollView>
     </View>
   )
 }
@@ -74,12 +84,28 @@ const styles = StyleSheet.create({
     paddingTop: 20,
     paddingHorizontal: 12,
   },
+  compactContainer: {
+    borderBottomWidth: 1,
+    paddingTop: 10,
+    paddingBottom: 8,
+  },
   header: {
     fontFamily: 'Inclusive Sans',
     fontSize: 15,
     color: '#E8862A',
     marginBottom: 20,
     paddingHorizontal: 8,
+  },
+  compactHeader: {
+    fontFamily: 'Inclusive Sans',
+    fontSize: 14,
+    color: '#E8862A',
+    marginBottom: 8,
+    paddingHorizontal: 16,
+  },
+  compactTabs: {
+    gap: 6,
+    paddingHorizontal: 12,
   },
   tab: {
     flexDirection: 'row',
@@ -89,6 +115,14 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginBottom: 4,
   },
+  compactTab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 38,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+  },
   tabActive: {
     backgroundColor: 'rgba(232,134,42,0.12)',
   },
@@ -96,5 +130,9 @@ const styles = StyleSheet.create({
     fontFamily: 'Inclusive Sans',
     fontSize: 14,
     marginLeft: 10,
+  },
+  compactTabLabel: {
+    fontSize: 13,
+    marginLeft: 7,
   },
 })

--- a/packages/frontend/components/admin/CentersTab.tsx
+++ b/packages/frontend/components/admin/CentersTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
-import { View, Text, Pressable, ActivityIndicator, TextInput } from 'react-native'
+import { View, Text, Pressable, ActivityIndicator, TextInput, useWindowDimensions } from 'react-native'
 import { MapPin, Globe, Phone, User, Image as ImageIcon, Pencil } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminDetailPanel from './AdminDetailPanel'
@@ -24,7 +24,9 @@ import { useAnalytics } from '../../utils/analytics'
 export default function CentersTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
+  const isCompact = width < 640
   const [search, setSearch] = useState('')
   const [centers, setCenters] = useState<CenterData[]>([])
   const [total, setTotal] = useState(0)
@@ -250,12 +252,20 @@ export default function CentersTab() {
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>
-      <View style={{ flex: 1, padding: 20 }}>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+      <View style={{ flex: 1, padding: isCompact ? 14 : 20 }}>
+        <View
+          style={{
+            flexDirection: isCompact ? 'column' : 'row',
+            justifyContent: 'space-between',
+            alignItems: isCompact ? 'stretch' : 'center',
+            gap: 10,
+            marginBottom: 16,
+          }}
+        >
           <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 18, color: colors.text }}>
             Centers ({total})
           </Text>
-          <View style={{ width: 260 }}>
+          <View style={{ width: isCompact ? '100%' : 260 }}>
             <AdminSearchInput value={search} onChangeText={setSearch} placeholder="Search centers..." />
           </View>
         </View>

--- a/packages/frontend/components/admin/EventsTab.tsx
+++ b/packages/frontend/components/admin/EventsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
-import { View, Text, Pressable, ActivityIndicator } from 'react-native'
+import { View, Text, Pressable, ActivityIndicator, useWindowDimensions } from 'react-native'
 import { MapPin, Clock, Users, FileText } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminDetailPanel from './AdminDetailPanel'
@@ -28,7 +28,9 @@ const formatTime = (dateStr: string) => {
 export default function EventsTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
+  const isCompact = width < 640
   const [search, setSearch] = useState('')
   const [events, setEvents] = useState<EventData[]>([])
   const [total, setTotal] = useState(0)
@@ -138,12 +140,20 @@ export default function EventsTab() {
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>
-      <View style={{ flex: 1, padding: 20 }}>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+      <View style={{ flex: 1, padding: isCompact ? 14 : 20 }}>
+        <View
+          style={{
+            flexDirection: isCompact ? 'column' : 'row',
+            justifyContent: 'space-between',
+            alignItems: isCompact ? 'stretch' : 'center',
+            gap: 10,
+            marginBottom: 16,
+          }}
+        >
           <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 18, color: colors.text }}>
             Events ({total})
           </Text>
-          <View style={{ width: 240 }}>
+          <View style={{ width: isCompact ? '100%' : 240 }}>
             <AdminSearchInput value={search} onChangeText={setSearch} placeholder="Search events..." />
           </View>
         </View>

--- a/packages/frontend/components/admin/ModerationTab.tsx
+++ b/packages/frontend/components/admin/ModerationTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react'
-import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native'
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, useWindowDimensions } from 'react-native'
 import { Trash2, UserX, Flag, ScrollText, ArrowLeft } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminDetailPanel from './AdminDetailPanel'
@@ -33,7 +33,9 @@ type PendingAction =
 
 export default function ModerationTab() {
   const colors = useDetailColors()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
+  const isCompact = width < 640
 
   const [items, setItems] = useState<ModerationQueueItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -349,13 +351,13 @@ export default function ModerationTab() {
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.tablePanel}>
-        <View style={styles.header}>
-          <Text style={[styles.title, { color: colors.text }]}>
-            Moderation queue ({items.length})
-          </Text>
-          <View style={{ flexDirection: 'row', gap: 8 }}>
+      <View style={styles.container}>
+        <View style={styles.tablePanel}>
+          <View style={[styles.header, isCompact && styles.compactHeader]}>
+            <Text style={[styles.title, { color: colors.text }]}>
+              Moderation queue ({items.length})
+            </Text>
+          <View style={[styles.headerActions, isCompact && styles.compactHeaderActions]}>
             <Pressable
               onPress={() => setIncludeResolved((v) => !v)}
               style={[styles.pill, includeResolved && styles.pillActive]}
@@ -418,6 +420,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
+  compactHeader: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: 10,
+  },
+  headerActions: { flexDirection: 'row', gap: 8 },
+  compactHeaderActions: { flexWrap: 'wrap' },
   title: { fontFamily: 'Inclusive Sans', fontSize: 16 },
   pill: {
     paddingHorizontal: 12,

--- a/packages/frontend/components/admin/NotificationsTab.tsx
+++ b/packages/frontend/components/admin/NotificationsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { View, Text, Pressable, ActivityIndicator, TextInput, ScrollView } from 'react-native'
+import { View, Text, Pressable, ActivityIndicator, TextInput, ScrollView, useWindowDimensions } from 'react-native'
 import { Bell, Send, Trash2, ChevronDown } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminSearchInput from './AdminSearchInput'
@@ -29,7 +29,9 @@ const NOTIFICATION_TYPE_NAMES: Record<number, string> = {
 export default function NotificationsTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
+  const isCompact = width < 640
   const [notifications, setNotifications] = useState<AdminNotification[]>([])
   const [stats, setStats] = useState<AdminNotificationStats | null>(null)
   const [total, setTotal] = useState(0)
@@ -225,10 +227,10 @@ export default function NotificationsTab() {
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>
-      <View style={{ flex: 1, padding: 20 }}>
+      <View style={{ flex: 1, padding: isCompact ? 14 : 20 }}>
         {/* Stats bar */}
         {stats && (
-          <View style={{ flexDirection: 'row', gap: 16, marginBottom: 16 }}>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: isCompact ? 8 : 16, marginBottom: 16 }}>
             {[
               { label: 'Total', value: stats.total },
               { label: 'Unread', value: stats.unread },
@@ -257,14 +259,22 @@ export default function NotificationsTab() {
         )}
 
         {/* Header row */}
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <View
+          style={{
+            flexDirection: isCompact ? 'column' : 'row',
+            justifyContent: 'space-between',
+            alignItems: isCompact ? 'stretch' : 'center',
+            gap: 10,
+            marginBottom: 16,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
             <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 18, color: colors.text }}>
               Notifications ({total})
             </Text>
 
             {/* Type filter */}
-            <View style={{ flexDirection: 'row', gap: 4 }}>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 4 }}>
               <Pressable
                 onPress={() => setFilterType(undefined)}
                 style={{
@@ -315,6 +325,7 @@ export default function NotificationsTab() {
               paddingHorizontal: 14,
               paddingVertical: 8,
               borderRadius: 8,
+              alignSelf: isCompact ? 'flex-start' : 'auto',
             }}
           >
             <Send size={14} color="#fff" />
@@ -336,7 +347,7 @@ export default function NotificationsTab() {
               Send Notification
             </Text>
 
-            <View style={{ flexDirection: 'row', gap: 12, marginBottom: 10 }}>
+            <View style={{ flexDirection: isCompact ? 'column' : 'row', gap: 12, marginBottom: 10 }}>
               <View style={{ flex: 1 }}>
                 <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 11, color: colors.textMuted, marginBottom: 4 }}>Title</Text>
                 <TextInput
@@ -357,7 +368,7 @@ export default function NotificationsTab() {
                   }}
                 />
               </View>
-              <View style={{ width: 160 }}>
+              <View style={{ width: isCompact ? '100%' : 160 }}>
                 <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 11, color: colors.textMuted, marginBottom: 4 }}>Type</Text>
                 <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 4 }}>
                   {[7, 6].map((tid) => (
@@ -408,7 +419,7 @@ export default function NotificationsTab() {
               />
             </View>
 
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 12, marginBottom: 12 }}>
               <Pressable
                 onPress={() => setSendBroadcast(true)}
                 style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
@@ -461,7 +472,7 @@ export default function NotificationsTab() {
                     borderRadius: 6,
                     paddingHorizontal: 10,
                     paddingVertical: 6,
-                    width: 200,
+                    width: isCompact ? '100%' : 200,
                   }}
                 />
               )}
@@ -528,10 +539,20 @@ export default function NotificationsTab() {
       {/* Detail panel */}
       {selected && (
         <View style={{
-          width: 320,
-          borderLeftWidth: 1,
+          width: isCompact ? '100%' : 320,
+          borderLeftWidth: isCompact ? 0 : 1,
           borderLeftColor: colors.border,
           backgroundColor: colors.panelBg,
+          ...(isCompact
+            ? {
+                position: 'absolute' as const,
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+                zIndex: 20,
+              }
+            : null),
         }}>
           <View style={{
             flexDirection: 'row',

--- a/packages/frontend/components/admin/UsersTab.tsx
+++ b/packages/frontend/components/admin/UsersTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react'
-import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native'
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, useWindowDimensions } from 'react-native'
 import { Building2, Calendar, Shield } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminDetailPanel from './AdminDetailPanel'
@@ -48,7 +48,9 @@ function formatJoinDate(iso?: string): string {
 export default function UsersTab() {
   const colors = useDetailColors()
   const { isDark } = useTheme()
+  const { width } = useWindowDimensions()
   const { track } = useAnalytics()
+  const isCompact = width < 640
 
   const [search, setSearch] = useState('')
   const [users, setUsers] = useState<UserData[]>([])
@@ -281,9 +283,9 @@ export default function UsersTab() {
   return (
     <View style={styles.container}>
       <View style={styles.tablePanel}>
-        <View style={styles.header}>
+        <View style={[styles.header, isCompact && styles.compactHeader]}>
           <Text style={[styles.title, { color: colors.text }]}>Users ({total})</Text>
-          <View style={styles.searchWrap}>
+          <View style={isCompact ? styles.compactSearchWrap : styles.searchWrap}>
             <AdminSearchInput value={search} onChangeText={setSearch} placeholder="Search users..." />
           </View>
         </View>
@@ -331,8 +333,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
+  compactHeader: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: 10,
+  },
   title: { fontFamily: 'Inclusive Sans', fontSize: 16 },
   searchWrap: { width: 240 },
+  compactSearchWrap: { width: '100%' },
 })
 
 const detailStyles = StyleSheet.create({


### PR DESCRIPTION
Makes the web admin dashboard usable on a phone (compact layout < 768px). Pairs with the sibling PR that opens the web admin from the iOS home shortcut.

- Admin shell → column layout on narrow widths
- `AdminSidebar` → horizontal scrolling tab strip
- `AdminDetailPanel` → full-screen overlay
- Centers / Events / Moderation / Notifications / Users tabs adapt to narrow width

Note: this was uncommitted work already in the tree; reviewed (coherent responsive pass, no debug/leftovers) and split into its own PR. Validation: typecheck ✓, frontend tests 197/197 ✓ (run on the combined tree).