### PR TITLE
fix(feed): native post detail uses real API (was mock data)

### DIFF
--- a/packages/frontend/app/feed/[id].tsx
+++ b/packages/frontend/app/feed/[id].tsx
@@ -1,151 +1,141 @@
-import React, { useMemo } from 'react'
-import { View, Text, ScrollView, Pressable } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ArrowLeft, Building2, CalendarDays, MessageCircle } from 'lucide-react-native'
-import { useTheme, useUser } from '../../components/contexts'
-import { useMyEvents, useCenterList } from '../../hooks/useApiData'
-import { Avatar } from '../../components/ui'
-import type { DiscoverCenter } from '../../utils/api'
-import {
-  buildCenterBoard,
-  buildEventBoard,
-  centerBoards,
-  eventBoards,
-  type BoardMessage,
-  type PersonSummary,
-} from '../../components/boards'
+import { useUser } from '../../components/contexts'
+import { useColors } from '../../hooks/useColors'
+import { boardPostToMessage } from '../../components/boards'
+import { NativeChatHeader, PostThread } from '../../components/feed'
+import { buildFeedPostFromMessage } from '../../components/feed/feedData'
+import type { FeedPost } from '../../components/feed'
+import { fetchAggregatedFeed, type BoardPostData } from '../../utils/api'
 import { useAnalytics } from '../../utils/analytics'
 
-type GroupKind = 'center' | 'event'
+type LoadState = 'loading' | 'loaded' | 'error'
 
-type FeedPost = BoardMessage & {
-  groupId: string
-  groupKind: GroupKind
-  sourceTitle: string
-  sourceSubtitle: string
-  sourceLabel: string
-  replyMessages: BoardMessage[]
+// The aggregated feed already scopes to every board the signed-in user can see
+// (public + their center board + boards for events they've joined), so it is the
+// real-data source the Feed tab and Home peek both read from. We pull the max
+// page so a deep-linked / push-notification post (which arrives as a raw post id
+// via /feed/:postId) is found even when it's a little older.
+const FEED_PAGE = 100
+
+// A post is matched either by its raw API id (deep links / push) or by the
+// board-scoped compound key `${groupId}-${postId}` that the Feed tab uses for
+// in-app selection.
+function matchesId(post: BoardPostData, id: string): boolean {
+  return post.id === id || id.endsWith(`-${post.id}`)
 }
 
-function findPostById(
-  id: string,
-  allCenters: DiscoverCenter[],
-  myEvents: any[],
-  user: any,
-  isVerified: boolean
-): FeedPost | null {
-  // Build groups same as feed page
-  const groups: any[] = []
-
-  if (user && isVerified) {
-    for (const center of allCenters) {
-      groups.push({
-        id: `center-${center.id}`,
-        kind: 'center' as GroupKind,
-        title: center.name,
-        messages: centerBoards[0]?.messages || [],
-      })
-    }
-    for (const event of myEvents) {
-      groups.push({
-        id: `event-${event.id}`,
-        kind: 'event' as GroupKind,
-        title: event.title,
-        messages: eventBoards[0]?.messages || [],
-      })
-    }
-  } else {
-    groups.push({
-      id: `center-${centerBoards[0]?.id || 'default'}`,
-      kind: 'center' as GroupKind,
-      title: centerBoards[0]?.centerName || 'Center',
-      messages: centerBoards[0]?.messages || [],
-    })
-    groups.push(
-      ...eventBoards.map((eb) => ({
-        id: `event-${eb.id}`,
-        kind: 'event' as GroupKind,
-        title: eb.title,
-        messages: eb.messages,
-      }))
-    )
-  }
-
-  for (const group of groups) {
-    for (const message of group.messages) {
-      const postId = `${group.id}-${message.id}`
-      if (postId === id) {
-        const replies = group.messages.filter((m: BoardMessage) => m.id !== message.id)
-        return {
-          ...message,
-          id: postId,
-          sourceLabel: group.title,
-          sourceKind: group.kind,
-          sourceTitle: group.title,
-          sourceSubtitle: '',
-          groupId: group.id,
-          groupKind: group.kind,
-          replyMessages: replies.slice(0, Math.max(message.replyCount ?? 2, 1)),
-        }
-      }
-    }
-  }
-
-  return null
+function buildPost(post: BoardPostData): FeedPost {
+  const sourceKind = post.sourceKind ?? (post.boardId === null ? 'public' : 'center')
+  const sourceLabel = post.sourceLabel ?? (sourceKind === 'public' ? 'Public' : 'Your center')
+  return buildFeedPostFromMessage(boardPostToMessage(post), {
+    groupId: post.boardId ? `${sourceKind}-${post.boardId}` : 'public',
+    kind: sourceKind,
+    parentId: post.boardId ?? 'public',
+    title: sourceLabel,
+    subtitle: '',
+  })
 }
 
 export default function FeedPostDetail() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
   const { user } = useUser()
-  const { isDark } = useTheme()
+  const colors = useColors()
+  const insets = useSafeAreaInsets()
   const { track } = useAnalytics()
-  const { centers: allCenters } = useCenterList()
-  const { events: myEvents } = useMyEvents(user?.username)
 
-  const colors = useMemo(
-    () => ({
-      page: isDark ? '#1A1A1A' : '#F5F5F4',
-      surface: isDark ? '#171717' : '#FFFFFF',
-      text: isDark ? '#FAFAF9' : '#1F1D1B',
-      textMuted: isDark ? '#A8A29E' : '#78716C',
-      textSecondary: isDark ? '#D6D3D1' : '#44403C',
-      border: isDark ? '#262626' : '#E7E5E4',
-      orange: '#E8862A',
-      orangeSoft: isDark ? 'rgba(232,134,42,0.15)' : '#FFF7ED',
-      panel: isDark ? '#1F1F1F' : '#F7F4EF',
-    }),
-    [isDark]
+  const [state, setState] = useState<LoadState>('loading')
+  const [post, setPost] = useState<FeedPost | null>(null)
+
+  const load = useCallback(async () => {
+    if (!id) {
+      setState('loaded')
+      setPost(null)
+      return
+    }
+    setState('loading')
+    try {
+      const posts = await fetchAggregatedFeed({ limit: FEED_PAGE })
+      const match = posts.find((p) => matchesId(p, id))
+      setPost(match ? buildPost(match) : null)
+      setState('loaded')
+    } catch {
+      setPost(null)
+      setState('error')
+    }
+  }, [id])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleBack = useCallback(
+    (reason?: string) => {
+      track('feed_post_back_pressed', {
+        post_id: id,
+        source: 'feed_post_detail',
+        ...(reason ? { reason } : {}),
+        ...(post ? { group_id: post.groupId, group_kind: post.groupKind } : {}),
+      })
+      router.back()
+    },
+    [id, post, router, track]
   )
 
-  const post = useMemo(
-    () => findPostById(id || '', allCenters, myEvents, user, user?.isVerified === true),
-    [id, allCenters, myEvents, user]
-  )
+  const messageState = useMemo(() => {
+    if (state === 'error') {
+      return { label: 'Couldn’t load this post', action: 'Try again', onPress: load }
+    }
+    return { label: 'Post not found', action: 'Go back', onPress: () => handleBack('not_found') }
+  }, [state, load, handleBack])
+
+  if (state === 'loading') {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.surface }} edges={['top']}>
+        <NativeChatHeader
+          colors={colors}
+          insetsTop={insets.top}
+          title="Post"
+          hideAvatar
+          onBack={() => handleBack()}
+        />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator size="large" color={colors.accent} />
+        </View>
+      </SafeAreaView>
+    )
+  }
 
   if (!post) {
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: colors.surface }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.surface }} edges={['top']}>
+        <NativeChatHeader
+          colors={colors}
+          insetsTop={insets.top}
+          title="Post"
+          hideAvatar
+          onBack={() => handleBack()}
+        />
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: colors.textMuted }}>
-            Post not found
+          <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 16, color: colors.textFaint }}>
+            {messageState.label}
           </Text>
           <Pressable
-            onPress={() => {
-              track('feed_post_back_pressed', { post_id: id, source: 'feed_post_detail', reason: 'not_found' })
-              router.back()
-            }}
+            onPress={messageState.onPress}
+            accessibilityRole="button"
             style={{
               marginTop: 16,
               paddingVertical: 10,
               paddingHorizontal: 20,
               borderRadius: 12,
-              backgroundColor: colors.orange,
+              backgroundColor: colors.accent,
             }}
           >
             <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 14, color: '#FFFFFF' }}>
-              Go back
+              {messageState.action}
             </Text>
           </Pressable>
         </View>
@@ -153,195 +143,33 @@ export default function FeedPostDetail() {
     )
   }
 
-  const reactions = post.reactions ?? [{ emoji: '🙏', count: 2 }]
-  const replies = post.replyMessages.slice(0, Math.max(post.replyCount ?? 2, 1))
+  const openAuthorProfile = (authorId: string) => {
+    if (!authorId || authorId === user?.id) return
+    track('feed_author_profile_pressed', { author_id: authorId, source: 'feed_post_detail' })
+    router.push(`/members/${encodeURIComponent(authorId)}` as never)
+  }
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.surface }} edges={['top']}>
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: 12,
-          paddingHorizontal: 16,
-          paddingVertical: 12,
-          borderBottomWidth: 1,
-          borderBottomColor: colors.border,
-        }}
-      >
-        <Pressable
-          onPress={() => {
-            track('feed_post_back_pressed', { post_id: id, source: 'feed_post_detail', group_id: post?.groupId, group_kind: post?.groupKind })
-            router.back()
-          }}
-          accessibilityRole="button"
-          accessibilityLabel="Back"
-          hitSlop={10}
-        >
-          <ArrowLeft size={22} color={colors.orange} />
-        </Pressable>
-        <View style={{ flex: 1 }}>
-          <Text style={{ fontSize: 16, color: colors.text }}>Post</Text>
-          <Text style={{ fontSize: 12, color: colors.textMuted }} numberOfLines={1}>
-            {post.sourceTitle}
-          </Text>
-        </View>
+      <NativeChatHeader
+        colors={colors}
+        insetsTop={insets.top}
+        title="Post"
+        subtitle={post.sourceTitle}
+        hideAvatar
+        onBack={() => handleBack()}
+      />
+      <View style={{ flex: 1 }}>
+        <PostThread
+          post={post}
+          colors={colors}
+          fullScreen
+          bottomInset={insets.bottom}
+          onAuthorPress={openAuthorProfile}
+          onPostChanged={load}
+          onPostDeleted={() => handleBack('deleted')}
+        />
       </View>
-
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 40 }}>
-        <View style={{ padding: 16 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 12 }}>
-            <View
-              style={{
-                width: 18,
-                height: 18,
-                borderRadius: 5,
-                backgroundColor: post.sourceKind === 'event' ? colors.orangeSoft : colors.panel,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              {post.sourceKind === 'event' ? (
-                <CalendarDays size={10} color={colors.orange} strokeWidth={2.4} />
-              ) : (
-                <Building2 size={10} color={colors.textMuted} strokeWidth={2.3} />
-              )}
-            </View>
-            <Text style={{ fontFamily: 'Inclusive Sans', fontSize: 12, color: colors.textMuted }}>
-              {post.sourceTitle}
-            </Text>
-          </View>
-
-          <View style={{ flexDirection: 'row', gap: 12 }}>
-            <Avatar
-              name={post.author.name}
-              initials={post.author.initials}
-              image={post.author.image}
-              size={42}
-              backgroundColor={post.author.accentColor}
-            />
-            <View style={{ flex: 1, gap: 8 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <Text style={{ fontSize: 15, color: colors.text }}>{post.author.name}</Text>
-                {post.author.verification === 'sevak' ? (
-                  <View
-                    style={{
-                      backgroundColor: colors.orangeSoft,
-                      paddingHorizontal: 6,
-                      paddingVertical: 2,
-                      borderRadius: 4,
-                    }}
-                  >
-                    <Text style={{ fontSize: 10, color: colors.orange }}>SEVAK</Text>
-                  </View>
-                ) : null}
-                <Text style={{ fontSize: 12, color: colors.textMuted }}>· {post.timestamp}</Text>
-              </View>
-
-              <Text style={{ fontSize: 15, lineHeight: 22, color: colors.text }}>{post.body}</Text>
-
-              {post.attachmentLabel ? (
-                <View
-                  style={{
-                    marginTop: 4,
-                    height: 80,
-                    borderRadius: 14,
-                    backgroundColor: colors.panel,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Text style={{ fontSize: 12, color: colors.textMuted }}>
-                    {post.attachmentLabel}
-                  </Text>
-                </View>
-              ) : null}
-
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16, marginTop: 8 }}>
-                {reactions.map((reaction, i) => (
-                  <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                    <Text style={{ fontSize: 14 }}>{reaction.emoji}</Text>
-                    <Text
-                      style={{
-                        fontSize: 13,
-                        color: colors.textMuted,
-                      }}
-                    >
-                      {reaction.count}
-                    </Text>
-                  </View>
-                ))}
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                  <MessageCircle size={14} color={colors.textMuted} />
-                  <Text style={{ fontSize: 13, color: colors.textMuted }}>
-                    {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-
-        {replies.length > 0 ? (
-          <View style={{ borderTopWidth: 1, borderTopColor: colors.border, paddingTop: 16 }}>
-            <Text
-              style={{
-                fontFamily: 'Inclusive Sans',
-                fontSize: 12,
-                letterSpacing: 0.5,
-                color: colors.textMuted,
-                paddingHorizontal: 16,
-                marginBottom: 12,
-              }}
-            >
-              REPLIES
-            </Text>
-            {replies.map((reply) => (
-              <View
-                key={reply.id}
-                style={{
-                  flexDirection: 'row',
-                  gap: 12,
-                  paddingHorizontal: 16,
-                  paddingVertical: 12,
-                  borderBottomWidth: 1,
-                  borderBottomColor: colors.border,
-                }}
-              >
-                <Avatar
-                  name={reply.author.name}
-                  initials={reply.author.initials}
-                  image={reply.author.image}
-                  size={36}
-                  backgroundColor={reply.author.accentColor}
-                />
-                <View style={{ flex: 1, gap: 4 }}>
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                    <Text style={{ fontSize: 14, color: colors.text }}>{reply.author.name}</Text>
-                    <Text
-                      style={{
-                        fontSize: 12,
-                        color: colors.textMuted,
-                      }}
-                    >
-                      · {reply.timestamp}
-                    </Text>
-                  </View>
-                  <Text
-                    style={{
-                      fontSize: 14,
-                      lineHeight: 20,
-                      color: colors.textSecondary,
-                    }}
-                  >
-                    {reply.body}
-                  </Text>
-                </View>
-              </View>
-            ))}
-          </View>
-        ) : null}
-      </ScrollView>
     </SafeAreaView>
   )
 }


### PR DESCRIPTION
## The bug

The native post-detail screen `packages/frontend/app/feed/[id].tsx` built the post and its thread from **mock fixtures** — it imported `centerBoards` / `eventBoards` from `components/boards/__mocks__/mockData.ts` and synthesized a fake post + replies. So opening a board/feed post by id (a deep link, or a push-notification tap — the backend sends `/feed/:postId`) rendered fake content instead of the real post.

The web variant (`app/feed/[id].web.tsx`, which delegates to the native screen on mobile) and the Feed tab (`app/(tabs)/feed.tsx`) already use the real API; only this native route was stuck on mocks.

## What changed

`app/feed/[id].tsx` now loads real data:

- Fetches the **aggregated feed** (`fetchAggregatedFeed`) — the same real-data source the Feed tab and Home board peek read from (scoped to public + the user's center board + boards for events they've joined).
- Finds the post by the route `id`, matching either the **raw API post id** (deep links / push) or the board-scoped compound key `${groupId}-${postId}` the Feed tab uses for in-app selection.
- Maps it via `boardPostToMessage` + `buildFeedPostFromMessage` (deriving the source label/kind from the aggregated post's `sourceKind` / `sourceLabel`) and renders the shared **`PostThread`** component.
- `PostThread` loads the **real replies** (`fetchBoardPostReplies`) and already handles reactions, replies, and pin/edit/delete against the real API.
- Clean **loading**, **error** (retryable), and **not-found** states, using the existing `NativeChatHeader` + `useColors` tokens to match surrounding screens.

No new API endpoints were invented — this reuses `fetchAggregatedFeed`, the exact pattern already used by the Feed tab and Home peek. The `__mocks__` file is left untouched (other tests/screens use it); this screen simply no longer imports it.

## How it was verified

- `npx tsc --noEmit` (frontend) — **passes, 0 errors** (deps installed via `npm ci` in the worktree since `node_modules` was absent).
- `npx vitest run` (frontend) — **198 tests passed, 12 files**.
- Confirmed no `__mocks__` / `centerBoards` / `eventBoards` references remain in the screen.

**Caveat:** the repo's vitest suite excludes `app/**`, so a green test run does not exercise this screen directly — correctness rests on the typecheck + reusing the already-working `fetchAggregatedFeed` → `PostThread` path. Like the Feed tab, post lookup is bounded by the aggregated feed page (limit 100); a deep-linked post older than that window would fall through to the not-found state (there is no single-post-by-id endpoint to fetch against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)