### PR TITLE
[codex] Gate guest RSVP visibility

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -440,6 +440,13 @@ describe('invite gate (#403)', () => {
         .bind(eventId, 'guest@example.com')
         .first<{ c: number }>()
       expect(row?.c).toBe(1)
+
+      const publicEvent = await jsonPost('/api/fetchEvent', { id: eventId })
+      expect(publicEvent.body.event.peopleAttending).toBe(0)
+
+      const publicEvents = await fetchJSON('/api/fetchAllEvents')
+      const event = publicEvents.body.events.find((e: any) => e.eventID === eventId)
+      expect(event.peopleAttending).toBe(0)
     })
 
     it('rejects a guest RSVP with an invalid email (400)', async () => {
@@ -2160,10 +2167,64 @@ describe('event routes', () => {
 
       await jsonPost('/api/attendEvent', { eventID: addBody.id }, authHeader(userToken))
 
-      const { res, body } = await jsonPost('/api/getEventUsers', { id: addBody.id })
+      const { res, body } = await jsonPost('/api/getEventUsers', { id: addBody.id }, authHeader(userToken))
       expect(res.status).toBe(200)
       expect(body.users).toHaveLength(1)
       expect(body.users[0].username).toBe('eventuser')
+      expect(body.users[0].attendeeType).toBe('account')
+      expect(body.totalAttendeeCount).toBe(1)
+    })
+
+    it('requires an account RSVP before viewing attendees', async () => {
+      const { token: strangerToken } = await registerAndLogin('stranger', 'password123')
+      const { body: addBody } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'Private Attendee List Event',
+          date: '2025-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: centerId,
+        },
+        authHeader(userToken)
+      )
+
+      const guest = await jsonPost('/api/getEventUsers', { id: addBody.id })
+      expect(guest.res.status).toBe(401)
+
+      const stranger = await jsonPost('/api/getEventUsers', { id: addBody.id }, authHeader(strangerToken))
+      expect(stranger.res.status).toBe(403)
+    })
+
+    it('includes account-less guest RSVPs for allowed viewers without exposing guest email', async () => {
+      const { body: addBody } = await jsonPost(
+        '/api/addEvent',
+        {
+          title: 'Guest Visible Event',
+          date: '2025-06-01T10:00:00Z',
+          latitude: 37.0,
+          longitude: -121.0,
+          centerID: centerId,
+        },
+        authHeader(userToken)
+      )
+
+      await jsonPost('/api/attendEvent', { eventID: addBody.id }, authHeader(userToken))
+      await jsonPost('/api/attendEventGuest', {
+        eventID: addBody.id,
+        name: 'Guest One',
+        email: 'guest-one@example.com',
+      })
+
+      const { res, body } = await jsonPost('/api/getEventUsers', { id: addBody.id }, authHeader(userToken))
+      expect(res.status).toBe(200)
+      expect(body.users).toHaveLength(2)
+      expect(body.accountAttendeeCount).toBe(1)
+      expect(body.guestRsvpCount).toBe(1)
+      expect(body.totalAttendeeCount).toBe(2)
+      const guest = body.users.find((u: any) => u.attendeeType === 'guest')
+      expect(guest.firstName).toBe('Guest One')
+      expect(guest.email).toBeNull()
     })
   })
 
@@ -2613,6 +2674,34 @@ describe('GET /api/admin/events', () => {
     expect(body.data).toHaveLength(2)
     expect(body.data[0].eventID).toBeDefined()
     expect(body.data[0].title).toBeDefined()
+  })
+
+  it('includes guest RSVP counts and admin guest review rows', async () => {
+    const adminToken = await createAdmin()
+    const { body: centerBody } = await jsonPost('/api/addCenter', { centerName: 'CM San Jose', latitude: 37.3, longitude: -121.9 }, authHeader(adminToken))
+    const { body: eventBody } = await jsonPost(
+      '/api/addEvent',
+      { title: 'Guest Review', date: '2026-04-05T10:00:00Z', latitude: 37.3, longitude: -121.9, centerID: centerBody.id },
+      authHeader(adminToken),
+    )
+    await jsonPost('/api/attendEventGuest', {
+      eventID: eventBody.id,
+      name: 'Guest Reviewer',
+      email: 'guest-reviewer@example.com',
+    })
+
+    const { body } = await fetchJSON('/api/admin/events?limit=10&offset=0', { headers: authHeader(adminToken) })
+    const event = body.data.find((e: any) => e.eventID === eventBody.id)
+    expect(event.peopleAttending).toBe(1)
+    expect(event.accountAttendeeCount).toBe(0)
+    expect(event.guestRsvpCount).toBe(1)
+
+    const review = await fetchJSON(`/api/admin/events/${eventBody.id}/guest-rsvps`, {
+      headers: authHeader(adminToken),
+    })
+    expect(review.res.status).toBe(200)
+    expect(review.body.data).toHaveLength(1)
+    expect(review.body.data[0].email).toBe('guest-reviewer@example.com')
   })
 
   it('searches by title, address, or description', async () => {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2180,7 +2180,8 @@ app.post('/updateEvent', authMiddleware, async (c) => {
   return c.json({ message: 'Update failed' }, 400)
 })
 
-app.post('/getEventUsers', async (c) => {
+app.post('/getEventUsers', authMiddleware, async (c) => {
+  const user = c.get('user')
   const { id } = await c.req.json<{ id: string }>()
   if (!id) {
     return c.json({ message: 'Bad request - missing id' }, 400)
@@ -2191,10 +2192,46 @@ app.post('/getEventUsers', async (c) => {
     return c.json({ message: 'Event not found' }, 404)
   }
 
+  const userIsAdmin = isAdmin(user)
+  const userIsCreator = event.created_by === user.id
+  const userIsAttending = await db.isUserAttending(c.env.DB, id, user.id)
+  if (!userIsAdmin && !userIsCreator && !userIsAttending) {
+    return c.json({ message: 'You must be registered for this event to see attendees' }, 403)
+  }
+
   const attendees = await db.getEventAttendees(c.env.DB, id)
+  const guestRsvps = await db.getEventGuestRsvps(c.env.DB, id)
+  const accountUsers = attendees.map((u) => ({
+    ...userRowToApi(u),
+    attendeeType: 'account',
+  }))
+  const guestUsers = guestRsvps.map((guest, index) => ({
+    id: `guest-${index + 1}`,
+    username: guest.name,
+    email: null,
+    firstName: guest.name,
+    lastName: '',
+    dateOfBirth: null,
+    phoneNumber: null,
+    profileImage: null,
+    centerID: null,
+    points: 0,
+    isVerified: false,
+    verificationLevel: 0,
+    isActive: true,
+    profileComplete: false,
+    interests: null,
+    createdAt: guest.created_at,
+    updatedAt: guest.created_at,
+    attendeeType: 'guest',
+  }))
+
   return c.json({
     message: 'Success',
-    users: attendees.map((u) => userRowToApi(u)),
+    users: [...accountUsers, ...guestUsers],
+    accountAttendeeCount: attendees.length,
+    guestRsvpCount: guestRsvps.length,
+    totalAttendeeCount: attendees.length + guestRsvps.length,
   })
 })
 
@@ -2543,7 +2580,36 @@ app.get('/admin/events', adminMiddleware, async (c) => {
   const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '50', 10) || 50, 1), 100)
   const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10) || 0, 0)
   const { data, total } = await db.listEvents(c.env.DB, { q, limit, offset })
-  return c.json({ data: data.map(eventRowToApi), total, limit, offset })
+  const events = await Promise.all(
+    data.map(async (event) => {
+      const guestRsvpCount = await db.countEventGuestRsvps(c.env.DB, event.id)
+      return {
+        ...eventRowToApi(event),
+        accountAttendeeCount: event.people_attending,
+        guestRsvpCount,
+        peopleAttending: event.people_attending + guestRsvpCount,
+      }
+    }),
+  )
+  return c.json({ data: events, total, limit, offset })
+})
+
+app.get('/admin/events/:id/guest-rsvps', adminMiddleware, async (c) => {
+  const eventId = c.req.param('id')
+  const event = await db.getEventById(c.env.DB, eventId)
+  if (!event) {
+    return c.json({ message: 'Event not found' }, 404)
+  }
+  const guestRsvps = await db.getEventGuestRsvps(c.env.DB, eventId)
+  return c.json({
+    data: guestRsvps.map((guest) => ({
+      eventID: guest.event_id,
+      name: guest.name,
+      email: guest.email,
+      createdAt: guest.created_at,
+    })),
+    total: guestRsvps.length,
+  })
 })
 
 // ── Admin center actions ──────────────────────────────────────────────

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -11,6 +11,7 @@ import type {
   UserRow,
   CenterRow,
   EventRow,
+  EventGuestRsvpRow,
   EventAttendeeRow,
   EventEndorserRow,
   BoardRow,
@@ -518,6 +519,35 @@ export async function createGuestRsvp(
   } catch (err: any) {
     return { success: false, error: err?.message ?? 'Unknown error' }
   }
+}
+
+export async function getEventGuestRsvps(
+  db: D1Database,
+  eventId: string,
+): Promise<EventGuestRsvpRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM event_guest_rsvps
+       WHERE event_id = ?1 AND upgraded_user_id IS NULL
+       ORDER BY created_at DESC`,
+    )
+    .bind(eventId)
+    .all<EventGuestRsvpRow>()
+  return result.results ?? []
+}
+
+export async function countEventGuestRsvps(
+  db: D1Database,
+  eventId: string,
+): Promise<number> {
+  const result = await db
+    .prepare(
+      `SELECT COUNT(*) AS count FROM event_guest_rsvps
+       WHERE event_id = ?1 AND upgraded_user_id IS NULL`,
+    )
+    .bind(eventId)
+    .first<{ count: number }>()
+  return result?.count ?? 0
 }
 
 /**

--- a/packages/frontend/components/admin/EventsTab.tsx
+++ b/packages/frontend/components/admin/EventsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react'
 import { View, Text, Pressable, ActivityIndicator, useWindowDimensions } from 'react-native'
-import { MapPin, Clock, Users, FileText } from 'lucide-react-native'
+import { MapPin, Clock, Users, FileText, Mail } from 'lucide-react-native'
 import AdminTable, { type Column } from './AdminTable'
 import AdminDetailPanel from './AdminDetailPanel'
 import AdminSearchInput from './AdminSearchInput'
@@ -8,8 +8,10 @@ import AdminInfoRow from './AdminInfoRow'
 import ConfirmDialog from './ConfirmDialog'
 import {
   fetchAdminEvents,
+  fetchAdminEventGuestRsvps,
   adminDeleteEvent,
   type EventData,
+  type GuestRsvpData,
 } from '../../utils/api'
 import { useDetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
@@ -37,6 +39,8 @@ export default function EventsTab() {
   const [loading, setLoading] = useState(true)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<EventData | null>(null)
+  const [guestRsvps, setGuestRsvps] = useState<GuestRsvpData[]>([])
+  const [guestRsvpsLoading, setGuestRsvpsLoading] = useState(false)
 
   const [error, setError] = useState<string | null>(null)
 
@@ -70,6 +74,30 @@ export default function EventsTab() {
     () => events.find((e) => e.eventID === selectedId) ?? null,
     [selectedId, events]
   )
+
+  useEffect(() => {
+    let mounted = true
+    if (!selectedId) {
+      setGuestRsvps([])
+      return
+    }
+    setGuestRsvpsLoading(true)
+    setGuestRsvps([])
+    fetchAdminEventGuestRsvps(selectedId)
+      .then((rows) => {
+        if (mounted) setGuestRsvps(rows)
+      })
+      .catch((err) => {
+        if (__DEV__) console.error('Failed to load guest RSVPs:', err)
+        if (mounted) setGuestRsvps([])
+      })
+      .finally(() => {
+        if (mounted) setGuestRsvpsLoading(false)
+      })
+    return () => {
+      mounted = false
+    }
+  }, [selectedId])
 
   const handleDelete = async () => {
     if (!deleteTarget) return
@@ -180,11 +208,50 @@ export default function EventsTab() {
             )}
             <AdminInfoRow
               icon={<Users size={14} color={colors.textMuted} />}
-              text={`${selected.peopleAttending} attendees`}
+              text={`${selected.peopleAttending} attendees (${selected.accountAttendeeCount ?? selected.peopleAttending} accounts, ${selected.guestRsvpCount ?? 0} guests)`}
               colors={colors}
             />
             {selected.description && (
               <AdminInfoRow icon={<FileText size={14} color={colors.textMuted} />} text={selected.description} colors={colors} />
+            )}
+          </View>
+
+          <View style={{ marginTop: 18, gap: 10 }}>
+            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.text }}>
+              Guest RSVPs
+            </Text>
+            {guestRsvpsLoading ? (
+              <ActivityIndicator color="#E8862A" style={{ alignSelf: 'flex-start' }} />
+            ) : guestRsvps.length > 0 ? (
+              <View style={{ gap: 10 }}>
+                {guestRsvps.map((guest) => (
+                  <View
+                    key={`${guest.email}-${guest.createdAt}`}
+                    style={{
+                      borderTopWidth: 1,
+                      borderTopColor: colors.border,
+                      paddingTop: 10,
+                      gap: 4,
+                    }}
+                  >
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.text }}>
+                      {guest.name}
+                    </Text>
+                    <AdminInfoRow
+                      icon={<Mail size={14} color={colors.textMuted} />}
+                      text={guest.email}
+                      colors={colors}
+                    />
+                    <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 11, color: colors.textMuted }}>
+                      No account · RSVPed {formatDate(guest.createdAt)} at {formatTime(guest.createdAt)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textSecondary }}>
+                No account-less RSVPs yet.
+              </Text>
             )}
           </View>
 

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -93,6 +93,7 @@ type Attendee = {
   subtitle: string
   image?: string
   initials?: string
+  attendeeType?: 'account' | 'guest'
 }
 
 type EventDetailPanelProps = {
@@ -593,15 +594,17 @@ function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: Detai
                 >
                   {a.name}
                 </Text>
-                <Text
-                  style={{
-                    fontFamily: 'Inclusive Sans',
-                    fontSize: 12,
-                    color: colors.textSecondary,
-                  }}
-                >
-                  {a.subtitle}
-                </Text>
+                {a.subtitle ? (
+                  <Text
+                    style={{
+                      fontFamily: 'Inclusive Sans',
+                      fontSize: 12,
+                      color: colors.textSecondary,
+                    }}
+                  >
+                    {a.subtitle}
+                  </Text>
+                ) : null}
               </View>
             </View>
           ))}

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -26,6 +26,7 @@ import {
   DISCOVER_SAMPLE_EVENTS,
   DISCOVER_SAMPLE_CENTERS,
   AttendeeInfo,
+  UserData,
 } from '../utils/api'
 import { extractCountryAndState } from '../utils/addressParsing'
 
@@ -238,10 +239,42 @@ export function useEventList() {
   return { events, loading, isLive, error }
 }
 
+function apiUserToDisplayName(user: UserData): string {
+  return user.firstName ? `${user.firstName} ${user.lastName || ''}`.trim() : user.username
+}
+
+function apiUserToInitials(user: UserData): string {
+  const name = apiUserToDisplayName(user)
+  if (user.firstName) {
+    return `${user.firstName[0]}${user.lastName?.[0] || ''}`.toUpperCase()
+  }
+  return name.slice(0, 2).toUpperCase()
+}
+
+function apiUserToAttendee(user: UserData) {
+  const isGuest = user.attendeeType === 'guest'
+  return {
+    name: apiUserToDisplayName(user),
+    subtitle: isGuest ? 'Guest RSVP · no account' : '',
+    image: user.profileImage ?? undefined,
+    initials: apiUserToInitials(user),
+    attendeeType: user.attendeeType,
+  }
+}
+
+function apiUserToAttendeeInfo(user: UserData): AttendeeInfo {
+  return {
+    name: apiUserToDisplayName(user),
+    image: user.profileImage || undefined,
+    initials: apiUserToInitials(user),
+    attendeeType: user.attendeeType,
+  }
+}
+
 export function useEventDetail(eventId: string, username?: string, userId?: string) {
   const [event, setEvent] = useState<EventDisplay | null>(null)
   const [attendees, setAttendees] = useState<
-    { name: string; subtitle: string; image?: string; initials: string }[]
+    { name: string; subtitle: string; image?: string; initials: string; attendeeType?: 'account' | 'guest' }[]
   >([])
   const [messages, setMessages] = useState<
     { author: string; timestamp: string; text: string; image: string }[]
@@ -274,20 +307,21 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           // Fetch attendees and check if current user is registered
           const users = await fetchEventUsers(eventId)
           if (mounted) {
-            setAttendees(
-              users.map((u) => ({
-                name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
-                subtitle: '',
-                image: u.profileImage ?? undefined,
-                initials: u.firstName
-                  ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                  : u.username.slice(0, 2).toUpperCase(),
-              }))
-            )
+            const canSeeAttendees = users.length > 0 || display.attendees === 0
+            setAttendees(canSeeAttendees ? users.map(apiUserToAttendee) : [])
             // Check if current user is in attendees list
-            const userIsRegistered = userId ? users.some((u) => u.id === userId) : false
+            const userIsRegistered = userId ? users.some((u) => u.id === userId && u.attendeeType !== 'guest') : false
             setIsRegistered(userIsRegistered)
-            setEvent((prev) => (prev ? { ...prev, isRegistered: userIsRegistered } : null))
+            setEvent((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    attendees: canSeeAttendees ? users.length : prev.attendees,
+                    attendeesList: canSeeAttendees ? users.map(apiUserToAttendeeInfo).slice(0, 4) : prev.attendeesList,
+                    isRegistered: userIsRegistered,
+                  }
+                : null
+            )
           }
         }
       } catch (err: any) {
@@ -315,55 +349,35 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
       try {
         // Check current registration status directly from API
         const users = await fetchEventUsers(eventId)
-        const currentUserInAttendees = users.some((u) => u.id === userId)
+        const currentUserInAttendees = users.some((u) => u.id === userId && u.attendeeType !== 'guest')
 
         if (currentUserInAttendees) {
           // Already registered - unattend
-          await unattendEvent(eventId)
+          const result = await unattendEvent(eventId)
           setIsRegistered(false)
           // Re-fetch attendees after unregistering
           const updatedUsers = await fetchEventUsers(eventId)
-          const newAttendeesList = updatedUsers.map((u) => ({
-            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
-            image: u.profileImage || undefined,
-            initials: u.firstName
-              ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-              : u.username.slice(0, 2).toUpperCase(),
-          }))
+          const canStillSeeAttendees = updatedUsers.length > 0 || result.peopleAttending === 0
+          const newAttendeesList = updatedUsers.map(apiUserToAttendeeInfo)
           setEvent((prev) =>
             prev
               ? {
                   ...prev,
                   isRegistered: false,
-                  attendees: updatedUsers.length,
+                  attendees: canStillSeeAttendees ? updatedUsers.length : result.peopleAttending,
                   attendeesList: newAttendeesList.slice(0, 4),
                 }
               : null
           )
           // Also update attendees state
-          setAttendees(
-            updatedUsers.map((u) => ({
-              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
-              subtitle: '',
-              image: u.profileImage ?? undefined,
-              initials: u.firstName
-                ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                : u.username.slice(0, 2).toUpperCase(),
-            }))
-          )
+          setAttendees(canStillSeeAttendees ? updatedUsers.map(apiUserToAttendee) : [])
         } else {
           // Not registered - attend
           await attendEvent(eventId)
           setIsRegistered(true)
           // Re-fetch attendees after registering
           const updatedUsers = await fetchEventUsers(eventId)
-          const newAttendeesList = updatedUsers.map((u) => ({
-            name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
-            image: u.profileImage || undefined,
-            initials: u.firstName
-              ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-              : u.username.slice(0, 2).toUpperCase(),
-          }))
+          const newAttendeesList = updatedUsers.map(apiUserToAttendeeInfo)
           setEvent((prev) =>
             prev
               ? {
@@ -375,16 +389,7 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
               : null
           )
           // Also update attendees state
-          setAttendees(
-            updatedUsers.map((u) => ({
-              name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
-              subtitle: '',
-              image: u.profileImage ?? undefined,
-              initials: u.firstName
-                ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
-                : u.username.slice(0, 2).toUpperCase(),
-            }))
-          )
+          setAttendees(updatedUsers.map(apiUserToAttendee))
         }
       } catch (error: any) {
         // If error says already registered, update UI
@@ -749,19 +754,19 @@ export function useDiscoverData(
         const eventsWithAttendees = await Promise.all(
           allApiEvents.map(async (e) => {
             const users = await fetchEventUsers(e.eventID)
-            const attendeesList = users.map((u) => ({
+            const accountUsers = users.filter((u) => u.attendeeType !== 'guest')
+            const attendeesList = accountUsers.map((u) => ({
               name: u.firstName ? `${u.firstName} ${u.lastName || ''}`.trim() : u.username,
               image: u.profileImage || undefined,
               initials: u.firstName
                 ? `${u.firstName[0]}${u.lastName?.[0] || ''}`.toUpperCase()
                 : u.username.slice(0, 2).toUpperCase(),
             }))
-            const userIsRegistered = userId ? users.some((u) => u.id === userId) : false
+            const userIsRegistered = userId ? accountUsers.some((u) => u.id === userId) : false
             return {
               ...e,
               attendeesList: attendeesList.slice(0, 4),
               isRegistered: userIsRegistered,
-              peopleAttending: users.length,
             }
           })
         )
@@ -770,7 +775,6 @@ export function useDiscoverData(
           const display = apiEventToDisplay(e)
           display.attendeesList = e.attendeesList
           display.isRegistered = e.isRegistered
-          display.attendees = e.peopleAttending
           return display
         })
       } else {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -43,6 +43,8 @@ export interface EventData {
   externalUrl?: string | null
   signupUrl?: string | null
   allowJanataSignup?: boolean
+  accountAttendeeCount?: number
+  guestRsvpCount?: number
   // #192 — true when creator was at SEVAK level or higher at create time.
   isOfficial?: boolean
   createdAt?: string
@@ -70,8 +72,16 @@ export interface UserData {
   work?: string | null
   region?: string | null
   lookingFor?: string[] | null
+  attendeeType?: 'account' | 'guest'
   createdAt?: string
   updatedAt?: string
+}
+
+export interface GuestRsvpData {
+  eventID: string
+  name: string
+  email: string
+  createdAt: string
 }
 
 export interface PublicProfileData {
@@ -133,6 +143,7 @@ export interface AttendeeInfo {
   name: string
   image?: string
   initials?: string
+  attendeeType?: 'account' | 'guest'
 }
 
 export interface EventDisplay {
@@ -410,7 +421,7 @@ export async function fetchEventsPage(
 
 export async function fetchEventUsers(eventID: string): Promise<UserData[]> {
   try {
-    const response = await apiFetch('/getEventUsers', {
+    const response = await authFetch('/getEventUsers', {
       method: 'POST',
       body: JSON.stringify({ id: eventID }),
     })
@@ -987,6 +998,13 @@ export async function fetchAdminEvents(params?: {
   const response = await authFetch(`/admin/events${qs ? `?${qs}` : ''}`)
   if (!response.ok) throw new Error('Failed to fetch admin events')
   return response.json()
+}
+
+export async function fetchAdminEventGuestRsvps(eventId: string): Promise<GuestRsvpData[]> {
+  const response = await authFetch(`/admin/events/${eventId}/guest-rsvps`)
+  if (!response.ok) throw new Error('Failed to fetch guest RSVPs')
+  const data = await response.json()
+  return data.data || []
 }
 
 export async function fetchAdminCenterMembers(centerId: string): Promise<UserData[]> {


### PR DESCRIPTION
## Summary
- make event attendee lists private to admins, event creators, and account users registered for the event
- include account-less guest RSVPs in private event-detail counts/lists while keeping guest emails hidden outside admin review
- add admin guest RSVP review rows with name/email and split account-vs-guest counts
- keep public event counts and avatar previews account-attendee-only

## Why
Account-less RSVPs were saved but not visible to organizers. They should be reviewable by admins and visible to people who are legitimately part of the event, without leaking guest attendance through public event cards, counts, or avatar stacks.

## Validation
- npm run typecheck:backend
- npm run typecheck:frontend
- cd packages/backend && npm run test:cloudflare:app
