### PR TITLE
Security: stop /getEventUsers leaking attendee PII

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -2163,7 +2163,32 @@ describe('event routes', () => {
       const { res, body } = await jsonPost('/api/getEventUsers', { id: addBody.id })
       expect(res.status).toBe(200)
       expect(body.users).toHaveLength(1)
-      expect(body.users[0].username).toBe('eventuser')
+      expect(body.users[0].id).toBeDefined()
+    })
+
+    it('does NOT leak PII — no email/username/phone/DOB in the public list', async () => {
+      const { body: addBody } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'PII Event',
+          date: '2025-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: centerId,
+        },
+        authHeader(userToken),
+      )
+      await jsonPost('/api/attendEvent', { eventID: addBody.id }, authHeader(userToken))
+
+      const { body } = await jsonPost('/api/getEventUsers', { id: addBody.id })
+      const attendee = body.users[0]
+      expect(attendee).not.toHaveProperty('email')
+      expect(attendee).not.toHaveProperty('username')
+      expect(attendee).not.toHaveProperty('phoneNumber')
+      expect(attendee).not.toHaveProperty('dateOfBirth')
+      // Display-only fields remain.
+      expect(attendee).toHaveProperty('id')
+      expect(attendee).toHaveProperty('profileImage')
     })
   })
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -13,6 +13,7 @@ import { cors } from 'hono/cors'
 import type { Env, UserRow, EventRow, CenterRow, BoardPostApiResponse, BoardType } from './types'
 import {
   userRowToApi,
+  userRowToAttendee,
   userRowToPublicProfile,
   centerRowToApi,
   eventRowToApi,
@@ -2192,9 +2193,11 @@ app.post('/getEventUsers', async (c) => {
   }
 
   const attendees = await db.getEventAttendees(c.env.DB, id)
+  // Public endpoint — return display-only fields, never PII. (Coordinators get
+  // emails + guests via the gated GET /events/:id/roster.)
   return c.json({
     message: 'Success',
-    users: attendees.map((u) => userRowToApi(u)),
+    users: attendees.map((u) => userRowToAttendee(u)),
   })
 })
 

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -401,6 +401,26 @@ export function userRowToPublicProfile(
   }
 }
 
+// Minimal, display-only shape for a public attendee list. Deliberately omits
+// ALL PII — no email, phone, date_of_birth, suspension fields, AND no username
+// (in this app `username` currently holds the login email, so exposing it would
+// leak the email). Use this for any UNAUTHENTICATED list of other users.
+export interface AttendeeApiResponse {
+  id: string
+  firstName: string | null
+  lastName: string | null
+  profileImage: string | null
+}
+
+export function userRowToAttendee(row: UserRow): AttendeeApiResponse {
+  return {
+    id: row.id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    profileImage: row.profile_image,
+  }
+}
+
 export function centerRowToApi(row: CenterRow): CenterApiResponse {
   return {
     centerID: row.id,

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -276,12 +276,12 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           if (mounted) {
             setAttendees(
               users.map((u) => ({
-                name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+                name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
                 subtitle: '',
                 image: u.profileImage ?? undefined,
                 initials: u.firstName
                   ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                  : u.username.slice(0, 2).toUpperCase(),
+                  : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
               }))
             )
             // Check if current user is in attendees list
@@ -324,11 +324,11 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           // Re-fetch attendees after unregistering
           const updatedUsers = await fetchEventUsers(eventId)
           const newAttendeesList = updatedUsers.map((u) => ({
-            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
             image: u.profileImage || undefined,
             initials: u.firstName
               ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-              : u.username.slice(0, 2).toUpperCase(),
+              : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
           }))
           setEvent((prev) =>
             prev
@@ -343,12 +343,12 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           // Also update attendees state
           setAttendees(
             updatedUsers.map((u) => ({
-              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
               subtitle: '',
               image: u.profileImage ?? undefined,
               initials: u.firstName
                 ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                : u.username.slice(0, 2).toUpperCase(),
+                : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
             }))
           )
         } else {
@@ -358,11 +358,11 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           // Re-fetch attendees after registering
           const updatedUsers = await fetchEventUsers(eventId)
           const newAttendeesList = updatedUsers.map((u) => ({
-            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
             image: u.profileImage || undefined,
             initials: u.firstName
               ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-              : u.username.slice(0, 2).toUpperCase(),
+              : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
           }))
           setEvent((prev) =>
             prev
@@ -377,12 +377,12 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           // Also update attendees state
           setAttendees(
             updatedUsers.map((u) => ({
-              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
               subtitle: '',
               image: u.profileImage ?? undefined,
               initials: u.firstName
                 ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                : u.username.slice(0, 2).toUpperCase(),
+                : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
             }))
           )
         }
@@ -750,11 +750,11 @@ export function useDiscoverData(
           allApiEvents.map(async (e) => {
             const users = await fetchEventUsers(e.eventID)
             const attendeesList = users.map((u) => ({
-              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
+              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : (u.username ?? 'Member'),
               image: u.profileImage || undefined,
               initials: u.firstName
                 ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                : u.username.slice(0, 2).toUpperCase(),
+                : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
             }))
             const userIsRegistered = userId ? users.some((u) => u.id === userId) : false
             return {


### PR DESCRIPTION
## Problem
`POST /getEventUsers` is **public (no auth)** and returned the full `userRowToApi()` object for every attendee — leaking **email, phoneNumber, dateOfBirth**, and suspension internals to anyone who knows (or enumerates) an event ID. It powers the attendee avatar list, which only needs name + photo.

## Fix
- New display-only mapper `userRowToAttendee()` → `{ id, firstName, lastName, profileImage }`, used for the public attendee list.
- Also drops `username`, because in this app **`username` currently holds the login email** — exposing it would leak the email anyway. (That username==email coupling is a separate, larger cleanup; this PR is safe regardless of it.)
- Frontend: the 5 attendee-display sites fall back to `'Member'` / initials now that `username` isn't in the public payload (no crash on missing field).
- Coordinators still get full emails + guest RSVPs via the **gated** `GET /events/:id/roster` (separate PR #504).

## Test plan
- [x] `npm run typecheck` (backend + frontend) clean
- [x] backend tests — 432 passing, incl. a new assertion that the public list has **no** email/username/phone/DOB
- [x] frontend tests — 197 passing
- [ ] Manual: open an event with attendees → avatar list still shows names/photos; network response for `/getEventUsers` contains only id/firstName/lastName/profileImage

## Related
Surfaces the broader **username == email** data-model issue (login uses email, stored in `username`, with a parallel `email` column) — flagged for a dedicated decision/migration.