### PR TITLE
feat(boards): surface Report action on posts (member-side moderation entry)

### DIFF
--- a/packages/frontend/components/feed/PostThread.tsx
+++ b/packages/frontend/components/feed/PostThread.tsx
@@ -4,6 +4,7 @@ import {
   Building2,
   CalendarDays,
   ChevronUp,
+  Flag,
   Globe2,
   MoreHorizontal,
   Pencil,
@@ -22,6 +23,7 @@ import {
   deleteBoardPost,
   editBoardPost,
   fetchBoardPostReplies,
+  reportBoardPost,
   setBoardPostPinned,
   toggleBoardPostReaction,
 } from '../../utils/api'
@@ -30,6 +32,7 @@ import {
   authorFromUser,
   canModifyPost,
   canPinPosts,
+  canReportPost,
   optimisticReply,
 } from './feedData'
 import type { FeedPost } from './types'
@@ -107,10 +110,12 @@ export function PostThread({
   const [editDraft, setEditDraft] = useState(post.body)
   const [actionBusy, setActionBusy] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [actionNotice, setActionNotice] = useState<string | null>(null)
 
   const canPin = post.groupKind !== 'public' && canPinPosts(user)
   const isAuthor = canModifyPost(user, post.author.id)
-  const hasMenu = canPin || isAuthor
+  const canReport = canReportPost(user, post.author.id)
+  const hasMenu = canPin || isAuthor || canReport
   const authorProfilePress =
     onAuthorPress && post.author.id !== user?.id
       ? () => onAuthorPress(post.author.id)
@@ -149,6 +154,24 @@ export function PostThread({
     } catch (err: any) {
       track('feed_post_delete_failed', { post_id: post.postId, error: err?.message, source: 'post_thread' })
       setActionError(err?.message || 'Could not delete the post.')
+    } finally {
+      setActionBusy(false)
+    }
+  }
+
+  const handleReport = async () => {
+    if (actionBusy) return
+    setActionBusy(true)
+    setActionError(null)
+    setActionNotice(null)
+    try {
+      await reportBoardPost(post.postId)
+      setMenuOpen(false)
+      setActionNotice('Thanks — this post was reported to the moderators.')
+      track('feed_post_reported', { post_id: post.postId, source: 'post_thread' })
+    } catch (err: any) {
+      track('feed_post_report_failed', { post_id: post.postId, error: err?.message, source: 'post_thread' })
+      setActionError(err?.message || 'Could not submit the report.')
     } finally {
       setActionBusy(false)
     }
@@ -225,6 +248,7 @@ export function PostThread({
     setMenuOpen(false)
     setEditOpen(false)
     setActionError(null)
+    setActionNotice(null)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [post.postId])
 
@@ -296,6 +320,10 @@ export function PostThread({
 
       {actionError ? (
         <Text style={{ fontSize: 12, color: '#C2410C', marginTop: 8 }}>{actionError}</Text>
+      ) : null}
+
+      {actionNotice ? (
+        <Text style={{ fontSize: 12, color: colors.accent, marginTop: 8 }}>{actionNotice}</Text>
       ) : null}
 
       <View
@@ -446,6 +474,7 @@ export function PostThread({
         colors={colors}
         canPin={canPin}
         isAuthor={isAuthor}
+        canReport={canReport}
         pinned={pinned}
         busy={actionBusy}
         postId={post.postId}
@@ -458,6 +487,7 @@ export function PostThread({
           track('feed_post_edit_opened', { post_id: post.postId, source: 'post_thread' })
         }}
         onDelete={handleDelete}
+        onReport={handleReport}
       />
 
       <EditPostModal
@@ -830,6 +860,7 @@ function ActionMenuSheet({
   colors,
   canPin,
   isAuthor,
+  canReport,
   pinned,
   busy,
   postId,
@@ -837,11 +868,13 @@ function ActionMenuSheet({
   onTogglePin,
   onEdit,
   onDelete,
+  onReport,
 }: {
   visible: boolean
   colors: AppColors
   canPin: boolean
   isAuthor: boolean
+  canReport: boolean
   pinned: boolean
   busy: boolean
   postId: string
@@ -849,11 +882,16 @@ function ActionMenuSheet({
   onTogglePin: () => void
   onEdit: () => void
   onDelete: () => void
+  onReport: () => void
 }) {
   const { track } = useAnalytics()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [confirmingReport, setConfirmingReport] = useState(false)
   useEffect(() => {
-    if (!visible) setConfirmingDelete(false)
+    if (!visible) {
+      setConfirmingDelete(false)
+      setConfirmingReport(false)
+    }
   }, [visible])
 
   return (
@@ -955,6 +993,62 @@ function ActionMenuSheet({
                 destructive
                 disabled={busy}
                 onPress={() => { setConfirmingDelete(true); track('feed_post_delete_confirm_shown', { post_id: postId, source: 'post_thread' }) }}
+              />
+            )
+          ) : null}
+          {canReport ? (
+            confirmingReport ? (
+              <View style={{ paddingVertical: 10, paddingHorizontal: 12, gap: 10 }}>
+                <Text style={{ fontSize: 14, color: colors.text }}>
+                  Report this post to the moderators?
+                </Text>
+                <View style={{ flexDirection: 'row', gap: 10 }}>
+                  <Pressable
+                    onPress={() => { setConfirmingReport(false); track('feed_post_report_cancelled', { post_id: postId, source: 'post_thread' }) }}
+                    disabled={busy}
+                    accessibilityRole="button"
+                    accessibilityLabel="Cancel report"
+                    style={{
+                      flex: 1,
+                      borderRadius: 12,
+                      borderWidth: 1,
+                      borderColor: colors.border,
+                      paddingVertical: 11,
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Text style={{ fontSize: 14, color: colors.text }}>Cancel</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={onReport}
+                    disabled={busy}
+                    accessibilityRole="button"
+                    accessibilityLabel="Confirm report"
+                    style={{
+                      flex: 1,
+                      borderRadius: 12,
+                      backgroundColor: '#C2410C',
+                      paddingVertical: 11,
+                      alignItems: 'center',
+                      opacity: busy ? 0.6 : 1,
+                    }}
+                  >
+                    {busy ? (
+                      <ActivityIndicator size="small" color="#FFFFFF" />
+                    ) : (
+                      <Text style={{ fontSize: 14, color: '#FFFFFF' }}>Report</Text>
+                    )}
+                  </Pressable>
+                </View>
+              </View>
+            ) : (
+              <MenuRow
+                icon={<Flag size={18} color="#C2410C" />}
+                label="Report post"
+                colors={colors}
+                destructive
+                disabled={busy}
+                onPress={() => { setConfirmingReport(true); track('feed_post_report_confirm_shown', { post_id: postId, source: 'post_thread' }) }}
               />
             )
           ) : null}

--- a/packages/frontend/components/feed/feedData.ts
+++ b/packages/frontend/components/feed/feedData.ts
@@ -51,6 +51,16 @@ export function canModifyPost(user: User | null, authorId: string): boolean {
 }
 
 /**
+ * Report is the member-side moderation entry (#209): any verified member may
+ * report a post that isn't their own. Own posts already have edit/delete, so we
+ * hide Report there to keep the menu focused.
+ */
+export function canReportPost(user: User | null, authorId: string): boolean {
+  if (!user?.id || user.id === authorId) return false
+  return !!user.isVerified || (user.verificationLevel ?? 0) > 0
+}
+
+/**
  * Optimistically bump the tapped emoji's count (adds a chip if absent). The
  * server's authoritative reaction list replaces this on response; reverted on
  * failure. Does not mutate the input.

--- a/packages/frontend/src/__tests__/feedData.test.ts
+++ b/packages/frontend/src/__tests__/feedData.test.ts
@@ -6,6 +6,7 @@ import {
   optimisticReply,
   canPinPosts,
   canModifyPost,
+  canReportPost,
   applyOptimisticReaction,
 } from '../../components/feed/feedData'
 import type { GroupBoard } from '../../components/feed/types'
@@ -148,6 +149,23 @@ describe('canModifyPost', () => {
     expect(canModifyPost({ id: 'u1', username: 'a' } as any, 'u2')).toBe(false)
     expect(canModifyPost({ username: 'a' } as any, 'u1')).toBe(false)
     expect(canModifyPost(null, 'u1')).toBe(false)
+  })
+})
+
+describe('canReportPost', () => {
+  it('lets a verified member report someone else\'s post', () => {
+    expect(canReportPost({ id: 'u1', username: 'a', isVerified: true } as any, 'u2')).toBe(true)
+    expect(canReportPost({ id: 'u1', username: 'a', verificationLevel: 1 } as any, 'u2')).toBe(true)
+  })
+
+  it('hides report on your own post (edit/delete cover that)', () => {
+    expect(canReportPost({ id: 'u1', username: 'a', isVerified: true } as any, 'u1')).toBe(false)
+  })
+
+  it('requires a signed-in verified user', () => {
+    expect(canReportPost(null, 'u2')).toBe(false)
+    expect(canReportPost({ id: 'u1', username: 'a' } as any, 'u2')).toBe(false)
+    expect(canReportPost({ id: 'u1', username: 'a', verificationLevel: 0 } as any, 'u2')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## The gap

`reportBoardPost(postId, reason?)` has lived in `packages/frontend/utils/api.ts` (the member-side moderation entry from #209) but had **zero callers** anywhere in `components/**` or `app/**`. There was no Report affordance in the UI, so members could never report a board/feed post — the moderation queue could only ever be filled from the admin side.

## What this adds

A **Report** action in the shared post action menu, wired to `reportBoardPost`.

- **`canReportPost(user, authorId)`** helper in `components/feed/feedData.ts`, sitting alongside the existing `canModifyPost` / `canPinPosts` gates.
- **Report row** in `PostThread`'s `ActionMenuSheet`, using the same `MenuRow` + inline-confirm pattern as Delete (a "Report this post to the moderators?" confirm with Cancel / Report buttons — no new modal style introduced).
- On success it shows an inline notice ("Thanks — this post was reported to the moderators.") using `colors.accent`, mirroring how the menu already surfaces `actionError`. Errors are awaited and surfaced gracefully; busy state disables the buttons and shows a spinner.
- Analytics: `feed_post_reported` / `feed_post_report_failed` / `feed_post_report_confirm_shown` / `feed_post_report_cancelled`, matching the existing `feed_post_*` event naming.
- Uses `className`-free inline styles consistent with the rest of the file (no NativeWind `style={({pressed}) => ...}` footgun).

## Gating / ownership rules

- **Hidden on your own posts** — own posts already expose Edit/Delete, so Report would be noise there.
- **Verified members only** — `isVerified` or `verificationLevel > 0`, matching how the codebase reads the current user's verification for posting/replying.
- **Signed-out / unverified** users don't see it.

## Web + native parity

`PostThread.tsx` is **not** platform-split (there is only one `PostThread.tsx`, no `.web.tsx`). It is the single shared detail component used by the Connect feed, center boards, and event boards on both web and native (`app/feed/[id].*` → `FeedWorkspace` → `PostThread`, plus `app/center/[id].*`, `app/events/[id].*`, and the desktop `*DetailPanel.web.tsx`). One change covers every surface and both platforms. The menu is shared between the top-level post; replies do not currently render their own action menu, so the change applies wherever a menu exists today.

## Verification

- `npm run typecheck` (tsc --noEmit) in `packages/frontend` — **clean, exit 0**.
- `npx vitest run` — **198 passed** (full suite); added 3 `canReportPost` cases to `src/__tests__/feedData.test.ts` (now **17 passed** in that file).
- No `lint` script exists in the repo; ESLint is not configured.
- Note: vitest excludes `app/**`, so green tests don't exercise the rendered menu — the UI wiring was verified by reading + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)