### PR TITLE
[codex] Fix Pages project deploy comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,10 +76,8 @@ jobs:
           EXPO_PUBLIC_POSTHOG_HOST: ${{ secrets.EXPO_PUBLIC_POSTHOG_HOST }}
 
       - name: Deploy production frontend
-        # CF Pages project name is `project-janatha`; custom domain
-        # chinmayajanata.org CNAMEs to project-janatha.pages.dev.
-        # The old `chinmaya-janata` Pages project is frozen; deploys here
-        # would silently no-op due to API token scoping. See #165.
+        # CF Pages project name is `chinmaya-janata`; its pages.dev host is
+        # project-janatha.pages.dev, and chinmayajanata.org is attached there.
         run: npx wrangler pages deploy dist --project-name chinmaya-janata --branch __release
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Correct the production frontend deploy comment to say the Cloudflare Pages project is `chinmaya-janata`.
- Keep the actual `wrangler pages deploy --project-name chinmaya-janata` command unchanged.
- Clarify that `project-janatha.pages.dev` is the Pages host/custom-domain attachment, not the project name.

## Why

The deploy command was already using the correct Cloudflare Pages project name. The surrounding comment incorrectly claimed the project was `project-janatha`, which contradicted the command and the current Cloudflare dashboard state.

## Validation

- Not run; comment-only workflow change.