### PR TITLE
Show author profile pictures in feed + boards (not just initials)

### DIFF
--- a/packages/frontend/components/boards/ThreadPanel.tsx
+++ b/packages/frontend/components/boards/ThreadPanel.tsx
@@ -404,6 +404,7 @@ export function BoardPostCard({
           hitSlop={6}
         >
           <Avatar
+            image={message.author.image}
             name={message.author.name}
             initials={message.author.initials}
             size={42}

--- a/packages/frontend/components/boards/__mocks__/mockData.ts
+++ b/packages/frontend/components/boards/__mocks__/mockData.ts
@@ -7,6 +7,8 @@ export interface PersonSummary {
   subtitle?: string
   verification?: VerificationKind
   accentColor?: string
+  /** Absolute profile image URL; falls back to initials when absent. */
+  image?: string
 }
 
 export interface BoardMessage {

--- a/packages/frontend/components/boards/liveBoard.ts
+++ b/packages/frontend/components/boards/liveBoard.ts
@@ -44,6 +44,7 @@ export function boardPostToMessage(post: BoardPostData): BoardMessage {
       subtitle: post.author.centerID ? 'Verified member' : undefined,
       verification: verificationFor(post.author),
       accentColor: colorFor(post.author.id || 'member'),
+      image: post.author.profileImage ?? undefined,
     },
     timestamp: formatTimestamp(post.createdAt),
     body: post.body,

--- a/packages/frontend/components/feed/FeedPostCard.tsx
+++ b/packages/frontend/components/feed/FeedPostCard.tsx
@@ -68,6 +68,7 @@ export function FeedPostCard({
           hitSlop={6}
         >
           <Avatar
+            image={post.author.image}
             name={post.author.name}
             initials={post.author.initials}
             size={38}

--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -505,6 +505,7 @@ function PostMessageBlock({
         hitSlop={6}
       >
         <Avatar
+          image={message.author.image}
           name={message.author.name}
           initials={message.author.initials}
           size={original ? 42 : 34}
@@ -656,6 +657,7 @@ function OriginalPost({
         hitSlop={6}
       >
         <Avatar
+          image={post.author.image}
           name={post.author.name}
           initials={post.author.initials}
           size={42}

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -36,6 +36,7 @@ export function authorFromUser(user: User | null): PersonSummary {
     initials,
     verification: verificationFor(user),
     accentColor: colorFor(user.id || 'me'),
+    image: user.profileImage ?? undefined,
   }
 }
 


### PR DESCRIPTION
## What
From Abhiram's 6/16 TestFlight feedback: *"profile pictures do not appear in some areas."* Avatars are stored as absolute URLs, but the board/feed post mappers dropped the author's image — so every post/reply author rendered as **initials only** in the feed, center boards, and event boards.

## Fix
Threads `profileImage` from the API author all the way to the `<Avatar>`:
- `PersonSummary` gains an optional `image`
- `boardPostToMessage` (feed + boards) and `authorFromUser` (own optimistic posts) populate it from `author.profileImage`
- the four author-avatar render sites — `PostThread` (post + reply), `FeedPostCard`, `ThreadPanel` — pass `image`, keeping the initials fallback when there's no photo

`buildFeedPostFromMessage` already spreads the author, so the feed list picks it up automatically.

## Not in scope (other TestFlight items)
- **Admin dashboard won't load (native):** already handled on current v2 — the home admin shortcut opens the responsive web admin via `Linking` on iOS (index.tsx:242), and #501/#502 (mobile-responsive admin) merged right after the report.
- **Automatic theming:** the obvious one-line fix (pass `'system'` to nativewind) reverses a *documented Android-startup-crash workaround* (ThemeContext.tsx:130-132) — needs on-device Android verification, not a safe blind change. Flagged separately.
- **Notification toggle animation:** RN built-in `Switch`, no JS-side fix (adjacent to existing #477).
- **Tab size / Instagram-style profile buttons / slide-over:** design calls (#442/#330), not bugs.

## Test plan
- [x] `npm run typecheck` frontend clean
- [x] frontend tests 197 passing
- [ ] On device: feed + event/center board posts and replies show author photos (initials only when no photo set)