### PR TITLE
fix(events): reliable isRegistered + live attendee count

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2247,6 +2247,15 @@ app.post('/getEventUsers', authMiddleware, async (c) => {
   })
 })
 
+// The set of event IDs the authed user is registered for. Lets event LISTS
+// (Explore, Home) mark "Going" reliably without the fragile per-event roster
+// fetch. Authed + uncached. (Two segments — distinct from /events/:id/...)
+app.get('/events/registered', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const eventIds = await db.getRegisteredEventIds(c.env.DB, user.id)
+  return c.json({ eventIds })
+})
+
 // Per-user registration state + live attendee count for an event. The public
 // /fetchEvent is cached and has no user context, so clients must NOT infer
 // "am I registered" from the gated roster (a normal attendee can't read it).

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2247,6 +2247,20 @@ app.post('/getEventUsers', authMiddleware, async (c) => {
   })
 })
 
+// Per-user registration state + live attendee count for an event. The public
+// /fetchEvent is cached and has no user context, so clients must NOT infer
+// "am I registered" from the gated roster (a normal attendee can't read it).
+// This authed endpoint answers both reliably and is never cached.
+app.get('/events/:id/registration', authMiddleware, async (c) => {
+  const user = c.get('user')
+  const id = c.req.param('id')
+  const [isRegistered, attendeeCount] = await Promise.all([
+    db.isUserAttending(c.env.DB, id, user.id),
+    db.getLiveAttendeeCount(c.env.DB, id),
+  ])
+  return c.json({ isRegistered, attendeeCount })
+})
+
 // Coordinator-only attendee roster. Unlike /getEventUsers (public, avatar-only
 // display), this returns emails + account-less guest RSVPs and is gated to the
 // event's creator or an admin — the "replaces the Google Form / spreadsheet"

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -671,6 +671,20 @@ export async function getLiveAttendeeCount(db: D1Database, eventId: string): Pro
   return row?.count ?? 0
 }
 
+/**
+ * The set of event IDs the user has an account RSVP for. Lets clients mark
+ * "Going" on event LISTS reliably (the public/cached events endpoints can't
+ * carry per-user state, and the gated roster can't be read for events you're
+ * not in).
+ */
+export async function getRegisteredEventIds(db: D1Database, userId: string): Promise<string[]> {
+  const result = await db
+    .prepare('SELECT event_id FROM event_attendees WHERE user_id = ?1')
+    .bind(userId)
+    .all<{ event_id: string }>()
+  return (result.results ?? []).map((r) => r.event_id)
+}
+
 export async function getEventAttendees(
   db: D1Database,
   eventId: string,

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -652,6 +652,25 @@ export async function isUserAttending(
   return result !== null
 }
 
+/**
+ * Live, guest-inclusive attendee count (account attendees + non-upgraded guest
+ * RSVPs) — the same formula recomputeAttendeeCount writes to people_attending,
+ * but read directly so callers don't depend on that denormalized field being
+ * fresh. Read-only (safe in GET handlers).
+ */
+export async function getLiveAttendeeCount(db: D1Database, eventId: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT (
+        (SELECT COUNT(*) FROM event_attendees WHERE event_id = ?1)
+        + (SELECT COUNT(*) FROM event_guest_rsvps WHERE event_id = ?1 AND upgraded_user_id IS NULL)
+      ) AS count`,
+    )
+    .bind(eventId)
+    .first<{ count: number }>()
+  return row?.count ?? 0
+}
+
 export async function getEventAttendees(
   db: D1Database,
   eventId: string,

--- a/packages/frontend/app/(tabs)/explore.web.tsx
+++ b/packages/frontend/app/(tabs)/explore.web.tsx
@@ -133,6 +133,10 @@ function EventPanelInner({
     }
   }, [event?.isRegistered, event?.attendees, attendees, onStatusChange])
   const [showGuestRsvp, setShowGuestRsvp] = useState(false)
+  // Guest RSVPed this session — lock the attend CTA so they don't re-submit.
+  // Reset when the selected event changes (this panel is reused across events).
+  const [guestRsvped, setGuestRsvped] = useState(false)
+  useEffect(() => { setGuestRsvped(false) }, [event?.id])
 
   const handleToggleRegistration = async () => {
     if (!user) {
@@ -178,6 +182,7 @@ function EventPanelInner({
         onClose={onClose}
         onToggleRegistration={handleToggleRegistration}
         isToggling={isToggling}
+        guestRsvped={guestRsvped}
         onEdit={canEdit && !isPast ? onEdit : undefined}
         onDelete={
           canEdit
@@ -199,6 +204,7 @@ function EventPanelInner({
         onClose={() => setShowGuestRsvp(false)}
         eventId={eventId}
         eventTitle={event.title}
+        onRsvped={() => setGuestRsvped(true)}
       />
     </>
   )

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -814,15 +814,22 @@ export default function EventDetailPage() {
             count={event.attendees}
             contentStyle={{ gap: 8 }}
           >
-            {attendees.length > 0 ? (
+            {event.attendees > 0 ? (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 4 }}>
-                <AvatarStack attendees={attendees} colors={colors} />
+                {attendees.length > 0 ? <AvatarStack attendees={attendees} colors={colors} /> : null}
                 <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 13, color: colors.textSecondary }}>
                   {event.attendees} {event.attendees === 1 ? 'person' : 'people'} on Janata
                 </Text>
               </View>
-            ) : null}
-            <AttendeesContent attendees={attendees} colors={colors} />
+            ) : (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 4 }}>
+                <Users size={18} color={colors.textMuted} />
+                <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: colors.textSecondary }}>
+                  No attendees yet — be the first to RSVP.
+                </Text>
+              </View>
+            )}
+            {attendees.length > 0 ? <AttendeesContent attendees={attendees} colors={colors} /> : null}
           </DetailSection>
         )}
 

--- a/packages/frontend/app/events/[id].tsx
+++ b/packages/frontend/app/events/[id].tsx
@@ -446,6 +446,7 @@ function ActionBar({
   signupUrl,
   allowJanataSignup,
   onExternalSignup,
+  guestRsvped,
   colors,
 }: {
   isRegistered?: boolean
@@ -455,8 +456,15 @@ function ActionBar({
   signupUrl?: string | null
   allowJanataSignup?: boolean
   onExternalSignup?: () => void
+  // Guest RSVPed this session — lock the attend CTA to a confirmed state.
+  guestRsvped?: boolean
   colors: DetailColors
 }) {
+  const guestGoing = (
+    <View style={{ minHeight: 48, borderRadius: 12, borderWidth: 1, borderColor: colors.border, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, fontWeight: '500', color: colors.text }}>✓ You're going</Text>
+    </View>
+  )
   if (isPast) return null
 
   const wrapperStyle = {
@@ -475,6 +483,8 @@ function ActionBar({
           <DestructiveButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
             Cancel Registration
           </DestructiveButton>
+        ) : guestRsvped ? (
+          guestGoing
         ) : (
           <PrimaryButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
             Attend on Janata
@@ -529,9 +539,11 @@ function ActionBar({
 
   return (
     <View style={wrapperStyle}>
-      <PrimaryButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
-        Attend Event
-      </PrimaryButton>
+      {guestRsvped ? guestGoing : (
+        <PrimaryButton onPress={onToggle} disabled={isToggling} loading={isToggling}>
+          Attend Event
+        </PrimaryButton>
+      )}
       <Text
         style={{
           fontFamily: 'Inclusive Sans',
@@ -590,6 +602,8 @@ export default function EventDetailPage() {
   const hasTrackedView = useRef(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const [showGuestRsvp, setShowGuestRsvp] = useState(false)
+  // Guest RSVPed this session — lock the attend CTA so they don't re-submit.
+  const [guestRsvped, setGuestRsvped] = useState(false)
 
   const isAdmin = user?.email === ADMIN_EMAIL || (user?.verificationLevel !== undefined && user.verificationLevel >= 107)
   const canEdit = isAdmin || isCreator
@@ -863,6 +877,7 @@ export default function EventDetailPage() {
         signupUrl={event.signupUrl}
         allowJanataSignup={event.allowJanataSignup}
         onExternalSignup={() => track('event_external_signup_pressed', { eventId: id, signupUrl: event.signupUrl, source: 'event_detail' })}
+        guestRsvped={guestRsvped}
         colors={colors}
       />
 
@@ -871,6 +886,7 @@ export default function EventDetailPage() {
         onClose={() => setShowGuestRsvp(false)}
         eventId={id as string}
         eventTitle={event?.title}
+        onRsvped={() => setGuestRsvped(true)}
       />
     </SafeAreaView>
   )

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -312,6 +312,15 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
                   <Text style={{ color: colors.text, fontSize: 15, flex: 1 }}>{a.name}</Text>
                 </View>
               ))
+            ) : event.attendees > 0 ? (
+              // Registered, but the full roster is gated to coordinators — show
+              // the guest-inclusive count rather than a misleading "0".
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 4 }}>
+                <Users size={18} color={colors.textMuted} />
+                <Text style={{ color: colors.textSecondary, fontSize: 14 }}>
+                  {event.attendees} {event.attendees === 1 ? 'person' : 'people'} on Janata
+                </Text>
+              </View>
             ) : (
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 4 }}>
                 <Users size={18} color={colors.textMuted} />

--- a/packages/frontend/app/events/[id].web.tsx
+++ b/packages/frontend/app/events/[id].web.tsx
@@ -86,6 +86,9 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
   const colors = useDetailColors()
   const appColors = useColors()
   const [showGuestRsvp, setShowGuestRsvp] = useState(false)
+  // Guests have no account state, so we lock the RSVP CTA for this session once
+  // they're on the list — prevents a confusing re-submit + confirms it landed.
+  const [guestRsvped, setGuestRsvped] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [threadDetailPost, setThreadDetailPost] = useState<FeedPost | null>(null)
   const hasTrackedView = useRef(false)
@@ -372,6 +375,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
                 >
                   Cancel Registration
                 </DestructiveButton>
+              ) : !user && guestRsvped ? (
+                <View style={{ minHeight: 48, borderRadius: 12, borderWidth: 1, borderColor: colors.border, alignItems: 'center', justifyContent: 'center' }}>
+                  <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, fontWeight: '600', color: colors.text }}>✓ You're going</Text>
+                </View>
               ) : (
                 <PrimaryButton
                   onPress={() => {
@@ -427,6 +434,10 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
             >
               Cancel Registration
             </DestructiveButton>
+          ) : !user && guestRsvped ? (
+            <View style={{ minHeight: 48, borderRadius: 12, borderWidth: 1, borderColor: colors.border, alignItems: 'center', justifyContent: 'center' }}>
+              <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, fontWeight: '600', color: colors.text }}>✓ You're going</Text>
+            </View>
           ) : (
             <PrimaryButton
               onPress={() => {
@@ -452,6 +463,7 @@ function MobileEventDetail({ eventId }: { eventId: string }) {
         onClose={() => setShowGuestRsvp(false)}
         eventId={eventId}
         eventTitle={event?.title}
+        onRsvped={() => setGuestRsvped(true)}
       />
     </View>
   )

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -121,6 +121,8 @@ type EventDetailPanelProps = {
   onClose: () => void
   onToggleRegistration: () => void
   isToggling: boolean
+  // Guest RSVPed this session — lock the attend CTA to a confirmed state.
+  guestRsvped?: boolean
   onEdit?: (eventId: string) => void
   onDelete?: (eventId: string) => void
 }
@@ -858,6 +860,7 @@ function ActionBar({
   isToggling,
   signupUrl,
   allowJanataSignup,
+  guestRsvped,
   colors,
 }: {
   isRegistered?: boolean
@@ -866,9 +869,17 @@ function ActionBar({
   isToggling: boolean
   signupUrl?: string | null
   allowJanataSignup?: boolean
+  // Guest RSVPed this session — lock the attend CTA to a confirmed state.
+  guestRsvped?: boolean
   colors: DetailColors
 }) {
   if (isPast) return null
+
+  const guestGoing = (
+    <View style={{ minHeight: 48, borderRadius: 12, borderWidth: 1, borderColor: colors.border, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 15, fontWeight: '500', color: colors.text }}>✓ You're going</Text>
+    </View>
+  )
 
   // External signup is set + admin opted into letting users RSVP on Janata
   // too. Janata is primary, external is the alternate.
@@ -890,6 +901,8 @@ function ActionBar({
             loading={isToggling}
             colors={colors}
           />
+        ) : guestRsvped ? (
+          guestGoing
         ) : (
           <PrimaryButton
             onPress={onToggleRegistration}
@@ -980,13 +993,15 @@ function ActionBar({
         backgroundColor: colors.panelBg,
       }}
     >
-      <PrimaryButton
-        onPress={onToggleRegistration}
-        disabled={isToggling}
-        loading={isToggling}
-      >
-        Attend Event
-      </PrimaryButton>
+      {guestRsvped ? guestGoing : (
+        <PrimaryButton
+          onPress={onToggleRegistration}
+          disabled={isToggling}
+          loading={isToggling}
+        >
+          Attend Event
+        </PrimaryButton>
+      )}
       <Text
         style={{
           fontFamily: 'Inclusive Sans',
@@ -1015,6 +1030,7 @@ export default function EventDetailPanel({
   onClose,
   onToggleRegistration,
   isToggling,
+  guestRsvped,
   onEdit,
   onDelete,
 }: EventDetailPanelProps) {
@@ -1136,6 +1152,7 @@ export default function EventDetailPanel({
         isToggling={isToggling}
         signupUrl={event.signupUrl}
         allowJanataSignup={event.allowJanataSignup}
+        guestRsvped={guestRsvped}
         colors={colors}
       />
     </View>

--- a/packages/frontend/components/events/EventDetailPanel.web.tsx
+++ b/packages/frontend/components/events/EventDetailPanel.web.tsx
@@ -545,7 +545,7 @@ function AttendedBanner({ count, colors }: { count: number; colors: DetailColors
 // People tab content
 // ---------------------------------------------------------------------------
 
-function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: DetailColors }) {
+function PeopleTab({ attendees, count, colors }: { attendees: Attendee[]; count: number; colors: DetailColors }) {
   return (
     <View style={{ paddingHorizontal: 24, paddingTop: 16 }}>
       <Text
@@ -556,10 +556,12 @@ function PeopleTab({ attendees, colors }: { attendees: Attendee[]; colors: Detai
           marginBottom: 12,
         }}
       >
-        {attendees.length} {attendees.length === 1 ? 'person' : 'people'} on Janata
+        {count} {count === 1 ? 'person' : 'people'} on Janata
       </Text>
 
-      {attendees.length === 0 ? (
+      {/* The names list is gated to attendees/coordinators; non-roster viewers
+          still see the live count above. "No attendees yet" only when truly 0. */}
+      {attendees.length === 0 && count === 0 ? (
         <View style={{ alignItems: 'center', paddingTop: 32, gap: 8 }}>
           <Users size={32} color={colors.textMuted} />
           <Text
@@ -721,8 +723,8 @@ function RegisteredContent({
         </DetailSection>
 
         {/* ── PEOPLE ────────────────────────────────────────────── */}
-        <DetailSection title="People" count={attendees.length} contentStyle={{ paddingHorizontal: 0 }}>
-          <PeopleTab attendees={attendees} colors={colors} />
+        <DetailSection title="People" count={event.attendees} contentStyle={{ paddingHorizontal: 0 }}>
+          <PeopleTab attendees={attendees} count={event.attendees} colors={colors} />
         </DetailSection>
 
         {/* ── DISCUSSION ────────────────────────────────────────── */}

--- a/packages/frontend/components/events/GuestRsvpSheet.tsx
+++ b/packages/frontend/components/events/GuestRsvpSheet.tsx
@@ -12,6 +12,9 @@ interface GuestRsvpSheetProps {
   onClose: () => void
   eventId: string
   eventTitle?: string
+  // Fired once the guest is on the list (fresh RSVP or already-RSVPed) so the
+  // opener can lock its CTA for the session — no double submissions.
+  onRsvped?: () => void
 }
 
 type Status = 'form' | 'submitting' | 'success' | 'already' | 'requiresVerified' | 'error'
@@ -21,7 +24,7 @@ type Status = 'form' | 'submitting' | 'success' | 'already' | 'requiresVerified'
  * name + email, no account. Backed by POST /attendEventGuest. Same component on
  * web and native (RN Modal). Cancel-via-email is a follow-up (needs prod Resend).
  */
-export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }: GuestRsvpSheetProps) {
+export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle, onRsvped }: GuestRsvpSheetProps) {
   const colors = useDetailColors()
   const router = useRouter()
   const { track } = useAnalytics()
@@ -64,6 +67,7 @@ export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }
       const res = await attendEventGuest(eventId, trimmedName, trimmedEmail)
       track('guest_rsvp_submit', { eventId, alreadyRsvped: res.alreadyRsvped })
       setStatus(res.alreadyRsvped ? 'already' : 'success')
+      onRsvped?.()
     } catch (e: any) {
       if (e?.status === 403) {
         setStatus('requiresVerified')
@@ -72,7 +76,7 @@ export default function GuestRsvpSheet({ visible, onClose, eventId, eventTitle }
         setStatus('error')
       }
     }
-  }, [name, email, eventId, track])
+  }, [name, email, eventId, track, onRsvped])
 
   if (!visible) return null
 

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -7,6 +7,7 @@ import {
   fetchEventsByCenter,
   fetchAllEvents,
   fetchEventUsers,
+  fetchEventRegistration,
   fetchBoard,
   fetchAggregatedFeed,
   attendEvent,
@@ -276,11 +277,24 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
           setIsCreator(userIsCreator)
           setIsLive(true)
 
-          // Fetch the attendee LIST separately — it is gated (401/403 for
-          // non-attendees). A gated/failed list must NOT error the screen; the
-          // event + its guest-inclusive count still render. The public count
-          // comes from the event object (display.attendees = peopleAttending),
-          // never from the list length.
+          // Source of truth for the RSVP CTA + count: the authed registration
+          // endpoint (the public /fetchEvent is cached + user-agnostic, and the
+          // roster is gated, so neither can answer reliably). Derived isRegistered
+          // from the gated roster used to leave registered users on "Attend" and
+          // show a 0 count.
+          if (userId) {
+            const reg = await fetchEventRegistration(eventId)
+            if (mounted && reg) {
+              setIsRegistered(reg.isRegistered)
+              setEvent((prev) =>
+                prev ? { ...prev, isRegistered: reg.isRegistered, attendees: reg.attendeeCount } : null
+              )
+            }
+          }
+
+          // Attendee LIST (names/avatars) is gated to coordinators — used ONLY
+          // for the roster display, never to decide isRegistered. A gated/failed
+          // list must not error the screen or zero out the count.
           try {
             const users = await fetchEventUsers(eventId)
             if (mounted) {
@@ -294,18 +308,9 @@ export function useEventDetail(eventId: string, username?: string, userId?: stri
                     : (u.username?.slice(0, 2).toUpperCase() ?? 'M'),
                 }))
               )
-              // Check if current user is in attendees list
-              const userIsRegistered = userId ? users.some((u) => u.id === userId) : false
-              setIsRegistered(userIsRegistered)
-              setEvent((prev) => (prev ? { ...prev, isRegistered: userIsRegistered } : null))
             }
           } catch (listErr: any) {
-            // Gated list (not an attendee yet) — degrade gracefully.
-            if (mounted) {
-              setAttendees([])
-              setIsRegistered(false)
-              setEvent((prev) => (prev ? { ...prev, isRegistered: false } : null))
-            }
+            if (mounted) setAttendees([])
             if (__DEV__) console.warn('[useEventDetail] attendee list gated/unavailable', listErr?.message)
           }
         }

--- a/packages/frontend/hooks/useApiData.ts
+++ b/packages/frontend/hooks/useApiData.ts
@@ -8,6 +8,7 @@ import {
   fetchAllEvents,
   fetchEventUsers,
   fetchEventRegistration,
+  fetchMyRegisteredEventIds,
   fetchBoard,
   fetchAggregatedFeed,
   attendEvent,
@@ -831,7 +832,9 @@ export function useDiscoverData(
               ...e,
               attendeesList: attendeesList.slice(0, 4),
               isRegistered: userIsRegistered,
-              peopleAttending: users.length,
+              // Keep the event's real (guest-inclusive) count — the gated roster
+              // length is 0 for events you can't read, which zeroed the card.
+              peopleAttending: e.peopleAttending,
             }
           })
         )
@@ -845,6 +848,15 @@ export function useDiscoverData(
         })
       } else {
         fetchedEvents = allApiEvents.map((e) => apiEventToDisplay(e))
+      }
+
+      // Reliable "Going" on list cards: mark events the user has an account RSVP
+      // for, from the authed registered-IDs set. The public events list can't
+      // carry per-user state, and the gated roster can't be read for events the
+      // user isn't in — so neither could drive the badge before.
+      if (userId) {
+        const registeredSet = new Set(await fetchMyRegisteredEventIds())
+        fetchedEvents = fetchedEvents.map((e) => ({ ...e, isRegistered: registeredSet.has(e.id) }))
       }
 
       const todayStr = new Date().toISOString().split('T')[0]

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -438,6 +438,24 @@ export async function fetchEventUsers(eventID: string): Promise<UserData[]> {
   }
 }
 
+/**
+ * Authed per-user registration state + live (guest-inclusive) attendee count
+ * for an event (GET /events/:id/registration). Reliable source of truth for the
+ * RSVP CTA + count — unlike the public/cached /fetchEvent or the gated roster.
+ */
+export async function fetchEventRegistration(
+  eventID: string
+): Promise<{ isRegistered: boolean; attendeeCount: number } | null> {
+  try {
+    const response = await authFetch(`/events/${eventID}/registration`)
+    if (!response.ok) return null
+    return await response.json()
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchEventRegistration]', err?.message || err)
+    return null
+  }
+}
+
 // Coordinator-only attendee roster (creator or admin). Returns emails + guest
 // RSVPs for the "manage attendees / export" panel on the event page.
 export interface EventRosterEntry {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -456,6 +456,22 @@ export async function fetchEventRegistration(
   }
 }
 
+/**
+ * Event IDs the authed user is registered for (GET /events/registered). Lets
+ * event LISTS mark "Going" reliably without a per-event roster fetch.
+ */
+export async function fetchMyRegisteredEventIds(): Promise<string[]> {
+  try {
+    const response = await authFetch('/events/registered')
+    if (!response.ok) return []
+    const data = await response.json()
+    return data.eventIds ?? []
+  } catch (err: any) {
+    if (__DEV__) console.warn('[fetchMyRegisteredEventIds]', err?.message || err)
+    return []
+  }
+}
+
 // Coordinator-only attendee roster (creator or admin). Returns emails + guest
 // RSVPs for the "manage attendees / export" panel on the event page.
 export interface EventRosterEntry {

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -414,7 +414,9 @@ export async function fetchEventsPage(
 
 export async function fetchEventUsers(eventID: string): Promise<UserData[]> {
   try {
-    const response = await apiFetch('/getEventUsers', {
+    // Must be authed — /getEventUsers is gated (attendee/creator/admin). apiFetch
+    // sends no token, so it 401'd and the attendee names list never loaded.
+    const response = await authFetch('/getEventUsers', {
       method: 'POST',
       body: JSON.stringify({ id: eventID }),
     })


### PR DESCRIPTION
## Problem
On the event page, the RSVP CTA + attendee count were unreliable: a registered user could see **"Attend"** + **"0 / No attendees yet"** on refresh.

## Root cause
`/fetchEvent` is **public + cached (30s)** — no user context — so the client *inferred* `isRegistered` by fetching the **admin-gated roster** and looking for itself. A normal attendee gets 403 on that roster → inferred `isRegistered=false` + empty list. The count read the denormalized `people_attending`, which could be stale/0.

## Fix
- New authed **`GET /events/:id/registration`** → `{ isRegistered, attendeeCount }`, computed live from `event_attendees` (+ non-upgraded guest RSVPs).
- `useEventDetail` uses it for the CTA + count instead of inferring from the gated roster.
- Attendee **list** gating is unchanged (attendee/creator/admin → names+avatars, no PII; coordinator roster → PII/CSV). The "No attendees yet" message now keys off the live count, so a registered user without roster access sees the accurate count, not "0".

## Verify (local)
- Registered user → **Cancel Registration** + "N person(s) on Janata"; attendee → sees the list; non-attendee → 403 (count only). `tsc` (both) + feed tests green.
