### PR TITLE
feat(invites): make janata.app a working universal-link domain

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -2909,7 +2909,7 @@ describe('POST /api/auth/invite-codes (mint)', () => {
     const { res, body } = await jsonPost('/api/auth/invite-codes', {}, authHeader(token))
     expect(res.status).toBe(200)
     expect(body.code).toMatch(/^[0-9A-F]{12}$/)
-    expect(body.shareUrl).toBe(`https://chinmayajanata.org/i/${body.code}`)
+    expect(body.shareUrl).toBe(`https://janata.app/i/${body.code}`)
     expect(body.maxUses).toBe(25)
     const ttlDays = (new Date(body.expiresAt).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
     expect(ttlDays).toBeGreaterThan(6.9)
@@ -2999,7 +2999,7 @@ describe('GET /api/auth/invite-codes/mine', () => {
     })
     expect(body.codes).toHaveLength(2)
     expect(body.codes[0].isUsable).toBe(true)
-    expect(body.codes[0].shareUrl).toBe(`https://chinmayajanata.org/i/${body.codes[0].code}`)
+    expect(body.codes[0].shareUrl).toBe(`https://janata.app/i/${body.codes[0].code}`)
   })
 
   it("does not leak other users' codes", async () => {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -712,7 +712,7 @@ app.post('/auth/password-reset/verify', rateLimit(10, 60_000), async (c) => {
 // post-signup via /auth/redeem-invite. See
 // docs/plans/2026-05-05-v2-roles-invites-messaging.md §5.A.
 
-const INVITE_SHARE_URL_BASE = 'https://chinmayajanata.org/i'
+const INVITE_SHARE_URL_BASE = 'https://janata.app/i'
 
 app.post('/auth/invite-codes', authMiddleware, async (c) => {
   const user = c.get('user')

--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -82,6 +82,11 @@
               "scheme": "https",
               "host": "www.chinmayajanata.org",
               "pathPrefix": "/auth"
+            },
+            {
+              "scheme": "https",
+              "host": "janata.app",
+              "pathPrefix": "/i"
             }
           ],
           "category": [
@@ -142,6 +147,11 @@
               "scheme": "https",
               "host": "www.chinmayajanata.org",
               "pathPrefix": "/auth"
+            },
+            {
+              "scheme": "https",
+              "host": "janata.app",
+              "pathPrefix": "/i"
             }
           ],
           "category": [
@@ -167,7 +177,8 @@
       "bundleIdentifier": "org.chinmayamission.janata",
       "associatedDomains": [
         "applinks:chinmayajanata.org",
-        "applinks:www.chinmayajanata.org"
+        "applinks:www.chinmayajanata.org",
+        "applinks:janata.app"
       ]
     },
     "web": {

--- a/packages/frontend/app/settings/invite.tsx
+++ b/packages/frontend/app/settings/invite.tsx
@@ -14,7 +14,7 @@ const MONO_FONT = Platform.select({
   default: 'monospace',
 })
 
-const linkForCode = (code: string) => `https://chinmayajanata.org/i/${code}`
+const linkForCode = (code: string) => `https://janata.app/i/${code}`
 
 // Role → verification level the link grants (#451). Mirrors the backend
 // INVITE_ROLE_LEVELS; used to reuse an existing link of the same role.
@@ -254,7 +254,7 @@ export default function InviteScreen() {
                     ellipsizeMode="tail"
                     style={{ flex: 1, fontFamily: MONO_FONT, fontSize: 13, color: c.text }}
                   >
-                    chinmayajanata.org/i/{code}
+                    janata.app/i/{code}
                   </Text>
                 </View>
 

--- a/packages/frontend/src/__tests__/extractInviteCode.test.ts
+++ b/packages/frontend/src/__tests__/extractInviteCode.test.ts
@@ -20,6 +20,11 @@ describe('extractInviteCode', () => {
     expect(extractInviteCode('https://chinmayajanata.org/i/ABC123')).toBe('ABC123')
   })
 
+  it('pulls the code out of a janata.app short link', () => {
+    expect(extractInviteCode('https://janata.app/i/ABC123')).toBe('ABC123')
+    expect(extractInviteCode('janata.app/i/ABC123?utm=x')).toBe('ABC123')
+  })
+
   it('pulls the code out of a legacy /invite/ link', () => {
     expect(extractInviteCode('https://chinmayajanata.org/invite/XYZ789')).toBe('XYZ789')
   })

--- a/packages/frontend/utils/validation.ts
+++ b/packages/frontend/utils/validation.ts
@@ -42,8 +42,9 @@ export const validatePhoneNumber = (phoneNumber: string): boolean => {
 };
 
 // Accept a full invite link or a raw code; return the bare code.
-// Handles the canonical chinmayajanata.org/i/CODE route plus older
-// chinmayajanata.org/invite/CODE and /join?code=CODE links.
+// Handles the canonical chinmayajanata.org/i/CODE route, the janata.app/i/CODE
+// short-link domain, plus older chinmayajanata.org/invite/CODE and
+// /join?code=CODE links.
 export const extractInviteCode = (input: string): string => {
   const trimmed = (input ?? '').trim()
   const fromJoinLink = trimmed.match(/chinmayajanata\.org\/join\?code=([^&#\s]+)/i)
@@ -51,7 +52,7 @@ export const extractInviteCode = (input: string): string => {
     return decodeURIComponent(fromJoinLink[1]).trim()
   }
   const match = trimmed.match(
-    /(?:chinmayajanata\.org\/invite\/|chinmayajanata\.org\/i\/)([^/?#\s]+)/i,
+    /(?:chinmayajanata\.org\/invite\/|chinmayajanata\.org\/i\/|janata\.app\/i\/)([^/?#\s]+)/i,
   )
   return (match ? match[1] : trimmed).trim()
 }

--- a/workers/janata-shortlink/README.md
+++ b/workers/janata-shortlink/README.md
@@ -1,0 +1,42 @@
+# janata-shortlink
+
+Cloudflare Worker that powers the **janata.app** short-link / universal-link domain.
+
+- `janata.app/i/CODE` → invite link (Door 1). Web fallback 301s to
+  `chinmayajanata.org/i/CODE`; on iOS/Android with the app installed it opens
+  the app directly via the association files below.
+- `janata.app/e|c|f|u/<id>` → events / center / feed / users short links.
+- Serves `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json`.
+
+## Source of truth
+
+This directory is the source of truth. The live worker was originally deployed
+from the Cloudflare dashboard (2026-06-08) with placeholder values and was not
+tracked in git. Re-deploying from here corrects:
+
+- Apple `appID` team prefix: `TEAMID` → `GN3TH9WD6W`.
+- Invite redirect target: legacy `/invite/CODE` → canonical `/i/CODE`.
+
+## Deploy
+
+```sh
+cd workers/janata-shortlink
+CLOUDFLARE_ACCOUNT_ID=<account-id> npx wrangler deploy
+```
+
+## Still TODO for iOS universal links to actually open the app
+
+This worker is only the **server** half. The **app** half is also required:
+
+1. Add `applinks:janata.app` to `associatedDomains` in
+   `packages/frontend/app.json` (currently only `chinmayajanata.org` + `www`).
+2. Ship a new native build (EAS) so the entitlement is re-signed.
+
+Until both ship, janata.app invite links open Safari and ride the web 301
+instead of deep-linking into the app.
+
+## Android (not launch-blocking)
+
+`ANDROID_SHA256` is still a placeholder here **and** in
+`packages/frontend/public/.well-known/assetlinks.json`. Fill in the EAS Android
+upload-key SHA-256 before Android launch.

--- a/workers/janata-shortlink/src/index.ts
+++ b/workers/janata-shortlink/src/index.ts
@@ -1,0 +1,86 @@
+// janata.app short-link / universal-link worker.
+//
+// Serves the janata.app zone. Two jobs:
+//   1. Serve the iOS/Android app-association files so janata.app/<prefix>/<id>
+//      links open the native app (universal links / app links).
+//   2. For everyone else (web browsers, no app installed), 301 the short link
+//      to the canonical chinmayajanata.org route.
+//
+// Invite links are the primary use case: janata.app/i/CODE.
+//
+// NOTE: this is the source of truth for the deployed `janata-shortlink` worker.
+// It was previously deployed straight from the dashboard with placeholder
+// values and was NOT tracked in git. Deploy with `wrangler deploy` from this dir.
+
+const CANONICAL = 'https://chinmayajanata.org'
+
+// short prefix -> canonical web path segment.
+// `i` maps to `i` (Door 1, the canonical invite resolver) — not the legacy
+// `/invite/` route, which only works via an extra in-app redirect hop.
+const ROUTES: Record<string, string> = {
+  i: 'i',
+  e: 'events',
+  c: 'center',
+  f: 'feed',
+  u: 'users',
+}
+
+// Apple team-id prefixed app id. Must match the app's signing team or iOS
+// silently refuses to associate the domain. GN3TH9WD6W is the real team id
+// (the dashboard worker shipped the literal placeholder "TEAMID").
+const APP_ID = 'GN3TH9WD6W.org.chinmayamission.janata'
+const ANDROID_PACKAGE = 'org.chinmayamission.janata'
+// TODO: replace with the EAS Android upload-key SHA-256 before Android launch.
+const ANDROID_SHA256 = 'REPLACE_WITH_EAS_ANDROID_SHA256_FINGERPRINT'
+
+// Only /i/* (invites) deep-links into the app — it's the one short prefix with
+// a matching native route (app/i/[code]). The other prefixes (e/c/f/u) still
+// web-redirect below, but iOS/Android shouldn't open the app to a route it
+// can't render, so they're intentionally excluded from the association paths.
+const AASA = JSON.stringify({
+  applinks: {
+    apps: [],
+    details: [
+      {
+        appID: APP_ID,
+        paths: ['NOT /.well-known/*', '/i/*'],
+      },
+    ],
+  },
+})
+
+const ASSET_LINKS = JSON.stringify([
+  {
+    relation: ['delegate_permission/common.handle_all_urls'],
+    target: {
+      namespace: 'android_app',
+      package_name: ANDROID_PACKAGE,
+      sha256_cert_fingerprints: [ANDROID_SHA256],
+    },
+  },
+])
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/.well-known/apple-app-site-association') {
+      return new Response(AASA, { headers: { 'Content-Type': 'application/json' } })
+    }
+    if (pathname === '/.well-known/assetlinks.json') {
+      return new Response(ASSET_LINKS, { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    const match = pathname.match(/^\/([a-z])\/(.+)$/)
+    if (match) {
+      const [, prefix, id] = match
+      const canonical = ROUTES[prefix]
+      if (canonical) {
+        return Response.redirect(`${CANONICAL}/${canonical}/${id}`, 301)
+      }
+    }
+
+    // Root and anything unrecognised -> canonical site.
+    return Response.redirect(CANONICAL, 301)
+  },
+}

--- a/workers/janata-shortlink/wrangler.toml
+++ b/workers/janata-shortlink/wrangler.toml
@@ -1,0 +1,10 @@
+name = "janata-shortlink"
+main = "src/index.ts"
+compatibility_date = "2026-02-26"
+workers_dev = false
+
+# Binds the worker to the whole janata.app zone. Account id comes from the
+# CLOUDFLARE_ACCOUNT_ID env var (same as the other workers in this repo).
+routes = [
+  { pattern = "janata.app/*", zone_name = "janata.app" },
+]


### PR DESCRIPTION
## What

Makes **both** `chinmayajanata.org/i/CODE` and `janata.app/i/CODE` work as invite links and (after the next native build) as iOS/Android universal links — and switches the app to **mint/share `janata.app/i/CODE`** as the primary link. `chinmayajanata.org` keeps working unchanged.

## Why

`janata.app` was already live (Cloudflare `janata-shortlink` worker) but half-broken: its AASA shipped a placeholder Apple team id (`TEAMID`), the app never claimed the domain, and pasted `janata.app` links didn't parse. So `janata.app` invite links could never deep-link into the app.

## Changes

- **`workers/janata-shortlink/`** — captures the previously dashboard-only worker as version-controlled source.
  - AASA team id `TEAMID` → `GN3TH9WD6W` (the real signing team).
  - `/i/` redirect target → canonical `chinmayajanata.org/i/CODE` (was legacy `/invite/`).
  - Deep-linking scoped to `/i/*` — the one short prefix with a matching native route. `e/c/f/u` still web-redirect (no native screen).
- **`packages/frontend/app.json`** — claim `janata.app` for iOS (`associatedDomains`) + Android (`intentFilter /i`), alongside the existing `chinmayajanata.org` entries.
- **`packages/frontend/utils/validation.ts`** (+ test) — `extractInviteCode` now parses pasted `janata.app/i/CODE` links.
- **Mint/share on `janata.app`** — `settings/invite.tsx` `linkForCode` + displayed text, and backend `INVITE_SHARE_URL_BASE` (the API `shareUrl`), now use `janata.app/i`. Backend tests updated.

## Status

- ✅ Worker **already deployed** — `janata.app` AASA serves the correct team id, scoped to `/i/*`; redirects verified live.
- ⏳ **Requires a new EAS build** for the `app.json` domain claim to take effect on devices. Until then `janata.app/i/CODE` works on iOS via the web 301 (just not a native deep link).
- Both domains resolve, so existing `chinmayajanata.org/i` links keep working; this just changes which URL the app shares.

## Verification

- Live: `curl https://janata.app/.well-known/apple-app-site-association` → team id `GN3TH9WD6W`, paths `["NOT /.well-known/*","/i/*"]`.
- Live: `janata.app/i/ABC123` → 301 → `chinmayajanata.org/i/ABC123`.
- Parser logic checked for both domains. Full vitest not run locally (no `node_modules` in the worktree) — CI will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)