### PR TITLE
fix(events): move attendee roster into the edit form (web + native)

### DIFF
--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -26,7 +26,6 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../../compon
 import { PostThread, type FeedPost } from '../../components/feed'
 import { buildFeedPostFromMessage } from '../../components/feed/feedData'
 import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
-import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 
 const ADMIN_EMAIL = 'chinmayajanata@gmail.com'
 
@@ -825,13 +824,6 @@ export default function EventDetailPage() {
             ) : null}
             <AttendeesContent attendees={attendees} colors={colors} />
           </DetailSection>
-        )}
-
-        {/* COORDINATOR ROSTER — creator/admin only: full list w/ emails + guests + CSV export */}
-        {canEdit && (
-          <View style={{ paddingHorizontal: 20 }}>
-            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
-          </View>
         )}
 
         {/* COMMENTS — board posts, feed-style. Composer sits at the top of the

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -12,7 +12,6 @@ import Badge from '../../components/ui/Badge'
 import PrimaryButton from '../../components/ui/buttons/PrimaryButton'
 import DestructiveButton from '../../components/ui/buttons/DestructiveButton'
 import GuestRsvpSheet from '../../components/events/GuestRsvpSheet'
-import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 import { DetailSection } from '../../components/ui'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useColors } from '../../hooks/useColors'
@@ -320,13 +319,6 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
               </View>
             )}
           </DetailSection>
-        )}
-
-        {/* COORDINATOR ROSTER — creator/admin only: full list w/ emails + guests + CSV export */}
-        {canEdit && (
-          <View style={{ paddingHorizontal: 20 }}>
-            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
-          </View>
         )}
 
         {/* COMMENTS */}

--- a/packages/frontend/app/events/form.tsx
+++ b/packages/frontend/app/events/form.tsx
@@ -17,6 +17,7 @@ import DateTimePicker from '@react-native-community/datetimepicker'
 import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { PrimaryButton } from '../../components/ui'
+import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import {
   fetchEvent,
@@ -834,6 +835,14 @@ export default function EventFormPage() {
             </View>
           )}
         </View>
+
+        {/* Manage attendees — edit only; the detail view already shows the
+            public attendee list, so the full roster + CSV export lives here. */}
+        {isEdit && eventId && (
+          <View style={{ paddingHorizontal: 20, marginTop: 8, marginBottom: 24 }}>
+            <EventAttendeeRoster eventId={eventId} eventTitle={title} />
+          </View>
+        )}
       </ScrollView>
 
       {/* Sticky action bar */}

--- a/packages/frontend/app/events/form.web.tsx
+++ b/packages/frontend/app/events/form.web.tsx
@@ -16,6 +16,7 @@ import { useAnalytics } from '../../utils/analytics'
 import { useTheme } from '../../components/contexts'
 import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { PrimaryButton, SecondaryButton } from '../../components/ui'
+import EventAttendeeRoster from '../../components/events/EventAttendeeRoster'
 import {
   fetchEvent,
   fetchCenters,
@@ -697,6 +698,14 @@ export default function EventFormPage() {
             </>
           )}
         </View>
+
+        {/* Manage attendees — edit only; the detail view already shows the
+            public attendee list, so the full roster + CSV export lives here. */}
+        {isEdit && eventId && (
+          <View style={{ paddingHorizontal: 20, marginTop: 8, marginBottom: 24 }}>
+            <EventAttendeeRoster eventId={eventId} eventTitle={title} />
+          </View>
+        )}
       </ScrollView>
 
       {/* Sticky action bar */}

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -14,7 +14,6 @@ import { ThreadPanel, boardPostToMessage, type BoardMessage } from '../boards'
 import { PostThread, type FeedPost } from '../feed'
 import { buildFeedPostFromMessage } from '../feed/feedData'
 import { useUser } from '../contexts'
-import EventAttendeeRoster from './EventAttendeeRoster'
 
 // ---------------------------------------------------------------------------
 // Date helpers
@@ -666,8 +665,6 @@ function DefaultContent({
         <AboutSection description={event.description} colors={colors} />
       )}
 
-      {/* Coordinator roster — creator/admin only */}
-      {canManage && <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />}
     </ScrollView>
   )
 }
@@ -727,13 +724,6 @@ function RegisteredContent({
         <DetailSection title="People" count={attendees.length} contentStyle={{ paddingHorizontal: 0 }}>
           <PeopleTab attendees={attendees} colors={colors} />
         </DetailSection>
-
-        {/* Coordinator roster — creator/admin only */}
-        {canManage && (
-          <View style={{ paddingHorizontal: 24 }}>
-            <EventAttendeeRoster eventId={event.id} eventTitle={event.title} />
-          </View>
-        )}
 
         {/* ── DISCUSSION ────────────────────────────────────────── */}
         <DetailSection title="Discussion" count={boardMessages.length} contentStyle={{ paddingHorizontal: 0 }}>

--- a/packages/frontend/components/events/EventFormPanel.web.tsx
+++ b/packages/frontend/components/events/EventFormPanel.web.tsx
@@ -5,6 +5,7 @@ import { useDetailColors, type DetailColors } from '../../hooks/useDetailColors'
 import { useTheme } from '../contexts'
 import PrimaryButton from '../ui/buttons/PrimaryButton'
 import SecondaryButton from '../ui/buttons/SecondaryButton'
+import EventAttendeeRoster from './EventAttendeeRoster'
 import {
   fetchEvent,
   fetchCenters,
@@ -775,6 +776,14 @@ export default function EventFormPanel({ eventId, onClose, onSaved }: EventFormP
             })}
           </View>
         </View>
+
+        {/* Manage attendees — edit only; the detail view already shows the
+            public attendee list, so the full roster + CSV export lives here. */}
+        {isEdit && eventId && (
+          <View style={{ paddingHorizontal: 20, marginTop: 8, marginBottom: 24 }}>
+            <EventAttendeeRoster eventId={eventId} eventTitle={title} />
+          </View>
+        )}
       </ScrollView>
 
       {/* Sticky action bar */}


### PR DESCRIPTION
## Problem
The "Manage attendees" roster card showed on the **event detail view**. The detail view already shows the attendee list, making the roster redundant there — and because localhost force-trues the admin gate, non-editors saw a "You do not have access to this roster" card.

## Change
Move the roster (full list + emails/guests + CSV export) out of the detail view and into the **event edit form**, shown only when editing an existing event. Only editors can reach the edit form, so it's naturally editor-only.

**Removed from detail views:** `app/events/[id].tsx` (native), `app/events/[id].web.tsx` (web full-page), `components/events/EventDetailPanel.web.tsx` (Explore split-view, both layouts).

**Added to edit forms (`{isEdit && eventId}`):** `app/events/form.tsx` (native), `app/events/form.web.tsx` (web full-page), `components/events/EventFormPanel.web.tsx` (Explore split-view).

## Verify
- Non-editor on an event: no "Manage attendees" card (just the attendee list).
- Editor → edit event → roster + CSV export at the bottom of the form.
- Both web and native. `tsc --noEmit` clean.