### PR TITLE
build(ios): pin buildNumber 34, drop broken local autoIncrement

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -167,7 +167,7 @@
     "ios": {
       "icon": "./assets/images/logo.png",
       "supportsTablet": true,
-      "buildNumber": "32",
+      "buildNumber": "34",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",

--- a/packages/frontend/eas.json
+++ b/packages/frontend/eas.json
@@ -43,7 +43,6 @@
       }
     },
     "production": {
-      "autoIncrement": true,
       "channel": "production",
       "ios": {
         "resourceClass": "m-medium"


### PR DESCRIPTION
Local `appVersionSource` + `autoIncrement` was re-deriving 32→33 every build without persisting, producing duplicate build 33s (TestFlight rejects dupes). Pin an explicit `buildNumber: 34` and remove the no-op autoIncrement. Bump per release going forward, or switch to remote appVersionSource for hands-off increments.