### PR TITLE
Scope sevak moderation access

### DIFF
--- a/packages/backend/src/__tests__/app.test.ts
+++ b/packages/backend/src/__tests__/app.test.ts
@@ -3445,6 +3445,34 @@ describe('moderation', () => {
     postId = post.post.id
   })
 
+  async function createReportedCenterPost(
+    centerName: string,
+    memberUsername: string,
+    body: string,
+  ): Promise<{ centerId: string; postId: string; memberToken: string }> {
+    const { body: center } = await jsonPost(
+      '/api/addCenter',
+      { centerName, latitude: 38.0, longitude: -122.0 },
+      authHeader(adminToken),
+    )
+    const member = await registerAndLogin(memberUsername, 'password123')
+    await env.DB.prepare('UPDATE users SET center_id = ? WHERE id = ?')
+      .bind(center.id, member.user.id)
+      .run()
+    const { body: post } = await jsonPost(
+      `/api/boards/center/${center.id}/posts`,
+      { body },
+      authHeader(member.token),
+    )
+    const report = await jsonPost(
+      `/api/boards/posts/${post.post.id}/report`,
+      { reason: 'out of scope' },
+      authHeader(member.token),
+    )
+    expect(report.res.status).toBe(201)
+    return { centerId: center.id, postId: post.post.id, memberToken: member.token }
+  }
+
   describe('POST /boards/posts/:postId/report', () => {
     it('lets an authenticated user report a post (201) and surfaces it in the queue', async () => {
       const reporter = await registerAndLogin('reporter1', 'password123')
@@ -3509,7 +3537,7 @@ describe('moderation', () => {
         .run()
     })
 
-    it('lets a sevak view the moderation queue (200)', async () => {
+    it('lets a sevak view reported posts in their own center scope', async () => {
       const reporter = await registerAndLogin('sevakreporter', 'password123')
       await jsonPost(`/api/boards/posts/${postId}/report`, { reason: 'spam' }, authHeader(reporter.token))
       const { res, body } = await fetchJSON('/api/admin/moderation/queue', {
@@ -3517,6 +3545,7 @@ describe('moderation', () => {
       })
       expect(res.status).toBe(200)
       expect(body.data).toHaveLength(1)
+      expect(body.data[0].post.id).toBe(postId)
     })
 
     it('lets a sevak remove a reported post + writes an audit entry', async () => {
@@ -3533,6 +3562,84 @@ describe('moderation', () => {
       })
       expect(aRes.status).toBe(200)
       expect(audit.data.length).toBeGreaterThan(0)
+    })
+
+    it('does not show another center report in a sevak moderation queue', async () => {
+      const reporter = await registerAndLogin('sevakreporter3', 'password123')
+      await jsonPost(`/api/boards/posts/${postId}/report`, { reason: 'spam' }, authHeader(reporter.token))
+      const other = await createReportedCenterPost(
+        'Other Mod Center',
+        'othermodmember',
+        'out-of-center post',
+      )
+
+      const { res, body } = await fetchJSON('/api/admin/moderation/queue', {
+        headers: authHeader(sevakToken),
+      })
+      expect(res.status).toBe(200)
+      expect(body.total).toBe(1)
+      expect(body.data.map((item: any) => item.post.id)).toEqual([postId])
+
+      const { body: adminQueue } = await fetchJSON('/api/admin/moderation/queue', {
+        headers: authHeader(adminToken),
+      })
+      expect(adminQueue.data.map((item: any) => item.post.id)).toEqual(
+        expect.arrayContaining([postId, other.postId]),
+      )
+    })
+
+    it('rejects sevak deletion outside scope but still allows own-center deletion', async () => {
+      const reporter = await registerAndLogin('sevakreporter4', 'password123')
+      await jsonPost(`/api/boards/posts/${postId}/report`, { reason: 'bad' }, authHeader(reporter.token))
+      const other = await createReportedCenterPost(
+        'Outside Delete Center',
+        'outsidedeletemember',
+        'out-of-center delete target',
+      )
+
+      const blocked = await jsonPost(
+        `/api/admin/moderation/posts/${other.postId}/delete`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(blocked.res.status).toBe(403)
+      const otherRow = await env.DB.prepare('SELECT deleted_at FROM board_posts WHERE id = ?')
+        .bind(other.postId)
+        .first<{ deleted_at: string | null }>()
+      expect(otherRow?.deleted_at).toBeNull()
+
+      const allowed = await jsonPost(
+        `/api/admin/moderation/posts/${postId}/delete`,
+        {},
+        authHeader(sevakToken),
+      )
+      expect(allowed.res.status).toBe(200)
+    })
+
+    it('scopes sevak audit entries to posts they can moderate', async () => {
+      const reporter = await registerAndLogin('sevakreporter5', 'password123')
+      await jsonPost(`/api/boards/posts/${postId}/report`, { reason: 'bad' }, authHeader(reporter.token))
+      const other = await createReportedCenterPost(
+        'Other Audit Center',
+        'otherauditmember',
+        'out-of-center audit target',
+      )
+
+      await jsonPost(`/api/admin/moderation/posts/${postId}/delete`, {}, authHeader(sevakToken))
+      await jsonPost(`/api/admin/moderation/posts/${other.postId}/delete`, {}, authHeader(adminToken))
+
+      const { res, body } = await fetchJSON('/api/admin/moderation/audit', {
+        headers: authHeader(sevakToken),
+      })
+      expect(res.status).toBe(200)
+      expect(body.data.map((item: any) => item.targetPostId)).toEqual([postId])
+
+      const { body: adminAudit } = await fetchJSON('/api/admin/moderation/audit', {
+        headers: authHeader(adminToken),
+      })
+      expect(adminAudit.data.map((item: any) => item.targetPostId)).toEqual(
+        expect.arrayContaining([postId, other.postId]),
+      )
     })
 
     it('does NOT let a sevak suspend a user — account actions stay admin-only (403)', async () => {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -192,6 +192,20 @@ async function moderatorMiddleware(c: any, next: () => Promise<void>): Promise<R
   await next()
 }
 
+// Content moderation policy: global admins moderate every report. Sevaks are
+// local moderators only: center-board reports for their own center, and
+// event-board reports when the event belongs to their center, was created by
+// them, or they attend it. Public/global feed reports have no local owner and
+// remain admin-only.
+function moderationScopeFor(user: UserRow): db.ModerationScope {
+  if (isAdmin(user)) return { isAdmin: true }
+  return {
+    isAdmin: false,
+    userId: user.id,
+    centerId: user.center_id,
+  }
+}
+
 // ── Global error handler ──────────────────────────────────────────────
 
 app.onError((err, c) => {
@@ -3259,12 +3273,18 @@ app.delete('/admin/notifications/:id', adminMiddleware, async (c) => {
 
 /** Admin moderation queue: reported posts grouped by post, newest first. */
 app.get('/admin/moderation/queue', moderatorMiddleware, async (c) => {
+  const moderator = c.get('user')
   const url = new URL(c.req.url)
   const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '50', 10) || 50, 1), 100)
   const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10) || 0, 0)
   const includeResolved = url.searchParams.get('includeResolved') === 'true'
 
-  const { items, total } = await db.listModerationQueue(c.env.DB, { limit, offset, includeResolved })
+  const { items, total } = await db.listModerationQueue(c.env.DB, {
+    limit,
+    offset,
+    includeResolved,
+    scope: moderationScopeFor(moderator),
+  })
   return c.json({
     data: items.map((item) => ({
       post: boardPostToApi(item.post),
@@ -3290,7 +3310,18 @@ app.post('/admin/moderation/posts/:postId/delete', moderatorMiddleware, async (c
     return c.json({ message: 'Board post not found' }, 404)
   }
 
-  const result = await db.softDeleteBoardPost(c.env.DB, postId, { id: admin.id, isAdmin: true })
+  const scope = moderationScopeFor(admin)
+  const canModerate = await db.canModerateBoardPost(c.env.DB, postId, scope)
+  if (!canModerate) {
+    return c.json({ message: 'You do not have access to moderate this post' }, 403)
+  }
+
+  const userIsAdmin = isAdmin(admin)
+  const result = await db.softDeleteBoardPost(c.env.DB, postId, {
+    id: admin.id,
+    isAdmin: userIsAdmin,
+    canModerate: !userIsAdmin,
+  })
   // already_deleted is fine — the post is gone either way; we still resolve
   // reports and log the action so the queue clears.
   if (!result.ok && result.reason === 'not_found') {
@@ -3388,10 +3419,15 @@ app.post('/admin/moderation/users/:userId/unsuspend', adminMiddleware, async (c)
 
 /** Admin: moderation audit log, newest first. */
 app.get('/admin/moderation/audit', moderatorMiddleware, async (c) => {
+  const moderator = c.get('user')
   const url = new URL(c.req.url)
   const limit = Math.min(Math.max(parseInt(url.searchParams.get('limit') ?? '50', 10) || 50, 1), 100)
   const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10) || 0, 0)
-  const { items, total } = await db.listModerationActions(c.env.DB, { limit, offset })
+  const { items, total } = await db.listModerationActions(c.env.DB, {
+    limit,
+    offset,
+    scope: moderationScopeFor(moderator),
+  })
   return c.json({ data: items.map(moderationActionRowToApi), total, limit, offset })
 })
 

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -1123,7 +1123,7 @@ export type BoardPostDeleteResult =
 export async function softDeleteBoardPost(
   db: D1Database,
   postId: string,
-  actor: { id: string; isAdmin: boolean },
+  actor: { id: string; isAdmin: boolean; canModerate?: boolean },
 ): Promise<BoardPostDeleteResult> {
   const post = await db
     .prepare(`SELECT author_id, deleted_at FROM board_posts WHERE id = ?1`)
@@ -1132,7 +1132,7 @@ export async function softDeleteBoardPost(
 
   if (!post) return { ok: false, reason: 'not_found' }
   if (post.deleted_at) return { ok: false, reason: 'already_deleted' }
-  if (post.author_id !== actor.id && !actor.isAdmin) {
+  if (post.author_id !== actor.id && !actor.isAdmin && !actor.canModerate) {
     return { ok: false, reason: 'forbidden' }
   }
 
@@ -1416,6 +1416,55 @@ export type ModerationQueueRow = {
   status: 'open' | 'actioned'
 }
 
+export type ModerationScope =
+  | { isAdmin: true }
+  | { isAdmin: false; userId: string; centerId: string | null }
+
+function scopedModerationWhere(): string {
+  return `bp.board_id IS NOT NULL
+    AND (
+      (b.type = 'center' AND ? = 1 AND b.parent_id = ?)
+      OR
+      (b.type = 'event' AND (
+        (? = 1 AND e.center_id = ?)
+        OR e.created_by = ?
+        OR EXISTS (
+          SELECT 1 FROM event_attendees ea
+          WHERE ea.event_id = e.id AND ea.user_id = ?
+        )
+      ))
+    )`
+}
+
+function scopedModerationParams(
+  scope: Extract<ModerationScope, { isAdmin: false }>,
+): Array<string | number> {
+  const hasCenter = scope.centerId ? 1 : 0
+  const centerId = scope.centerId ?? ''
+  return [hasCenter, centerId, hasCenter, centerId, scope.userId, scope.userId]
+}
+
+export async function canModerateBoardPost(
+  db: D1Database,
+  postId: string,
+  scope: ModerationScope,
+): Promise<boolean> {
+  if (scope.isAdmin) return true
+
+  const result = await db
+    .prepare(
+      `SELECT 1
+       FROM board_posts bp
+       LEFT JOIN boards b ON b.id = bp.board_id
+       LEFT JOIN events e ON b.type = 'event' AND e.id = b.parent_id
+       WHERE bp.id = ? AND ${scopedModerationWhere()}
+       LIMIT 1`,
+    )
+    .bind(postId, ...scopedModerationParams(scope))
+    .first()
+  return result !== null
+}
+
 /**
  * File or update a report on a board post. One report per (post, reporter):
  * re-reporting updates the reason and re-opens the report.
@@ -1450,35 +1499,53 @@ export async function createPostReport(
  */
 export async function listModerationQueue(
   db: D1Database,
-  opts: { limit?: number; offset?: number; includeResolved?: boolean } = {},
+  opts: {
+    limit?: number
+    offset?: number
+    includeResolved?: boolean
+    scope?: ModerationScope
+  } = {},
 ): Promise<{ items: ModerationQueueRow[]; total: number }> {
   const limit = Math.min(Math.max(opts.limit ?? 50, 1), 100)
   const offset = Math.max(opts.offset ?? 0, 0)
   const havingOpen = opts.includeResolved ? '' : 'HAVING open_count > 0'
+  const scope = opts.scope ?? { isAdmin: true as const }
+  const where = scope.isAdmin ? '1 = 1' : scopedModerationWhere()
+  const scopeParams = scope.isAdmin ? [] : scopedModerationParams(scope)
 
   const totalRow = await db
     .prepare(
       `SELECT COUNT(*) AS count FROM (
-         SELECT post_id, SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_count
-         FROM post_reports GROUP BY post_id ${havingOpen}
+         SELECT pr.post_id, SUM(CASE WHEN pr.status = 'open' THEN 1 ELSE 0 END) AS open_count
+         FROM post_reports pr
+         JOIN board_posts bp ON bp.id = pr.post_id
+         LEFT JOIN boards b ON b.id = bp.board_id
+         LEFT JOIN events e ON b.type = 'event' AND e.id = b.parent_id
+         WHERE ${where}
+         GROUP BY pr.post_id ${havingOpen}
        )`,
     )
+    .bind(...scopeParams)
     .first<{ count: number }>()
   const total = totalRow?.count ?? 0
 
   const grouped = await db
     .prepare(
-      `SELECT post_id,
+      `SELECT pr.post_id,
               COUNT(*) AS report_count,
-              SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_count,
-              MAX(created_at) AS latest_at
-       FROM post_reports
-       GROUP BY post_id
+              SUM(CASE WHEN pr.status = 'open' THEN 1 ELSE 0 END) AS open_count,
+              MAX(pr.created_at) AS latest_at
+       FROM post_reports pr
+       JOIN board_posts bp ON bp.id = pr.post_id
+       LEFT JOIN boards b ON b.id = bp.board_id
+       LEFT JOIN events e ON b.type = 'event' AND e.id = b.parent_id
+       WHERE ${where}
+       GROUP BY pr.post_id
        ${havingOpen}
        ORDER BY latest_at DESC
-       LIMIT ?1 OFFSET ?2`,
+       LIMIT ? OFFSET ?`,
     )
-    .bind(limit, offset)
+    .bind(...scopeParams, limit, offset)
     .all<{ post_id: string; report_count: number; open_count: number; latest_at: string }>()
 
   const rows = grouped.results ?? []
@@ -1557,10 +1624,41 @@ export async function createModerationAction(
 /** List moderation audit log entries, newest first. */
 export async function listModerationActions(
   db: D1Database,
-  opts: { limit?: number; offset?: number } = {},
+  opts: { limit?: number; offset?: number; scope?: ModerationScope } = {},
 ): Promise<{ items: ModerationActionRow[]; total: number }> {
   const limit = Math.min(Math.max(opts.limit ?? 50, 1), 100)
   const offset = Math.max(opts.offset ?? 0, 0)
+  const scope = opts.scope ?? { isAdmin: true as const }
+
+  if (!scope.isAdmin) {
+    const where = scopedModerationWhere()
+    const scopeParams = scopedModerationParams(scope)
+    const totalRow = await db
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM moderation_actions ma
+         JOIN board_posts bp ON bp.id = ma.target_post_id
+         LEFT JOIN boards b ON b.id = bp.board_id
+         LEFT JOIN events e ON b.type = 'event' AND e.id = b.parent_id
+         WHERE ${where}`,
+      )
+      .bind(...scopeParams)
+      .first<{ count: number }>()
+    const result = await db
+      .prepare(
+        `SELECT ma.*
+         FROM moderation_actions ma
+         JOIN board_posts bp ON bp.id = ma.target_post_id
+         LEFT JOIN boards b ON b.id = bp.board_id
+         LEFT JOIN events e ON b.type = 'event' AND e.id = b.parent_id
+         WHERE ${where}
+         ORDER BY ma.created_at DESC LIMIT ? OFFSET ?`,
+      )
+      .bind(...scopeParams, limit, offset)
+      .all<ModerationActionRow>()
+    return { items: result.results ?? [], total: totalRow?.count ?? 0 }
+  }
+
   const totalRow = await db
     .prepare('SELECT COUNT(*) AS count FROM moderation_actions')
     .first<{ count: number }>()


### PR DESCRIPTION
## Summary
- Scope moderation queue and audit results so global admins still see everything, while sevaks only see center-board reports for their own center and event-board reports for events tied to their center, created by them, or attended by them.
- Add an explicit scoped moderation check before deleting a reported post, and use a separate `canModerate` delete capability instead of treating sevaks as global admins.
- Add regression tests for sevak queue visibility, delete denial outside center scope, allowed own-scope delete, and audit filtering.

## Root cause
Sevaks passed the moderator gate, but queue/audit queries were global and the moderation delete route always called `softDeleteBoardPost` with `isAdmin: true`.

## Validation
- `npm run typecheck:backend`
- `npm run test:cloudflare:app`
