### PR TITLE
build(ios): remote appVersionSource (hands-off auto-increment)

### DIFF
--- a/packages/frontend/app.json
+++ b/packages/frontend/app.json
@@ -167,7 +167,7 @@
     "ios": {
       "icon": "./assets/images/logo.png",
       "supportsTablet": true,
-      "buildNumber": "34",
+      "buildNumber": "35",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Chinmaya Janata uses your location to show nearby centers and events on the map.",
         "NSPhotoLibraryUsageDescription": "Chinmaya Janata needs access to your photo library to set your profile picture.",

--- a/packages/frontend/eas.json
+++ b/packages/frontend/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 12.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -43,6 +43,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "channel": "production",
       "ios": {
         "resourceClass": "m-medium"


### PR DESCRIPTION
Switches `cli.appVersionSource` to `remote` and restores `autoIncrement: true` on the production profile so EAS tracks + bumps the iOS build number server-side every build (fixes the local-source stuck-dup issue from #526 properly). Seeds `app.json` buildNumber to 35 (34 is the last ASC build) so the first remote build is dup-free; EAS owns the number after that.