### PR TITLE
Gate event creation to coordinators (sevak+)

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -397,6 +397,10 @@ describe('invite gate (#403)', () => {
     beforeEach(async () => {
       const adminToken = await createAdmin()
       const { token } = await registerAndLogin('host', 'password123')
+      // Event creation is coordinator-gated (sevak+); the host is a coordinator.
+      await env.DB.prepare('UPDATE users SET verification_level = 54 WHERE username = ?')
+        .bind('host')
+        .run()
       const { body: center } = await jsonPost(
         '/api/addCenter',
         { centerName: 'Guest Center', latitude: 37.0, longitude: -121.0 },
@@ -1915,6 +1919,11 @@ describe('event routes', () => {
     adminToken = await createAdmin()
     const { token } = await registerAndLogin('eventuser', 'password123')
     userToken = token
+    // Event creation is coordinator-gated (sevak+). The fixture creator is a
+    // pilot coordinator, so promote it to SEVAK.
+    await env.DB.prepare('UPDATE users SET verification_level = 54 WHERE username = ?')
+      .bind('eventuser')
+      .run()
 
     // Create a center for events (requires auth now)
     const { body } = await jsonPost(
@@ -1946,6 +1955,22 @@ describe('event routes', () => {
       expect(res.status).toBe(200)
       expect(body.id).toBeDefined()
       expect(typeof body.tier).toBe('number')
+    })
+
+    it('rejects a non-coordinator (normal member) with 403', async () => {
+      const { token: memberToken } = await registerAndLogin('plainmember-evt', 'password123')
+      const { res } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'Unauthorized Event',
+          date: '2025-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: centerId,
+        },
+        authHeader(memberToken)
+      )
+      expect(res.status).toBe(403)
     })
 
     it('rejects missing centerID (400)', async () => {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1904,6 +1904,14 @@ app.post('/boards/posts/:postId/report', authMiddleware, rateLimit(10, 60_000), 
 
 app.post('/addEvent', authMiddleware, async (c) => {
   const user = c.get('user')
+
+  // Event creation is coordinator-gated: only sevak-and-above (or a global
+  // admin) can create events. Beta coordinators (e.g. SJ/Dallas pilots) are
+  // provisioned at SEVAK; they invite normal members to their center.
+  if (!isAdmin(user) && (user.verification_level ?? 0) < SEVAK) {
+    return c.json({ message: 'Only coordinators can create events' }, 403)
+  }
+
   const data = await c.req.json<{
     title?: string
     description?: string

--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -30,6 +30,7 @@ import { useTheme } from '../../components/contexts'
 import { Badge, Avatar, FilterChip } from '../../components/ui'
 import { type FilterPickerOption } from '../../components/ui/FilterPickerModal'
 import { useUser } from '../../components/contexts/UserContext'
+import { isSevakOrAdmin } from '../../utils/admin'
 import { useDiscoverData, type DiscoverFilter } from '../../hooks/useApiData'
 import type { EventDisplay, DiscoverCenter, AttendeeInfo } from '../../utils/api'
 import { extractCityState } from '../../utils/addressParsing'
@@ -764,7 +765,7 @@ export default function DiscoverScreen() {
                     />
                   )}
                 </View>
-                {user && (
+                {isSevakOrAdmin(user) && (
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Create event"

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -40,7 +40,7 @@ import type { MapPoint, EventDisplay, AttendeeInfo } from '../../utils/api'
 import { removeEvent } from '../../utils/api'
 import { extractCityState } from '../../utils/addressParsing'
 import { WeekCalendar } from '../../components'
-import { ADMIN_EMAIL, isLocal } from '../../utils/admin'
+import { ADMIN_EMAIL, isLocal, isSevakOrAdmin } from '../../utils/admin'
 import { EmptyState } from '../../components/ui/EmptyState'
 import { DiscoverListSkeleton } from '../../components/ui/Skeleton'
 import { ExploreEventItem } from '../../components/explore/ExploreEventItem.web'
@@ -256,9 +256,9 @@ export default function DiscoverScreenWeb() {
   const { user } = useUser()
   const { track } = useAnalytics()
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
-  // Beta: any signed-in user can create events. Backend enforces auth-only;
-  // post-beta this becomes a coordinator-tier gate (see issue tracker).
-  const canCreate = !!user
+  // Event creation is coordinator-gated: only sevak-and-above (or admins) see
+  // the create entry point. Mirrors the backend /addEvent gate.
+  const canCreate = isSevakOrAdmin(user)
   // Events-first: the desktop sidebar always shows the events list (the old
   // Events/Centers tab model was dropped to match native explore.tsx and the
   // mobile-web fallback).

--- a/packages/frontend/components/explore/MobileDiscoverFallback.web.tsx
+++ b/packages/frontend/components/explore/MobileDiscoverFallback.web.tsx
@@ -14,6 +14,7 @@ import { DiscoverListSkeleton } from '../ui/Skeleton'
 import { FilterChip } from '../ui'
 import type { FilterPickerOption } from '../ui/FilterPickerModal'
 import { useTheme, useUser } from '../contexts'
+import { isSevakOrAdmin } from '../../utils/admin'
 import { useAnalytics } from '../../utils/analytics'
 import { extractCityState } from '../../utils/addressParsing'
 import { useDiscoverData, type DiscoverFilter } from '../../hooks/useApiData'
@@ -520,7 +521,7 @@ export function MobileDiscoverFallback() {
                     />
                   )}
                 </View>
-                {user && (
+                {isSevakOrAdmin(user) && (
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel="Create event"


### PR DESCRIPTION
## What
Locks event creation to **coordinators (verification_level ≥ SEVAK / 54)** or global admins. This implements the beta decision: only admins create events; pilot coordinators (San Jose / Dallas) get admin access and invite normal members to their center.

Previously *any* signed-in user saw the "Create" button — that was temporary beta scaffolding (`explore.web.tsx` literally said *"Beta: any signed-in user can create events… post-beta this becomes a coordinator-tier gate"*). This turns the gate on.

## Changes
- **Backend** `POST /addEvent`: rejects below-SEVAK callers with `403` (admins still allowed).
- **Frontend**: hides the Create entry point on Discover for non-coordinators via `isSevakOrAdmin(user)` — covers all three entry points:
  - `app/(tabs)/explore.tsx` (native)
  - `app/(tabs)/explore.web.tsx` (desktop web)
  - `components/explore/MobileDiscoverFallback.web.tsx` (mobile web)
- **Tests**: promote the event-creating fixtures to SEVAK (they represent coordinators); add a negative test asserting a normal member gets `403`.

## Notes
- Edit/delete gates are unchanged (already creator-or-admin on both platforms).
- Beta coordinators must be provisioned at level 54 in prod D1 (ops task, tracked separately).
- Part of the round-1 event-admin work; companion PRs: admin attendee roster + CSV export, guest-RSVP open-by-default, invite-link share fix.

## Test plan
- [x] `npm run typecheck` (backend + frontend) clean
- [x] `npm run test` backend — 432 passing (incl. new 403 test)
- [ ] Manual: as a normal member, no Create button on Discover (native/desktop/mobile-web); as sevak/admin, Create is present and works