### PR TITLE
Coordinator attendee roster + CSV export on the event page

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -2167,6 +2167,67 @@ describe('event routes', () => {
     })
   })
 
+  describe('GET /api/events/:id/roster', () => {
+    async function createEvent() {
+      const { body } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'Roster Event',
+          date: '2030-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: centerId,
+        },
+        authHeader(userToken),
+      )
+      return body.id as string
+    }
+
+    it('returns registered members (with email) + guests to the creator', async () => {
+      const eventId = await createEvent()
+      await jsonPost('/api/attendEvent', { eventID: eventId }, authHeader(userToken))
+      await jsonPost('/api/attendEventGuest', {
+        eventID: eventId,
+        name: 'Guest Person',
+        email: 'guest@example.com',
+      })
+
+      const { res, body } = await fetchJSON(`/api/events/${eventId}/roster`, {
+        headers: authHeader(userToken),
+      })
+      expect(res.status).toBe(200)
+      expect(body.counts).toEqual({ registered: 1, guests: 1, total: 2 })
+      expect(body.registered[0].email).toBe('eventuser')
+      expect(body.guests[0].email).toBe('guest@example.com')
+      expect(body.guests[0].name).toBe('Guest Person')
+    })
+
+    it('rejects a non-creator, non-admin viewer with 403', async () => {
+      const eventId = await createEvent()
+      const { token: stranger } = await registerAndLogin('roster-stranger', 'password123')
+      const { res } = await fetchJSON(`/api/events/${eventId}/roster`, {
+        headers: authHeader(stranger),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('lets an admin view any event roster', async () => {
+      const eventId = await createEvent()
+      const { res, body } = await fetchJSON(`/api/events/${eventId}/roster`, {
+        headers: authHeader(adminToken),
+      })
+      expect(res.status).toBe(200)
+      expect(body.counts.total).toBe(0)
+    })
+
+    it('returns 404 for an unknown event', async () => {
+      const { res } = await fetchJSON('/api/events/does-not-exist/roster', {
+        headers: authHeader(adminToken),
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+
   describe('POST /api/removeEvent', () => {
     it('admin can remove an event', async () => {
       const { body: addBody } = await jsonPost(

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2198,6 +2198,45 @@ app.post('/getEventUsers', async (c) => {
   })
 })
 
+// Coordinator-only attendee roster. Unlike /getEventUsers (public, avatar-only
+// display), this returns emails + account-less guest RSVPs and is gated to the
+// event's creator or an admin — the "replaces the Google Form / spreadsheet"
+// view that lives on the event page.
+app.get('/events/:id/roster', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const id = c.req.param('id')
+
+  const event = await db.getEventById(c.env.DB, id)
+  if (!event) {
+    return c.json({ message: 'Event not found' }, 404)
+  }
+
+  const canManage = isAdmin(user) || (!!event.created_by && event.created_by === user.id)
+  if (!canManage) {
+    return c.json(
+      { message: 'Only the event creator or an admin can view the attendee roster' },
+      403,
+    )
+  }
+
+  const { registered, guests } = await db.getEventRoster(c.env.DB, id)
+  return c.json({
+    registered: registered.map((r) => ({
+      id: r.id,
+      name: [r.first_name, r.last_name].filter(Boolean).join(' ').trim() || r.username,
+      email: r.email,
+      image: r.profile_image,
+      joinedAt: r.joined_at,
+    })),
+    guests: guests.map((g) => ({ name: g.name, email: g.email, rsvpedAt: g.rsvped_at })),
+    counts: {
+      registered: registered.length,
+      guests: guests.length,
+      total: registered.length + guests.length,
+    },
+  })
+})
+
 app.post('/attendEvent', authMiddleware, async (c) => {
   const user = c.get('user')
   const { eventID } = await c.req.json<{ eventID: string }>()

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -670,6 +670,57 @@ export async function getEventAttendees(
   return result.results ?? []
 }
 
+export interface EventRosterRegisteredRow {
+  id: string
+  username: string
+  email: string | null
+  first_name: string | null
+  last_name: string | null
+  profile_image: string | null
+  joined_at: string
+}
+
+export interface EventRosterGuestRow {
+  email: string
+  name: string
+  rsvped_at: string
+}
+
+/**
+ * Full attendee roster for an event's coordinator — registered members (with
+ * email + join date) plus account-less guest RSVPs that haven't been upgraded
+ * into a real account yet. This is the gated "replaces the Google Form" view;
+ * the caller (route) enforces creator/admin access before returning PII.
+ */
+export async function getEventRoster(
+  db: D1Database,
+  eventId: string,
+): Promise<{ registered: EventRosterRegisteredRow[]; guests: EventRosterGuestRow[] }> {
+  const registered = await db
+    .prepare(
+      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.profile_image,
+              ea.created_at AS joined_at
+       FROM users u
+       JOIN event_attendees ea ON ea.user_id = u.id
+       WHERE ea.event_id = ?1
+       ORDER BY ea.created_at DESC`,
+    )
+    .bind(eventId)
+    .all<EventRosterRegisteredRow>()
+  // Only guests not yet upgraded — once a guest signs up + verifies, they
+  // become a real attendee row and would otherwise be double-counted.
+  const guests = await db
+    .prepare(
+      `SELECT email, name, created_at AS rsvped_at
+       FROM event_guest_rsvps
+       WHERE event_id = ?1 AND upgraded_user_id IS NULL
+       ORDER BY created_at DESC`,
+    )
+    .bind(eventId)
+    .all<EventRosterGuestRow>()
+  return { registered: registered.results ?? [], guests: guests.results ?? [] }
+}
+
 /**
  * IDs of every user "part of" a board, for notification fan-out (#102).
  *   - center board: users whose home center matches

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -174,6 +174,7 @@ function EventPanelInner({
         attendees={attendees}
         isPast={isPast}
         isAdmin={isAdmin}
+        canManage={canEdit}
         onClose={onClose}
         onToggleRegistration={handleToggleRegistration}
         isToggling={isToggling}

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -26,6 +26,7 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../compon
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
+import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
@@ -823,6 +824,13 @@ export default function EventDetailPage() {
             ) : null}
             <AttendeesContent attendees={attendees} colors={colors} />
           </DetailSection>
+        )}
+
+        {/* COORDINATOR ROSTER — creator/admin only: full list w/ emails + guests + CSV export */}
+        {canEdit && (
+          <View style={{ paddingHorizontal: 20 }}>
+            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
+          </View>
         )}
 
         {/* COMMENTS — board posts, feed-style. Composer sits at the top of the

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -12,6 +12,7 @@ import Badge from '../../components/ui/Badge'
 import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
 import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
+import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 import { DetailSection } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
@@ -318,6 +319,13 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
               </View>
             )}
           </DetailSection>
+        )}
+
+        {/* COORDINATOR ROSTER — creator/admin only: full list w/ emails + guests + CSV export */}
+        {canEdit && (
+          <View style={{ paddingHorizontal: 20 }}>
+            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
+          </View>
         )}
 
         {/* COMMENTS */}

--- a/packages/frontend/components/events/EventAttendeeRoster.tsx
+++ b/packages/frontend/components/events/EventAttendeeRoster.tsx
@@ -1,0 +1,263 @@
+// Coordinator-only attendee roster shown on the event page (native + web).
+// Renders the full list of who RSVP'd — registered members (with email) and
+// account-less guests — plus a CSV export. This is the "replaces the Google
+// Form / spreadsheet" surface for event coordinators (creator or admin).
+//
+// The caller is responsible for only rendering this when the viewer can manage
+// the event (creator or admin); the backend /events/:id/roster route enforces
+// the same gate, so a non-coordinator who somehow renders it gets a 403.
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  Image,
+  Platform,
+  Share,
+} from 'react-native'
+import { Users, Download } from 'lucide-react-native'
+import { useDetailColors } from '../../hooks/useDetailColors'
+import { getEventRoster, type EventRoster, type EventRosterEntry } from '../../utils/api'
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+function csvCell(value: string | null | undefined): string {
+  const s = value == null ? '' : String(value)
+  // Quote when the value contains a delimiter, quote, or newline; escape quotes.
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+function buildCsv(roster: EventRoster): string {
+  const rows: string[][] = [['Name', 'Email', 'Type', 'RSVP date']]
+  roster.registered.forEach((r) =>
+    rows.push([r.name, r.email ?? '', 'Member', r.joinedAt ?? '']),
+  )
+  roster.guests.forEach((g) => rows.push([g.name, g.email ?? '', 'Guest', g.rsvpedAt ?? '']))
+  return rows.map((cols) => cols.map(csvCell).join(',')).join('\n')
+}
+
+function slugify(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'event'
+  )
+}
+
+function Row({ entry, isGuest }: { entry: EventRosterEntry; isGuest: boolean }) {
+  const c = useDetailColors()
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+        paddingVertical: 8,
+        borderTopWidth: 1,
+        borderTopColor: c.border,
+      }}
+    >
+      {entry.image ? (
+        <Image
+          source={{ uri: entry.image }}
+          style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: c.iconBoxBg }}
+        />
+      ) : (
+        <View
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 16,
+            backgroundColor: c.iconBoxBg,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: c.textSecondary }}>
+            {initialsOf(entry.name)}
+          </Text>
+        </View>
+      )}
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text
+          style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: c.text }}
+          numberOfLines={1}
+        >
+          {entry.name}
+        </Text>
+        {entry.email ? (
+          <Text
+            style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: c.textMuted }}
+            numberOfLines={1}
+          >
+            {entry.email}
+          </Text>
+        ) : null}
+      </View>
+      {isGuest ? (
+        <View
+          style={{
+            paddingHorizontal: 8,
+            paddingVertical: 2,
+            borderRadius: 999,
+            backgroundColor: c.iconBoxBg,
+          }}
+        >
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 11, color: c.textSecondary }}>
+            Guest
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+export default function EventAttendeeRoster({
+  eventId,
+  eventTitle,
+}: {
+  eventId: string
+  eventTitle?: string
+}) {
+  const c = useDetailColors()
+  const [roster, setRoster] = useState<EventRoster | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      setRoster(await getEventRoster(eventId))
+    } catch (err: any) {
+      setError(err?.status === 403 ? 'You do not have access to this roster.' : 'Failed to load attendees.')
+    } finally {
+      setLoading(false)
+    }
+  }, [eventId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const onExport = useCallback(async () => {
+    if (!roster || roster.counts.total === 0) return
+    setExporting(true)
+    try {
+      const csv = buildCsv(roster)
+      const filename = `${slugify(eventTitle ?? '')}-attendees.csv`
+      if (Platform.OS === 'web') {
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = filename
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+        URL.revokeObjectURL(url)
+      } else {
+        // Native: share the CSV text via the OS share sheet (Mail, Files, etc.).
+        await Share.share({ message: csv, title: filename })
+      }
+    } catch (err: any) {
+      if (__DEV__) console.warn('[EventAttendeeRoster] export failed:', err?.message || err)
+    } finally {
+      setExporting(false)
+    }
+  }, [roster, eventTitle])
+
+  const total = roster?.counts.total ?? 0
+
+  return (
+    <View
+      style={{
+        marginTop: 16,
+        padding: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: c.border,
+        backgroundColor: c.cardBg,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+        }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flexShrink: 1 }}>
+          <Users size={16} color={c.iconHeader} />
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, color: c.text }}>
+            Manage attendees
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Export attendees as CSV"
+          onPress={onExport}
+          disabled={loading || exporting || total === 0}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 6,
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 999,
+            borderWidth: 1.5,
+            borderColor: '#E8862A',
+            opacity: loading || total === 0 ? 0.4 : 1,
+          }}
+        >
+          <Download size={14} color="#E8862A" strokeWidth={2.5} />
+          <Text style={{ fontFamily: 'Inclusive Sans', fontWeight: '600', fontSize: 13, color: '#E8862A' }}>
+            {exporting ? 'Exporting…' : 'Export CSV'}
+          </Text>
+        </Pressable>
+      </View>
+
+      {!loading && !error && roster ? (
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: c.textMuted, marginTop: 4 }}>
+          {roster.counts.registered} member{roster.counts.registered === 1 ? '' : 's'}
+          {roster.counts.guests > 0
+            ? ` · ${roster.counts.guests} guest${roster.counts.guests === 1 ? '' : 's'}`
+            : ''}
+        </Text>
+      ) : null}
+
+      {loading ? (
+        <View style={{ paddingVertical: 20, alignItems: 'center' }}>
+          <ActivityIndicator color="#E8862A" />
+        </View>
+      ) : error ? (
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: '#DC2626', marginTop: 10 }}>
+          {error}
+        </Text>
+      ) : total === 0 ? (
+        <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: c.textMuted, marginTop: 10 }}>
+          No RSVPs yet.
+        </Text>
+      ) : (
+        <View style={{ marginTop: 8 }}>
+          {roster!.registered.map((r) => (
+            <Row key={`m-${r.id ?? r.email ?? r.name}`} entry={r} isGuest={false} />
+          ))}
+          {roster!.guests.map((g) => (
+            <Row key={`g-${g.email ?? g.name}`} entry={g} isGuest />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -14,6 +14,7 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../boards'
 import { PostThread, type FeedPost } from '../feed'
 import { buildFeedPostFromMessage } from '../feed/feedData'
 import { useUser } from '../contexts'
+import EventAttendeeRoster from './EventAttendeeRoster'
 
 // ---------------------------------------------------------------------------
 // Date helpers
@@ -115,6 +116,9 @@ type EventDetailPanelProps = {
   attendees: Attendee[]
   isPast?: boolean
   isAdmin?: boolean
+  // Creator-or-admin: shows the coordinator attendee roster (emails + guests +
+  // CSV export). Distinct from isAdmin (which is global-admin only).
+  canManage?: boolean
   onClose: () => void
   onToggleRegistration: () => void
   isToggling: boolean
@@ -620,11 +624,13 @@ function DefaultContent({
   event,
   attendees,
   isPast,
+  canManage,
   colors,
 }: {
   event: EventDetailPanelProps['event']
   attendees: Attendee[]
   isPast?: boolean
+  canManage?: boolean
   colors: DetailColors
 }) {
   return (
@@ -659,6 +665,9 @@ function DefaultContent({
       {event.description && (
         <AboutSection description={event.description} colors={colors} />
       )}
+
+      {/* Coordinator roster — creator/admin only */}
+      {canManage && <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />}
     </ScrollView>
   )
 }
@@ -671,6 +680,7 @@ function RegisteredContent({
   event,
   attendees,
   colors,
+  canManage,
   canPostToThread,
   boardMessages,
   onSubmitPost,
@@ -679,6 +689,7 @@ function RegisteredContent({
   event: EventDetailPanelProps['event']
   attendees: Attendee[]
   colors: DetailColors
+  canManage?: boolean
   canPostToThread: boolean
   boardMessages: BoardMessage[]
   onSubmitPost: (body: string) => Promise<void>
@@ -716,6 +727,13 @@ function RegisteredContent({
         <DetailSection title="People" count={attendees.length} contentStyle={{ paddingHorizontal: 0 }}>
           <PeopleTab attendees={attendees} colors={colors} />
         </DetailSection>
+
+        {/* Coordinator roster — creator/admin only */}
+        {canManage && (
+          <View style={{ paddingHorizontal: 24 }}>
+            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
+          </View>
+        )}
 
         {/* ── DISCUSSION ────────────────────────────────────────── */}
         <DetailSection title="Discussion" count={boardMessages.length} contentStyle={{ paddingHorizontal: 0 }}>
@@ -1001,6 +1019,7 @@ export default function EventDetailPanel({
   attendees,
   isPast,
   isAdmin,
+  canManage,
   onClose,
   onToggleRegistration,
   isToggling,
@@ -1101,6 +1120,7 @@ export default function EventDetailPanel({
           event={event}
           attendees={attendees}
           colors={colors}
+          canManage={canManage}
           canPostToThread={canPostToThread}
           boardMessages={boardMessages}
           onSubmitPost={handleCreateThreadPost}
@@ -1111,6 +1131,7 @@ export default function EventDetailPanel({
           event={event}
           attendees={attendees}
           isPast={isPast}
+          canManage={canManage}
           colors={colors}
         />
       )}

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -434,6 +434,42 @@ export async function fetchEventUsers(eventID: string): Promise<UserData[]> {
   }
 }
 
+// Coordinator-only attendee roster (creator or admin). Returns emails + guest
+// RSVPs for the "manage attendees / export" panel on the event page.
+export interface EventRosterEntry {
+  id?: string
+  name: string
+  email: string | null
+  image?: string | null
+  joinedAt?: string
+  rsvpedAt?: string
+}
+
+export interface EventRoster {
+  registered: EventRosterEntry[]
+  guests: EventRosterEntry[]
+  counts: { registered: number; guests: number; total: number }
+}
+
+export async function getEventRoster(eventID: string): Promise<EventRoster> {
+  const response = await authFetch(`/events/${encodeURIComponent(eventID)}/roster`, {
+    method: 'GET',
+  })
+  if (!response.ok) {
+    const err: any = new Error('Failed to load attendee roster')
+    err.status = response.status
+    throw err
+  }
+  const data = await response.json()
+  const normalize = (e: EventRosterEntry): EventRosterEntry =>
+    e.image && e.image.startsWith('/') ? { ...e, image: `${API_BASE_URL}${e.image}` } : e
+  return {
+    registered: (data.registered || []).map(normalize),
+    guests: data.guests || [],
+    counts: data.counts || { registered: 0, guests: 0, total: 0 },
+  }
+}
+
 /**
  * Account-less RSVP (new-11): name + email, no auth. Returns `alreadyRsvped`
  * so the sheet can show the dedupe state (new-11b). Throws with `.status` set


### PR DESCRIPTION
## What
Adds a **"Manage attendees"** panel to the event detail view, visible only to the **event creator or an admin**. It's the in-app replacement for the Google Form / spreadsheet coordinators use today — exactly what Siddharth described in his demo ("uses a Google Spreadsheet; asks name, email, phone").

It lives **on the event page itself** (per request), not in the separate admin portal: native full-screen, mobile-web route, and the desktop explore side panel.

## What it shows
- Full roster: registered members (name + **email**) and account-less **guests**, with a Member/Guest tag
- Counts ("N members · M guests")
- **Export CSV** — web: downloads a `.csv` file; native: OS share sheet

## Changes
- **Backend** `GET /events/:id/roster` — gated to creator-or-admin (mirrors the `/updateEvent` gate). Merges `event_attendees` (email + join date) with non-upgraded `event_guest_rsvps`, returns `counts`. New `db.getEventRoster()`.
- **Frontend** shared `<EventAttendeeRoster>` component (native + web) + `api.getEventRoster()`. Wired into `events/[id].tsx`, `events/[id].web.tsx`, and `EventDetailPanel.web.tsx` (new `canManage` prop, passed from explore).
- **Tests**: roster returns members+guests to creator; `403` for a non-coordinator; admin can view any roster; `404` for unknown event.

## Scope notes
- Read-only roster for v1 (no remove-attendee / messaging yet). The event **board** remains the in-app "contact attendees" path; CSV gives emails for external blasts.
- ⚠️ **Separate finding:** `/getEventUsers` is public (no auth) and `userRowToApi` returns `email`, `phoneNumber`, `dateOfBirth` — so attendee PII is currently exposed to anyone. Not touched here; flagged for its own fix.

## Test plan
- [x] `npm run typecheck` (backend + frontend) clean
- [x] `npm run test` backend — 435 passing (incl. 4 new roster tests)
- [ ] Manual: as event creator, open the event (desktop panel / mobile web / native) → see Manage attendees with members + a guest; Export CSV downloads/shares; as a non-coordinator, the panel is absent and the endpoint 403s