### PR TITLE
[Janata #541] v2 · analytics · Fix PostHog CORS/collection before beta (#541)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,12 @@ jobs:
         env:
           # Inlined at build time by Expo; same key as local packages/frontend/.env
           EXPO_PUBLIC_POSTHOG_KEY: ${{ secrets.EXPO_PUBLIC_POSTHOG_KEY }}
-          EXPO_PUBLIC_POSTHOG_HOST: ${{ secrets.EXPO_PUBLIC_POSTHOG_HOST }}
+          # NOTE: deliberately NOT setting EXPO_PUBLIC_POSTHOG_HOST for web.
+          # Web analytics must stay same-origin to avoid CORS / ad-blocker drops
+          # (#541): with no override, resolvePostHogHost() routes the browser to
+          # the app's own /ingest path, which the Pages Function (public/functions/
+          # ingest/[[path]].js) proxies to PostHog. Setting a *.posthog.com host
+          # here would reintroduce the cross-origin request the proxy exists to fix.
 
       - name: Show Pages production branch (diagnostic)
         run: npx wrangler pages project list

--- a/packages/frontend/ANALYTICS.md
+++ b/packages/frontend/ANALYTICS.md
@@ -1,0 +1,45 @@
+# Analytics (PostHog) — configuration & verification
+
+Single source of truth for how the app talks to PostHog and how to confirm
+events are landing before a beta/admin rollout. Background: Janata #541.
+
+## How the host is chosen
+
+Host/key resolution lives in `utils/analyticsConfig.ts` (pure, unit-tested in
+`src/__tests__/analyticsConfig.test.ts`) and is wired into the `PostHogProvider`
+in `app/_layout.tsx`.
+
+| Platform | Host the client talks to | Why |
+| --- | --- | --- |
+| **Web** | the app's own origin at `/ingest` (e.g. `https://chinmayajanata.org/ingest`) | A browser request to `us.i.posthog.com` is **cross-origin** → CORS preflight/failure, and ad-blockers drop known PostHog hosts. Same-origin avoids both. |
+| **iOS / Android** | `https://us.i.posthog.com` (direct) | Native `fetch` has no CORS and can't resolve a relative path. |
+
+`/ingest/*` is rewritten to PostHog at the edge by the Cloudflare Pages Function
+in `public/functions/ingest/[[path]].js` (copied into `dist/` by `expo export`,
+compiled by `wrangler pages deploy dist`).
+
+### Keys
+Only a **public project key** (`phc_…`) may ship in the client bundle;
+`isSafeClientPostHogKey()` rejects personal/secret keys (`phx_…`/`phs_…`) so a
+secret can never be inlined into a public build. The web build sets
+`EXPO_PUBLIC_POSTHOG_KEY` (a `phc_` key) and **deliberately does not set
+`EXPO_PUBLIC_POSTHOG_HOST`** (see `.github/workflows/deploy.yml`) — any
+`*.posthog.com` value there would reintroduce the cross-origin request.
+
+## Verifying web analytics (do this each beta check)
+
+1. Open the live site (`https://chinmayajanata.org`) in a normal browser window.
+2. DevTools → Console: there should be **no PostHog CORS / config errors**
+   during normal usage.
+3. DevTools → Network, filter `ingest`: capture/flags requests go to
+   `…chinmayajanata.org/ingest/…` (same-origin) and return `200`, **not** to
+   `us.i.posthog.com`.
+4. In PostHog → Activity, confirm the fresh session's key events appear
+   (app open, screen views, sign-in). Allow a minute for ingestion.
+
+## Native / TestFlight
+
+Native builds (EAS) set only `EXPO_PUBLIC_POSTHOG_KEY` and use the direct host,
+so they were not affected by the web CORS issue. Verify a TestFlight session by
+watching for its events in PostHog (filter `app_platform = ios`). If a native
+gap surfaces during beta, file a follow-up issue and link it here.

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -33,6 +33,7 @@ import {
 import { ErrorBoundaryWithAnalytics } from '../components/ui/ErrorBoundary'
 import WebBottomNav from '../components/ui/WebBottomNav'
 import { AnalyticsScreenTracker, AnalyticsBootstrap } from '../utils/analytics'
+import { resolvePostHogHost, isSafeClientPostHogKey } from '../utils/analyticsConfig'
 import { supportsNativeDriver } from '../utils/animation'
 import { usePushNotifications } from '../hooks/usePushNotifications'
 import { getIntroShown } from '../utils/introStorage'
@@ -45,9 +46,20 @@ export const unstable_settings = {
 SplashScreen.preventAutoHideAsync()
 SplashScreen.setOptions({ duration: 350, fade: true })
 
-const posthogHost = process.env.EXPO_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com'
+// Web captures through the app's own origin (/ingest, rewritten to PostHog at
+// the edge) so the browser never makes a cross-origin request — no CORS errors,
+// ad-blocker resistant. Native talks to the direct absolute ingestion host. See
+// utils/analyticsConfig.ts and #541.
+const posthogHost = resolvePostHogHost({
+  platform: Platform.OS as 'web' | 'ios' | 'android',
+  // Reference the literal so Expo inlines it at build time (a dynamic lookup off
+  // a passed-in process.env object is NOT inlined and reads undefined on web).
+  env: { EXPO_PUBLIC_POSTHOG_HOST: process.env.EXPO_PUBLIC_POSTHOG_HOST },
+  origin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+})
 const posthogKey = process.env.EXPO_PUBLIC_POSTHOG_KEY
-const posthogEnabled = !!(posthogKey && posthogKey.trim().length > 0)
+// Only ship the public project key (phc_…); never a personal/secret key.
+const posthogEnabled = isSafeClientPostHogKey(posthogKey)
 
 export default function RootLayout() {
   const [fontsLoaded] = useFonts({

--- a/packages/frontend/public/functions/ingest/[[path]].js
+++ b/packages/frontend/public/functions/ingest/[[path]].js
@@ -1,0 +1,38 @@
+// Cloudflare Pages Function — PostHog reverse proxy (Janata #541).
+//
+// The web build sends analytics to the app's OWN origin at `/ingest/*` (see
+// utils/analyticsConfig.ts) so the browser never makes a cross-origin request:
+// no CORS preflight/failure, and ad-blockers that only block known PostHog
+// hostnames can't silently drop events. This edge function rewrites those
+// same-origin requests to PostHog's ingestion + asset hosts.
+//
+// Lives in packages/frontend/public/ so `expo export` copies it into `dist/`,
+// where `wrangler pages deploy dist` compiles it as a Pages Function.
+
+const API_HOST = 'us.i.posthog.com'
+const ASSET_HOST = 'us-assets.i.posthog.com'
+
+export async function onRequest(context) {
+  const { request } = context
+  const url = new URL(request.url)
+
+  // Strip the `/ingest` prefix; forward the remaining path + query upstream.
+  const path = url.pathname.replace(/^\/ingest/, '') || '/'
+  const upstreamHost = path.startsWith('/static/') ? ASSET_HOST : API_HOST
+
+  const upstreamUrl = new URL(request.url)
+  upstreamUrl.protocol = 'https:'
+  upstreamUrl.hostname = upstreamHost
+  upstreamUrl.port = ''
+  upstreamUrl.pathname = path
+
+  const headers = new Headers(request.headers)
+  headers.set('host', upstreamHost)
+
+  return fetch(upstreamUrl.toString(), {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: 'follow',
+  })
+}

--- a/packages/frontend/src/__tests__/analyticsConfig.test.ts
+++ b/packages/frontend/src/__tests__/analyticsConfig.test.ts
@@ -1,0 +1,146 @@
+/**
+ * analyticsConfig.test.ts
+ *
+ * Independent tests for the PostHog client configuration introduced to fix the
+ * live-web CORS / collection problem (Janata #541).
+ *
+ * Background: the web build currently points PostHog straight at the
+ * third-party origin `https://us.i.posthog.com` (see `app/_layout.tsx`). In a
+ * browser that is a cross-origin request, which is what throws the CORS /
+ * "config" console errors and lets ad-blockers silently drop events — so web
+ * analytics never reach PostHog.
+ *
+ * The fix these tests pin down extracts host/key resolution out of the
+ * (untestable) `_layout.tsx` component into a small pure module,
+ * `utils/analyticsConfig.ts`, with the SAME contract the live app must use:
+ *
+ *   resolvePostHogHost(options: {
+ *     platform: 'web' | 'ios' | 'android'
+ *     env?: Record<string, string | undefined>   // reads EXPO_PUBLIC_POSTHOG_HOST
+ *     origin?: string                              // window.location.origin on web
+ *   }): string
+ *
+ *     - WEB    → a SAME-ORIGIN host (the app's own reverse-proxy path/origin) so
+ *               the browser never makes a cross-origin request → no CORS errors,
+ *               no ad-blocker drops. Must NOT be a `*.posthog.com` host.
+ *     - NATIVE → a direct, absolute `https://…posthog.com` ingestion host
+ *               (native fetch has no CORS; a relative path would break it).
+ *     - An explicit `EXPO_PUBLIC_POSTHOG_HOST` override is honored.
+ *
+ *   isSafeClientPostHogKey(key: string | null | undefined): boolean
+ *
+ *     - true ONLY for a public project key (`phc_…`, the value safe to ship in
+ *       the client bundle). false for personal/secret keys (`phx_…`) and for
+ *       anything empty/unknown — so a secret can never be shipped to the browser.
+ *
+ * These assert observable behaviour (the host the browser/native client will
+ * actually talk to, and which keys are allowed client-side), not internals.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolvePostHogHost, isSafeClientPostHogKey } from '../../utils/analyticsConfig'
+
+const PROD_ORIGIN = 'https://chinmayajanata.org'
+const PREVIEW_ORIGIN = 'https://project-janatha.pages.dev'
+
+/** Origin of a host as the browser would compute it, resolving relative paths. */
+function originOf(host: string, base: string): string {
+  return new URL(host, base).origin
+}
+
+describe('resolvePostHogHost — web is CORS-safe (same-origin)', () => {
+  it('routes web capture through the app’s own origin (no cross-origin request)', () => {
+    const host = resolvePostHogHost({ platform: 'web', env: {}, origin: PROD_ORIGIN })
+    expect(host).toBeTruthy()
+    expect(typeof host).toBe('string')
+    // The browser must talk to the app's own origin, so the request is
+    // same-origin and never triggers a CORS preflight/failure.
+    expect(originOf(host, PROD_ORIGIN)).toBe(PROD_ORIGIN)
+  })
+
+  it('never sends web events directly to a *.posthog.com host', () => {
+    const host = resolvePostHogHost({ platform: 'web', env: {}, origin: PROD_ORIGIN })
+    const resolvedHostname = new URL(host, PROD_ORIGIN).hostname
+    expect(resolvedHostname).not.toBe('us.i.posthog.com')
+    expect(resolvedHostname.endsWith('posthog.com')).toBe(false)
+    expect(resolvedHostname).toBe('chinmayajanata.org')
+  })
+
+  it('is origin-relative so preview deploys stay same-origin too', () => {
+    const host = resolvePostHogHost({ platform: 'web', env: {}, origin: PREVIEW_ORIGIN })
+    expect(originOf(host, PREVIEW_ORIGIN)).toBe(PREVIEW_ORIGIN)
+    expect(new URL(host, PREVIEW_ORIGIN).hostname.endsWith('posthog.com')).toBe(false)
+  })
+
+  it('honors a same-origin / relative EXPO_PUBLIC_POSTHOG_HOST override on web', () => {
+    const host = resolvePostHogHost({
+      platform: 'web',
+      env: { EXPO_PUBLIC_POSTHOG_HOST: '/ingest' },
+      origin: PROD_ORIGIN,
+    })
+    expect(originOf(host, PROD_ORIGIN)).toBe(PROD_ORIGIN)
+  })
+
+  it('does not return the bare cross-origin PostHog default on web', () => {
+    const host = resolvePostHogHost({ platform: 'web', env: {}, origin: PROD_ORIGIN })
+    expect(host).not.toBe('https://us.i.posthog.com')
+    expect(host).not.toBe('https://us.i.posthog.com/')
+  })
+})
+
+describe('resolvePostHogHost — native uses a direct ingestion host', () => {
+  it('ios resolves to an absolute https PostHog host by default', () => {
+    const host = resolvePostHogHost({ platform: 'ios', env: {} })
+    expect(host).toMatch(/^https:\/\//)
+    expect(new URL(host).hostname.endsWith('posthog.com')).toBe(true)
+  })
+
+  it('android resolves to an absolute https PostHog host by default', () => {
+    const host = resolvePostHogHost({ platform: 'android', env: {} })
+    expect(host).toMatch(/^https:\/\//)
+    expect(new URL(host).hostname.endsWith('posthog.com')).toBe(true)
+  })
+
+  it('never returns a relative path on native (relative breaks native fetch)', () => {
+    const ios = resolvePostHogHost({ platform: 'ios', env: {} })
+    const android = resolvePostHogHost({ platform: 'android', env: {} })
+    expect(ios.startsWith('https://')).toBe(true)
+    expect(android.startsWith('https://')).toBe(true)
+  })
+
+  it('honors an absolute EXPO_PUBLIC_POSTHOG_HOST override exactly on native', () => {
+    const host = resolvePostHogHost({
+      platform: 'ios',
+      env: { EXPO_PUBLIC_POSTHOG_HOST: 'https://eu.i.posthog.com' },
+    })
+    expect(host).toBe('https://eu.i.posthog.com')
+  })
+})
+
+describe('isSafeClientPostHogKey — only the public project key may ship', () => {
+  it('accepts a public project key (phc_…)', () => {
+    expect(isSafeClientPostHogKey('phc_AbC123dEf456GhI789jKl')).toBe(true)
+  })
+
+  it('accepts a public project key with surrounding whitespace (trimmed)', () => {
+    expect(isSafeClientPostHogKey('  phc_AbC123dEf456GhI789jKl  ')).toBe(true)
+  })
+
+  it('rejects a personal API key (phx_…) so a secret never ships to the browser', () => {
+    expect(isSafeClientPostHogKey('phx_AbC123dEf456GhI789jKl')).toBe(false)
+  })
+
+  it('rejects any non-public-key string', () => {
+    expect(isSafeClientPostHogKey('phs_AbC123dEf456GhI789jKl')).toBe(false)
+    expect(isSafeClientPostHogKey('not-a-posthog-key')).toBe(false)
+    // A phc_ token that is NOT at the start must not slip through.
+    expect(isSafeClientPostHogKey('xphc_AbC123dEf456')).toBe(false)
+  })
+
+  it('rejects empty / blank / missing keys', () => {
+    expect(isSafeClientPostHogKey('')).toBe(false)
+    expect(isSafeClientPostHogKey('   ')).toBe(false)
+    expect(isSafeClientPostHogKey(undefined)).toBe(false)
+    expect(isSafeClientPostHogKey(null)).toBe(false)
+  })
+})

--- a/packages/frontend/utils/analyticsConfig.ts
+++ b/packages/frontend/utils/analyticsConfig.ts
@@ -1,0 +1,71 @@
+/**
+ * analyticsConfig.ts
+ *
+ * Pure host/key resolution for the PostHog client, extracted from `_layout.tsx`
+ * so the live contract is testable (Janata #541).
+ *
+ * The web build used to point PostHog straight at `https://us.i.posthog.com`.
+ * In a browser that is a cross-origin request — it triggers a CORS preflight
+ * and is trivially dropped by ad-blockers, so web analytics never landed.
+ *
+ * The fix: web captures through the app's OWN origin via a reverse-proxy path
+ * (`/ingest`, rewritten to PostHog at the edge). That keeps every request
+ * same-origin (no CORS, ad-blocker resistant). Native (iOS/Android) has no CORS
+ * and can't resolve a relative path, so it keeps talking to the direct
+ * absolute ingestion host.
+ */
+
+/** Same-origin reverse-proxy path the web build sends events to. */
+export const WEB_INGEST_PATH = '/ingest'
+
+/** Direct ingestion host used by the native clients (no CORS, needs absolute URL). */
+export const DEFAULT_NATIVE_POSTHOG_HOST = 'https://us.i.posthog.com'
+
+type Platform = 'web' | 'ios' | 'android'
+
+interface ResolvePostHogHostOptions {
+  platform: Platform
+  /** Process env, read for an EXPO_PUBLIC_POSTHOG_HOST override. */
+  env?: Record<string, string | undefined>
+  /** window.location.origin on web (unused for the relative default). */
+  origin?: string
+}
+
+/**
+ * Resolve the host the PostHog client should talk to.
+ *
+ *  - web    → a same-origin host (default: the `/ingest` reverse-proxy path) so
+ *             the browser never makes a cross-origin request.
+ *  - native → a direct absolute `https://…posthog.com` ingestion host.
+ *  - An explicit EXPO_PUBLIC_POSTHOG_HOST override is honored on either.
+ */
+export function resolvePostHogHost(options: ResolvePostHogHostOptions): string {
+  const { platform, env, origin } = options
+  const override = env?.EXPO_PUBLIC_POSTHOG_HOST?.trim()
+
+  if (platform === 'web') {
+    // Honor an explicit override, else proxy through the local /ingest path.
+    const path = override || WEB_INGEST_PATH
+    // Absolutize a same-origin/relative path against the app's own origin so the
+    // client always gets a well-formed URL — still same-origin, so no CORS.
+    if (origin && path.startsWith('/')) {
+      return origin.replace(/\/+$/, '') + path
+    }
+    return path
+  }
+
+  // Native: never a relative path — fetch needs an absolute URL.
+  return override || DEFAULT_NATIVE_POSTHOG_HOST
+}
+
+/**
+ * Whether a key is safe to ship in the client bundle.
+ *
+ * Only a public project key (`phc_…`) may reach the browser/app. Personal or
+ * secret keys (`phx_…`, `phs_…`) and anything empty/unknown are rejected so a
+ * secret can never be embedded in a public build.
+ */
+export function isSafeClientPostHogKey(key: string | null | undefined): boolean {
+  if (typeof key !== 'string') return false
+  return key.trim().startsWith('phc_')
+}


### PR DESCRIPTION
Automated KishOS software-factory run.

Refs #541
Issue: https://github.com/Project-Janata/Janata/issues/541

Human review required before merge. KishOS does not merge this PR automatically.

Factory spec:

Task: [Janata #541] v2 · analytics · Fix PostHog CORS/collection before beta

Software factory project: Janata
Repository: Project-Janata/Janata
GitHub issue: #541 https://github.com/Project-Janata/Janata/issues/541
Base branch: origin/v2
Labels: area:beta, bug, priority:p1, status:todo, v2

Factory rules:
- Work only inside the configured repository and keep the change focused on this issue.
- The KishOS dev gate owns the isolated worktree and verification.
- After verification passes, open a draft PR for human review. Do not merge.
- Do not perform release, App Store/TestFlight, credential, payment, or irreversible production actions.
- If a human dependency or credential blocks the work, gate the job with concrete next steps.
- If the project provides a Slack bridge, post the PR/update through that bridge after PR creation.

Issue body:

## Context

Source: Janatha beta planning meeting, 2026-06-19.

During live-site testing, PostHog appeared to be throwing console/CORS errors. Before broader admin beta rollout, we need to confirm analytics are actually being collected and that browser/runtime errors are not blocking capture.

## Scope

- Reproduce the live-site PostHog console/CORS issue.
- Confirm whether web analytics events are reaching PostHog.
- Check whether native/TestFlight analytics are affected separately.
- Fix configuration, proxying, allowed origins, or client setup as needed.
- Document the expected verification path for future beta checks.

## Acceptance criteria

- [ ] No PostHog CORS/config errors appear in the live web console during normal app usage.
- [ ] Key beta events are visible in PostHog after a fresh test session.
- [ ] Analytics capture works in production web without leaking secrets.
- [ ] Any remaining native/TestFlight analytics gap is documented or linked as a follow-up.

## Priority

Should be handled before broad beta/admin rollout so we have a reliable feedback loop.