### PR TITLE
Guest RSVP: success copy no longer reads as 'create an account'

### DIFF
--- a/packages/frontend/components/events/GuestRsvpSheet.tsx
+++ b/packages/frontend/components/events/GuestRsvpSheet.tsx
@@ -142,7 +142,7 @@ export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }
                 You're going{forEvent}
               </Text>
               <Text style={{ fontSize: 14, fontFamily: 'Inclusive Sans', color: colors.textSecondary, textAlign: 'center', lineHeight: 21 }}>
-                Want the full app? Members join Janata by invite. Ask a member to send you one.
+                You're on the list — we'll send the details to your email. No account needed.
               </Text>
               <PrimaryButton onPress={close} style={{ alignSelf: 'stretch' }}>Done</PrimaryButton>
             </View>


### PR DESCRIPTION
## What
Account-less guest RSVP already works, and new events default to **open** (`requires_verified = 0`, confirmed in migration 0023 + `createEvent`). The "it asks me to create an account when I register" report traces to the **success-screen copy**, not a functional bug:

> "Want the full app? Members join Janata by invite. Ask a member to send you one."

Shown right after a successful RSVP, that reads like a required next step. Reworded to confirm completion and reassure no account is needed:

> "You're on the list — we'll send the details to your email. No account needed."

## Scope
- One-line copy change in `GuestRsvpSheet.tsx` (success state).
- The genuine verified-only path (event with `requires_verified = 1` → 403 → "This event needs an account / paste an invite") is **unchanged** — that gate is correct.
- No backend change; open-by-default already holds.

## Test plan
- [ ] On an open event as a signed-out guest: RSVP with name + email → success screen says "You're on the list… No account needed", RSVP recorded (no account prompt)
- [ ] On a verified-only event: guest RSVP still shows the "needs an account / paste invite" path