### PR TITLE
fix(home): board peek pulls aggregated feed (public + center + joined events)

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1882,7 +1882,13 @@ app.get('/feed', authMiddleware, async (c) => {
   )
 
   return c.json({
-    posts: posts.map(boardPostToApi),
+    // Each feed post carries its board source (kind + display label) so clients
+    // can show "Public" / center name / event title without a second lookup.
+    posts: posts.map((p) => ({
+      ...boardPostToApi(p),
+      sourceKind: (p as unknown as { source_kind?: string }).source_kind,
+      sourceLabel: (p as unknown as { source_label?: string | null }).source_label,
+    })),
   })
 })
 

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -1348,7 +1348,13 @@ export async function listAggregatedFeed(
   //   event board the user has an event_attendees row for
   const result = await db
     .prepare(
-      `SELECT bp.*
+      `SELECT bp.*,
+         CASE WHEN bp.visibility = 'public_signed_in' THEN 'public' ELSE b.type END AS source_kind,
+         CASE
+           WHEN bp.visibility = 'public_signed_in' THEN 'Public'
+           WHEN b.type = 'center' THEN (SELECT name FROM centers WHERE id = b.parent_id)
+           WHEN b.type = 'event'  THEN (SELECT title FROM events WHERE id = b.parent_id)
+         END AS source_label
        FROM board_posts bp
        LEFT JOIN boards b ON b.id = bp.board_id
        WHERE bp.deleted_at IS NULL

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '../../utils/analytics'
 import { useUser } from '../../components/contexts'
 import { useColors } from '../../hooks/useColors'
 import { useDetailColors } from '../../hooks/useDetailColors'
-import { useDiscoverData, useMyEvents, useBoard } from '../../hooks/useApiData'
+import { useDiscoverData, useMyEvents, useAggregatedFeed } from '../../hooks/useApiData'
 import type { EventDisplay } from '../../utils/api'
 import { extractCityState } from '../../utils/addressParsing'
 import { FeaturedEventCard, type FeaturedSource } from '../../components/home/FeaturedEventCard'
@@ -82,9 +82,11 @@ export default function HomeScreen() {
     'Events', '', user?.id, false, false, false, user?.interests ?? undefined, user?.centerID
   )
 
-  // Boards peek (#199): surface the 1-2 latest posts from the user's center
-  // board so Home reflects real activity instead of a permanent empty state.
-  const { posts: centerBoardPosts } = useBoard('center', user?.centerID ?? undefined, !!user?.centerID)
+  // Boards peek (#199): surface the 1-2 latest posts from the user's ACTUAL
+  // activity — the aggregated feed (public + their center board + boards for
+  // events they've joined), not just the center board. Matches the "your
+  // center and events you've joined" promise in the slot copy.
+  const { posts: feedPosts, refetch: refetchFeed } = useAggregatedFeed(!!user)
   const userCenter = useMemo(
     () => allCenters.find((item) => item.id === user?.centerID),
     [allCenters, user?.centerID]
@@ -92,29 +94,30 @@ export default function HomeScreen() {
   const centerName = userCenter?.name
   const boardPeek = useMemo(
     () =>
-      centerBoardPosts.slice(0, 2).map((post) => ({
+      feedPosts.slice(0, 2).map((post) => ({
         ...boardPostToMessage(post),
-        sourceKind: 'center' as const,
-        sourceLabel: centerName ?? 'Your center',
+        sourceKind: post.sourceKind ?? 'center',
+        sourceLabel: post.sourceLabel ?? centerName ?? 'Your center',
       })),
-    [centerBoardPosts, centerName]
+    [feedPosts, centerName]
   )
 
   useFocusEffect(
     useCallback(() => {
       refetchMyEvents()
       refreshDiscover()
-    }, [refetchMyEvents, refreshDiscover])
+      refetchFeed()
+    }, [refetchMyEvents, refreshDiscover, refetchFeed])
   )
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true)
     try {
-      await Promise.all([refetchMyEvents(), refreshDiscover({ force: true })])
+      await Promise.all([refetchMyEvents(), refreshDiscover({ force: true }), refetchFeed()])
     } finally {
       setRefreshing(false)
     }
-  }, [refetchMyEvents, refreshDiscover])
+  }, [refetchMyEvents, refreshDiscover, refetchFeed])
 
   // Desktop two-column composition is web-only and gated on a wide breakpoint.
   // Mobile web and native use a single centered column.

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -8,6 +8,7 @@ import {
   fetchAllEvents,
   fetchEventUsers,
   fetchBoard,
+  fetchAggregatedFeed,
   attendEvent,
   unattendEvent,
   getUserEvents,
@@ -632,6 +633,36 @@ export function useBoard(type: BoardType, parentId: string | undefined, enabled 
   }, [load])
 
   return { posts, loading, error, refetch: load }
+}
+
+// Aggregated cross-board feed (#205 / GET /feed): public + the user's center
+// board + boards for events they've joined, reverse-chronological. Used by the
+// Home "Latest on your board" peek so it reflects real activity, not just the
+// center board. Each post carries sourceKind/sourceLabel for display.
+export function useAggregatedFeed(enabled = true, limit = 20) {
+  const [posts, setPosts] = useState<BoardPostData[]>([])
+  const [loading, setLoading] = useState(enabled)
+
+  const load = useCallback(async () => {
+    if (!enabled) {
+      setPosts([])
+      setLoading(false)
+      return
+    }
+    try {
+      setLoading(true)
+      const data = await fetchAggregatedFeed({ limit })
+      setPosts(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [enabled, limit])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  return { posts, loading, refetch: load }
 }
 
 // ── Discover hooks ──────────────────────────────────────────────────

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -125,6 +125,10 @@ export interface BoardPostData {
   // #205 boards enhancements — present once the post has been pinned (#249).
   pinnedAt?: string | null
   pinnedBy?: string | null
+  // Only on the aggregated /feed response: the post's board source so the
+  // Home peek can label it ("Public" / center name / event title).
+  sourceKind?: 'public' | 'center' | 'event'
+  sourceLabel?: string | null
 }
 
 // ── Discover-specific types ─────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Home's "Latest on your board" peek used `useBoard('center', …)` — center board only. So it showed "Your board will fill in" even when there were posts on the **Public** board or **event** boards the user joined (reported: posts visible on Feed, empty on Home).

## Fix
- New `useAggregatedFeed` hook → `GET /feed` (public + center + joined-event posts, reverse-chron). Home peek shows the latest 1–2.
- `/feed` query now returns per-post `sourceKind` + `sourceLabel` (Public / center name / event title) so the peek labels the source without a second lookup.

## Scope
Backend: `listAggregatedFeed` SELECT + `/feed` serializer. Frontend: `BoardPostData` type, `useAggregatedFeed`, Home peek. Feed tab unaffected (extra fields ignored). `tsc` + feed tests green. **Needs a backend + frontend prod deploy.**
