### PR TITLE
fix(ui): event Cancel button invisible in light mode + button-style consistency sweep

### DIFF
--- a/packages/frontend/components/boards/EmptyPanel.tsx
+++ b/packages/frontend/components/boards/EmptyPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { View, Text, Pressable } from 'react-native'
 import type { AppColors } from '../../tokens'
 
@@ -15,6 +15,10 @@ export function EmptyPanel({
   actionLabel?: string
   onAction?: () => void
 }) {
+  // NativeWind 4's CssInterop drops the function-style `style={({ pressed }) =>}`
+  // callback on Pressable, which stripped the accent background and left the
+  // white (textInverse) label invisible. Use a static style + state-driven press.
+  const [pressed, setPressed] = useState(false)
   return (
     <View style={{ paddingVertical: 18, paddingHorizontal: 4, gap: 5 }}>
       <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 17, color: colors.text }}>{title}</Text>
@@ -24,7 +28,9 @@ export function EmptyPanel({
           accessibilityRole="button"
           accessibilityLabel={actionLabel}
           onPress={onAction}
-          style={({ pressed }) => ({
+          onPressIn={() => setPressed(true)}
+          onPressOut={() => setPressed(false)}
+          style={{
             alignSelf: 'flex-start',
             marginTop: 10,
             paddingHorizontal: 16,
@@ -32,7 +38,7 @@ export function EmptyPanel({
             borderRadius: 999,
             backgroundColor: colors.accent,
             opacity: pressed ? 0.85 : 1,
-          })}
+          }}
         >
           <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textInverse }}>
             {actionLabel}

--- a/packages/frontend/components/ui/buttons/DestructiveButton.tsx
+++ b/packages/frontend/components/ui/buttons/DestructiveButton.tsx
@@ -9,6 +9,14 @@ interface DestructiveButtonProps {
   style?: object
 }
 
+// NativeWind 4's CssInterop silently drops the function-style
+// `style={({ pressed }) => ...}` callback on Pressable, so this button's red
+// background/padding/radius never applied — leaving white text on a
+// transparent background (invisible in light mode; see the event "Cancel
+// Registration" button). Fix: drive styling via className (which IS
+// interop-processed) with `active:` for press feedback — same pattern as
+// PrimaryButton.native. Arbitrary hex keeps the exact red regardless of the
+// Tailwind theme config.
 export default function DestructiveButton({ children, onPress, disabled, loading, style }: DestructiveButtonProps) {
   const isDisabled = disabled || loading
 
@@ -16,23 +24,18 @@ export default function DestructiveButton({ children, onPress, disabled, loading
     <Pressable
       onPress={!isDisabled ? onPress : undefined}
       disabled={isDisabled}
-      style={({ pressed }) => [
-        {
-          backgroundColor: pressed ? '#B91C1C' : '#DC2626',
-          paddingHorizontal: 16,
-          paddingVertical: 14,
-          borderRadius: 999,
-          alignItems: 'center',
-          justifyContent: 'center',
-          opacity: isDisabled ? 0.5 : 1,
-        },
-        style,
-      ]}
+      className={[
+        'bg-[#DC2626] active:bg-[#B91C1C]',
+        'px-4 py-3.5 rounded-full',
+        'items-center justify-center',
+        isDisabled ? 'opacity-50' : '',
+      ].join(' ')}
+      style={style}
     >
       {loading ? (
         <ActivityIndicator size="small" color="#FFFFFF" />
       ) : (
-        <Text style={{ fontWeight: '500', fontSize: 15, lineHeight: 20, color: '#FFFFFF', textAlign: 'center' }}>
+        <Text className="text-white font-medium text-[15px] leading-5">
           {children}
         </Text>
       )}

--- a/packages/frontend/components/ui/buttons/GhostButton.tsx
+++ b/packages/frontend/components/ui/buttons/GhostButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Pressable, Text } from 'react-native'
 import { useColors } from '../../../hooks/useColors'
 
@@ -9,14 +9,20 @@ interface GhostButtonProps {
   style?: object
 }
 
+// NativeWind 4's CssInterop drops the function-style `style={({ pressed }) =>}`
+// callback on Pressable. Use an array style with state-driven press feedback so
+// the padding/press background keep applying. See PrimaryButton.native.
 export default function GhostButton({ children, onPress, disabled, style }: GhostButtonProps) {
   const c = useColors()
+  const [pressed, setPressed] = useState(false)
 
   return (
     <Pressable
       onPress={!disabled ? onPress : undefined}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
       disabled={disabled}
-      style={({ pressed }) => [
+      style={[
         {
           backgroundColor: pressed ? c.surface : 'transparent',
           paddingHorizontal: 16,

--- a/packages/frontend/components/ui/buttons/IconButton.tsx
+++ b/packages/frontend/components/ui/buttons/IconButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Pressable } from 'react-native'
 import { useColors } from '../../../hooks/useColors'
 
@@ -11,14 +11,20 @@ interface IconButtonProps {
   style?: object
 }
 
+// NativeWind 4's CssInterop drops the function-style `style={({ pressed }) =>}`
+// callback on Pressable, which stripped the icon button's background/border.
+// Use an array style with state-driven press feedback. See PrimaryButton.native.
 export default function IconButton({ children, variant = 'solid', onPress, disabled, size = 36, style }: IconButtonProps) {
   const c = useColors()
+  const [pressed, setPressed] = useState(false)
 
   return (
     <Pressable
       onPress={!disabled ? onPress : undefined}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
       disabled={disabled}
-      style={({ pressed }) => [
+      style={[
         {
           width: size,
           height: size,

--- a/packages/frontend/components/ui/buttons/SecondaryButton.tsx
+++ b/packages/frontend/components/ui/buttons/SecondaryButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { ActivityIndicator, Pressable, Text } from 'react-native'
 import { useColors } from '../../../hooks/useColors'
 
@@ -10,15 +10,22 @@ interface SecondaryButtonProps {
   style?: object
 }
 
+// NativeWind 4's CssInterop drops the function-style `style={({ pressed }) =>}`
+// callback on Pressable, which stripped this button's border/padding/background.
+// Use an array style (interop-processed) with state-driven press feedback so the
+// theme colors from useColors() keep working without a function callback.
 export default function SecondaryButton({ children, onPress, disabled, loading, style }: SecondaryButtonProps) {
   const c = useColors()
+  const [pressed, setPressed] = useState(false)
   const isDisabled = disabled || loading
 
   return (
     <Pressable
       onPress={!isDisabled ? onPress : undefined}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
       disabled={isDisabled}
-      style={({ pressed }) => [
+      style={[
         {
           borderWidth: 1,
           borderColor: c.border,


### PR DESCRIPTION
## Problem
The event page's **Cancel Registration** button was invisible in light mode (white text on no background — see screenshot).

## Root cause
NativeWind 4's CssInterop **silently drops the `style={({ pressed }) => ...}` function form** on `Pressable` (already documented in `PrimaryButton.native.tsx`). The background/padding/border live in that callback, so they never apply. When the label is light/white, the result is white-on-transparent = invisible.

## Fixed
| Component | Was | Now |
|---|---|---|
| `DestructiveButton` (event + settings cancel) | white text, dropped red bg → **invisible** | `className` + `active:` (arbitrary hex `#DC2626`/`#B91C1C`) |
| `EmptyPanel` accent CTA | `textInverse` on dropped accent bg → **invisible** | static style + state press |
| `SecondaryButton` / `GhostButton` / `IconButton` | dropped border/padding/press (dark text/icons stayed visible) | array style + state-driven press |

All keep their exact visuals and regain press feedback. `tsc --noEmit` clean.

## Audit — remaining function-style Pressables (NOT broken, lower priority)
These use the same anti-pattern but their content stays visible today (icon or dark/theme text), so they only lose press-state chrome — safe to harden in a follow-up:
- `components/ui/TabHeader.tsx` (icon buttons)
- `components/ui/AuthPromptModal.tsx` (× close — `colors.text`)
- `components/invite/InviteCodeField.tsx`
- `app/(tabs)/profile.web.tsx` (web)
- `components/events/EventDetailPanel.web.tsx` (web cancel — dark-red text, visible)

## Verify
- Light + dark mode: event "Cancel Registration" is a solid red button.
- Board/feed empty-state CTA (EmptyPanel) shows its orange button.
- Secondary/Ghost/Icon buttons render with padding/border + press feedback.