### PR TITLE
[codex] Bump Hono to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "expo-contacts": "^55.0.14",
         "expo-image-picker": "^55.0.18",
         "expo-splash-screen": "^55.0.20",
-        "hono": "^4.7.0",
+        "hono": "^4.12.25",
         "jose": "^6.0.0",
         "nativewind": "4.2.2",
         "node-addon-api": "^8.0.0",
@@ -9659,9 +9659,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -17660,7 +17660,7 @@
       "name": "@janata/backend",
       "version": "0.2.0",
       "dependencies": {
-        "hono": "^4.7.0",
+        "hono": "^4.12.25",
         "jose": "^6.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "expo-contacts": "^55.0.14",
     "expo-image-picker": "^55.0.18",
     "expo-splash-screen": "^55.0.20",
-    "hono": "^4.7.0",
+    "hono": "^4.12.25",
     "jose": "^6.0.0",
     "nativewind": "4.2.2",
     "node-addon-api": "^8.0.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "seed:dev-users": "node src/seed/dev-users.mjs"
   },
   "dependencies": {
-    "hono": "^4.7.0",
+    "hono": "^4.12.25",
     "jose": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump the root and backend `hono` dependency range to `^4.12.25`.
- Refresh `package-lock.json` so the resolved Hono version is `4.12.25`.

## Why

`npm audit` reported the locked `hono@4.12.23` version. The advisories are fixed in `4.12.25`, and Hono is a direct backend runtime dependency.

## Validation

- `npm ci`
- `npm ls hono`
- `npm run typecheck:backend`
- `npm run test:backend`
- `npm run test:cloudflare:app`
- `npm run test:frontend`
- `npm audit --json` confirms `hono` is no longer reported