### PR TITLE
[codex] Add pull to refresh to main tabs

### DIFF
--- a/packages/frontend/app/(tabs)/explore.tsx
+++ b/packages/frontend/app/(tabs)/explore.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   ScrollView,
   Pressable,
+  RefreshControl,
   TextInput,
   Animated,
   PanResponder,
@@ -262,6 +263,7 @@ export default function DiscoverScreen() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [showGoingOnly, setShowGoingOnly] = useState(false)
   const [showPastEvents, setShowPastEvents] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [selectedCenter, setSelectedCenter] = useState<string | null>(null)
   // The center dropdown opens an in-sheet list (not a modal) — view, pick one, or close.
   const [centerPickerOpen, setCenterPickerOpen] = useState(false)
@@ -310,6 +312,15 @@ export default function DiscoverScreen() {
       refresh()
     }, [refresh])
   )
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await refresh({ force: true })
+    } finally {
+      setRefreshing(false)
+    }
+  }, [refresh])
 
   // ── Sheet snap points ──────────────────────────────────
   // Four positions (as translateY values from the expanded state):
@@ -808,6 +819,14 @@ export default function DiscoverScreen() {
             showsVerticalScrollIndicator={false}
             scrollEnabled={true}
             stickyHeaderIndices={centerPickerOpen ? undefined : stickyHeaderIndices}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={handleRefresh}
+                tintColor="#E8862A"
+                colors={['#E8862A']}
+              />
+            }
           >
             {centerPickerOpen && (
               <>

--- a/packages/frontend/app/(tabs)/feed.tsx
+++ b/packages/frontend/app/(tabs)/feed.tsx
@@ -4,6 +4,7 @@ import {
   Easing,
   KeyboardAvoidingView,
   Platform,
+  RefreshControl,
   ScrollView,
   Text,
   View,
@@ -194,6 +195,7 @@ export default function FeedScreen() {
   const [authPromptOpen, setAuthPromptOpen] = useState(false)
   const [boardMessagesByGroup, setBoardMessagesByGroup] = useState<Record<string, BoardMessage[]>>({})
   const [boardsLoading, setBoardsLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const { setCreateHandler } = useHeaderAction()
 
   useFocusEffect(
@@ -301,6 +303,19 @@ export default function FeedScreen() {
   useEffect(() => {
     loadBoards()
   }, [loadBoards])
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await Promise.all([
+        refetchMyEvents(),
+        refetchCenters({ force: true }),
+        loadBoards(),
+      ])
+    } finally {
+      setRefreshing(false)
+    }
+  }, [refetchMyEvents, refetchCenters, loadBoards])
 
   const groupsWithMessages = useMemo<GroupBoard[]>(
     () => {
@@ -512,6 +527,14 @@ export default function FeedScreen() {
           paddingBottom: isDesktop ? DESKTOP_PAGE_BOTTOM : Platform.OS === 'web' ? 40 : 112,
         }}
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={colors.accent}
+            colors={[colors.accent]}
+          />
+        }
       >
         {/* Desktop moves search into the right context rail (Twitter-style),
             so only render the full-width search header on mobile/narrow web. */}

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { ActivityIndicator, Linking, Platform, Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-native'
+import { ActivityIndicator, Linking, Platform, Pressable, RefreshControl, ScrollView, Text, View, useWindowDimensions } from 'react-native'
 import { ChevronRight, Compass, MapPin, Shield } from 'lucide-react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useAnalytics } from '../../utils/analytics'
@@ -74,7 +74,8 @@ export default function HomeScreen() {
 
   // Boards peek (#199): surface the 1-2 latest posts from the user's center
   // board so Home reflects real activity instead of a permanent empty state.
-  const { posts: centerBoardPosts } = useBoard('center', user?.centerID ?? undefined, !!user?.centerID)
+  const { posts: centerBoardPosts, refetch: refetchCenterBoard } = useBoard('center', user?.centerID ?? undefined, !!user?.centerID)
+  const [refreshing, setRefreshing] = useState(false)
   const userCenter = useMemo(
     () => allCenters.find((item) => item.id === user?.centerID),
     [allCenters, user?.centerID]
@@ -95,6 +96,28 @@ export default function HomeScreen() {
       refetchMyEvents()
       refreshDiscover()
     }, [refetchMyEvents, refreshDiscover])
+  )
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await Promise.all([
+        refetchMyEvents(),
+        refreshDiscover({ force: true }),
+        refetchCenterBoard(),
+      ])
+    } finally {
+      setRefreshing(false)
+    }
+  }, [refetchMyEvents, refreshDiscover, refetchCenterBoard])
+
+  const refreshControl = (
+    <RefreshControl
+      refreshing={refreshing}
+      onRefresh={handleRefresh}
+      tintColor={c.accent}
+      colors={[c.accent]}
+    />
   )
 
   // Desktop two-column composition is web-only and gated on a wide breakpoint.
@@ -418,6 +441,7 @@ export default function HomeScreen() {
             style={{ flex: 1, backgroundColor: c.bg }}
             contentContainerStyle={desktopScrollContent}
             showsVerticalScrollIndicator={false}
+            refreshControl={refreshControl}
           >
             <DesktopColumns
               main={<HomeGhostPreview c={c} />}
@@ -439,6 +463,7 @@ export default function HomeScreen() {
           style={{ flex: 1, backgroundColor: c.bg }}
           contentContainerStyle={desktopScrollContent}
           showsVerticalScrollIndicator={false}
+          refreshControl={refreshControl}
         >
           <DesktopColumns
             header={
@@ -473,6 +498,7 @@ export default function HomeScreen() {
             paddingBottom: Platform.OS === 'web' ? 40 : 112,
           }}
           showsVerticalScrollIndicator={false}
+          refreshControl={refreshControl}
         >
           <View style={{ width: '100%', maxWidth: 640, alignSelf: 'center' }}>
             {guestSetupRail}
@@ -494,6 +520,7 @@ export default function HomeScreen() {
           paddingBottom: Platform.OS === 'web' ? 40 : 112,
         }}
         showsVerticalScrollIndicator={false}
+        refreshControl={refreshControl}
       >
         {/* Mobile single column: lead with the schedule (the desktop "main"
             column — Up Next + Coming Up), then wrap the center/boards content

--- a/packages/frontend/app/(tabs)/profile.tsx
+++ b/packages/frontend/app/(tabs)/profile.tsx
@@ -4,7 +4,7 @@
 // centers). Editing lives on /edit-profile.
 // The "You" header + settings gear are provided by the navigator (TabHeader).
 import React, { useState, useCallback, useEffect } from 'react'
-import { ScrollView, View, Pressable, Image, Share } from 'react-native'
+import { RefreshControl, ScrollView, View, Pressable, Image, Share } from 'react-native'
 import { useRouter, useFocusEffect, useNavigation } from 'expo-router'
 import {
   Pencil, Share2, ChevronRight, BadgeCheck,
@@ -34,7 +34,7 @@ function datePill(dateStr?: string | null): { m: string; d: string } {
 export default function Profile() {
   const router = useRouter()
   const navigation = useNavigation()
-  const { user, loading } = useUser()
+  const { user, loading, refreshUser } = useUser()
   const { isDark } = useTheme()
   const c = isDark ? DARK : LIGHT
   const { track } = useAnalytics()
@@ -43,16 +43,51 @@ export default function Profile() {
   const [createdCount, setCreatedCount] = useState(0)
   const [events, setEvents] = useState<EventData[]>([])
   const [groups, setGroups] = useState<CenterData[]>([])
+  const [refreshing, setRefreshing] = useState(false)
+
+  const loadProfile = useCallback(async () => {
+    const requests: Promise<unknown>[] = [
+      fetchCenters().then(setAllCenters).catch(() => {}),
+    ]
+
+    if (user?.username) {
+      requests.push(
+        refreshUser().catch(() => {}),
+        fetchUserPosts(user.username).then((p) => setCreatedCount(p.length)).catch(() => {}),
+        fetchUserEvents(user.username).then(setEvents).catch(() => {}),
+        fetchUserGroups(user.username).then(setGroups).catch(() => {})
+      )
+    } else {
+      setCreatedCount(0)
+      setEvents([])
+      setGroups([])
+    }
+
+    await Promise.all(requests)
+  }, [refreshUser, user?.username])
 
   useFocusEffect(
     useCallback(() => {
-      fetchCenters().then(setAllCenters).catch(() => {})
-      if (user?.username) {
-        fetchUserPosts(user.username).then((p) => setCreatedCount(p.length)).catch(() => {})
-        fetchUserEvents(user.username).then(setEvents).catch(() => {})
-        fetchUserGroups(user.username).then(setGroups).catch(() => {})
-      }
-    }, [user?.username])
+      loadProfile()
+    }, [loadProfile])
+  )
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      await loadProfile()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [loadProfile])
+
+  const refreshControl = (
+    <RefreshControl
+      refreshing={refreshing}
+      onRefresh={handleRefresh}
+      tintColor="#C2410C"
+      colors={['#C2410C']}
+    />
   )
 
   const displayName =
@@ -184,6 +219,7 @@ export default function Profile() {
       <ScrollView
         style={{ flex: 1, backgroundColor: c.bg }}
         contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 18, paddingBottom: 48 }}
+        refreshControl={refreshControl}
       >
         <SignInCallout
           title="Sign in to Janata"
@@ -203,6 +239,7 @@ export default function Profile() {
     <ScrollView
       style={{ flex: 1, backgroundColor: c.bg }}
       contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 18, paddingBottom: 48 }}
+      refreshControl={refreshControl}
     >
       {/* Profile card */}
       <View style={[card, { padding: 16 }]}>

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -55,8 +55,8 @@ function cacheSet<T>(key: string, data: T) {
   cache.set(key, { data, ts: Date.now() })
 }
 
-async function cachedFetch<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
-  const cached = cacheGet<T>(key)
+async function cachedFetch<T>(key: string, fetcher: () => Promise<T>, options?: { force?: boolean }): Promise<T> {
+  const cached = options?.force ? null : cacheGet<T>(key)
   if (cached !== null) return cached
 
   const existing = inflight.get(key) as Promise<T> | undefined
@@ -609,10 +609,10 @@ export function useCenterList() {
   const [isLive, setIsLive] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (options?: { force?: boolean }) => {
     try {
       setError(null)
-      const apiCenters = await cachedFetch('centers', fetchCenters)
+      const apiCenters = await cachedFetch('centers', fetchCenters, options)
       const discoverCenters = centersToDiscoverCenters(apiCenters)
       if (discoverCenters.length > 0) {
         setCenters(discoverCenters)
@@ -732,16 +732,16 @@ export function useDiscoverData(
   const [isLive, setIsLive] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (options?: { force?: boolean }) => {
     // Note: We don't set loading(true) here to avoid jarring UI flickers on focus
     try {
-      const apiCenters = await cachedFetch('centers', fetchCenters)
+      const apiCenters = await cachedFetch('centers', fetchCenters, options)
       const discoverCenters = centersToDiscoverCenters(apiCenters)
       if (discoverCenters.length > 0) {
         setAllCenters(discoverCenters)
       }
 
-      const allApiEvents = await cachedFetch('allEvents', fetchAllEvents)
+      const allApiEvents = await cachedFetch('allEvents', fetchAllEvents, options)
 
       let fetchedEvents: EventDisplay[]
 


### PR DESCRIPTION
## Summary
- add pull-to-refresh controls to Home, Explore, Feed, and Profile scroll surfaces
- reload the relevant screen data on pull, including board peeks/posts, events, centers, and profile activity
- allow manual Discover/center refreshes to bypass the short in-memory cache

## Validation
- `npm run typecheck:frontend`
- `git diff --check`

## Notes
- Focus-based refreshes still use the existing short cache to avoid unnecessary network churn.
- Manual pull-to-refresh uses `{ force: true }` so the gesture asks the API for fresh Discover/center data.
