### PR TITLE
Invalidate refresh tokens after password reset

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -517,6 +517,67 @@ describe('POST /api/auth/authenticate', () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════
+// AUTH: REFRESH
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('POST /api/auth/refresh', () => {
+  it('rejects refresh tokens after password rotation (401, tv mismatch)', async () => {
+    await jsonPost('/api/auth/register', {
+      username: 'refreshrotate',
+      password: 'password123',
+      inviteCode: TEST_INVITE_CODE,
+    })
+    const login = await jsonPost('/api/auth/authenticate', {
+      username: 'refreshrotate',
+      password: 'password123',
+    })
+    expect(login.res.status).toBe(200)
+    expect(login.body.refreshToken).toBeDefined()
+
+    const newHash = await hashPassword('different-password')
+    await env.DB.prepare('UPDATE users SET password = ? WHERE username = ?')
+      .bind(newHash, 'refreshrotate')
+      .run()
+
+    const { res, body } = await jsonPost('/api/auth/refresh', {
+      refreshToken: login.body.refreshToken,
+    })
+    expect(res.status).toBe(401)
+    expect(body.message).toMatch(/sign in again/i)
+    expect(body.token).toBeUndefined()
+    expect(body.refreshToken).toBeUndefined()
+  })
+
+  it('accepts legacy refresh tokens that pre-date the tv claim', async () => {
+    await jsonPost('/api/auth/register', {
+      username: 'legacyrefresh',
+      password: 'password123',
+      inviteCode: TEST_INVITE_CODE,
+    })
+    const user = await env.DB.prepare('SELECT id, username FROM users WHERE username = ?')
+      .bind('legacyrefresh')
+      .first<{ id: string; username: string }>()
+    expect(user).not.toBeNull()
+
+    const refreshSecret = env.JWT_REFRESH_SECRET || env.JWT_SECRET
+    const legacy = await new SignJWT({
+      id: user!.id,
+      username: user!.username,
+      type: 'refresh',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('90d')
+      .sign(new TextEncoder().encode(refreshSecret))
+
+    const { res, body } = await jsonPost('/api/auth/refresh', { refreshToken: legacy })
+    expect(res.status).toBe(200)
+    expect(body.token).toBeDefined()
+    expect(body.refreshToken).toBeDefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
 // AUTH: VERIFY
 // ═══════════════════════════════════════════════════════════════════════
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -540,6 +540,15 @@ app.post('/auth/refresh', async (c) => {
       return c.json({ message: 'User not found' }, 401)
     }
 
+    // Match authMiddleware: refresh tokens minted after the tv rollout should
+    // die after a password reset, while legacy no-tv tokens remain valid.
+    if (typeof decoded.tv === 'string') {
+      const expected = await passwordFingerprint(user.password)
+      if (decoded.tv !== expected) {
+        return c.json({ message: 'Session expired, please sign in again' }, 401)
+      }
+    }
+
     const newAccessToken = await generateToken(user, c.env.JWT_SECRET)
     const newRefreshToken = await generateRefreshToken(user, refreshSecret)
 


### PR DESCRIPTION
## Summary
- Reject refresh tokens whose `tv` claim no longer matches the current user password fingerprint.
- Keep legacy refresh tokens without `tv` valid, matching the existing access-token middleware rollout behavior.
- Add regression coverage for refresh after password rotation plus legacy no-`tv` refresh compatibility.

## Validation
- `npm --workspace=@janata/backend exec -- vitest run src/__tests__/app.test.ts -t "POST /api/auth/refresh"`
- `npm --workspace=@janata/backend run typecheck`

## Notes
- This branch intentionally contains only the auth refresh route/test changes.