### PR TITLE
fix(theme): Auto theme follows the OS on native

### DIFF
--- a/packages/frontend/components/contexts/ThemeContext.tsx
+++ b/packages/frontend/components/contexts/ThemeContext.tsx
@@ -127,10 +127,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   // ── Apply to NativeWind + DOM on every change ──────────────────────────────
   useEffect(() => {
-    // React Native's native AppearanceModule only accepts concrete color
-    // schemes. Keep "system" as the stored preference, but apply the resolved
-    // light/dark value on native to avoid Android startup crashes.
-    setColorScheme(isWeb ? preference : theme)
+    // On native we now pass "system" through to NativeWind so it keeps tracking
+    // the OS color scheme (otherwise it locks to the last resolved light/dark
+    // value and "Auto" stops following the system — see #509). Concrete
+    // light/dark preferences still apply directly.
+    // NOTE: this reverses a prior workaround that always passed a concrete value
+    // to avoid an Android startup crash — that concern must be re-verified on a
+    // device before relying on this in production.
+    setColorScheme(isWeb ? preference : preference === 'system' ? 'system' : theme)
     if (isWeb) {
       applyToDOM(theme)
     } else {


### PR DESCRIPTION
## Problem

On native, picking **Auto/System** theme didn't follow the OS — it stuck to the last resolved value.

## Root cause

In `packages/frontend/components/contexts/ThemeContext.tsx`, the theme effect called NativeWind's `setColorScheme()` with the *resolved* light/dark `theme` even when the user's preference was `system`:

```ts
setColorScheme(isWeb ? preference : theme)
```

Passing a concrete `light`/`dark` value locks NativeWind to that scheme, so it stops tracking the OS.

## Fix

One logic line: on native, pass `'system'` through to NativeWind when the preference is system (concrete preferences still apply directly; web is unchanged):

```ts
setColorScheme(isWeb ? preference : preference === 'system' ? 'system' : theme)
```

Fixes #509

## ⚠️ Caveat — MUST smoke-test on both iOS and Android before merge

This **reverses a documented workaround** that previously always passed a concrete color scheme on native to avoid an **Android startup crash**. That concern has not been re-verified on a device.

Before merging, smoke-test app launch + Auto-theme behavior on **both iOS and Android**:
- If Android crashes on launch, **revert to `theme`** and rely on the in-app `Appearance` listener (in `useSystemTheme`) to update the resolved theme while the app is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)