### PR TITLE
[Janata #542] v2 · beta · Add simple user feedback capture path (#542)

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -332,6 +332,7 @@ function RootLayoutNav({ onAuthReady }: { onAuthReady: () => void }) {
           <Stack.Screen name="edit-profile" options={{ headerShown: false }} />
           <Stack.Screen name="center-picker" options={{ headerShown: false }} />
           <Stack.Screen name="admin" options={{ headerShown: false }} />
+          <Stack.Screen name="feedback" options={{ headerShown: true, title: 'Feedback' }} />
         </Stack>
         </View>
         {showBottomNav && <WebBottomNav />}

--- a/packages/frontend/app/feedback.tsx
+++ b/packages/frontend/app/feedback.tsx
@@ -1,0 +1,359 @@
+import React, { useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { AlertCircle, Camera, CheckCircle2, MessageSquare, X } from 'lucide-react-native'
+import * as ImagePicker from 'expo-image-picker'
+import { useUser, useTheme } from '../components/contexts'
+import { feedbackClient, validateFeedback } from '../src/feedback/feedbackClient'
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? ''
+  return value ?? ''
+}
+
+/**
+ * In-app feedback capture (issue #542).
+ *
+ * The low-friction path for beta testers/admins to report bugs and product
+ * feedback. Captures enough context to triage — a description, who to follow
+ * up with, the page/flow they came from, the platform, and an optional
+ * screenshot — and POSTs it through feedbackClient so the team has one place
+ * to review incoming reports.
+ */
+export default function FeedbackScreen() {
+  const router = useRouter()
+  const params = useLocalSearchParams<{ from?: string | string[] }>()
+  const { user } = useUser()
+  const { isDark } = useTheme()
+
+  const c = useMemo(
+    () => ({
+      bg: isDark ? '#1A1A1A' : '#F5F5F4',
+      card: isDark ? '#262626' : '#FFFFFF',
+      surface: isDark ? '#1A1A1A' : '#FAFAF9',
+      border: isDark ? '#3A3A3A' : '#E7E5E4',
+      text: isDark ? '#FAFAFA' : '#1C1917',
+      muted: isDark ? '#A8A29E' : '#78716C',
+      accent: '#E8862A',
+      success: isDark ? '#34D399' : '#059669',
+      successSoft: isDark ? 'rgba(6,95,70,0.2)' : '#ECFDF5',
+      error: isDark ? '#F87171' : '#DC2626',
+      errorSoft: isDark ? 'rgba(220,38,38,0.15)' : '#FEF2F2',
+    }),
+    [isDark],
+  )
+
+  const fromPage = firstParam(params.from).trim()
+  const defaultContact = user?.email || user?.username || ''
+
+  const [description, setDescription] = useState('')
+  const [contact, setContact] = useState(defaultContact)
+  const [screenshot, setScreenshot] = useState<string | null>(null)
+  const [status, setStatus] = useState<SubmitStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const isSubmitting = status === 'submitting'
+
+  const handleAttachScreenshot = async () => {
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync()
+      if (!permission.granted) return
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 0.6,
+        base64: true,
+      })
+      if (result.canceled) return
+      const asset = result.assets?.[0]
+      if (!asset) return
+      const uri = asset.base64 ? `data:image/jpeg;base64,${asset.base64}` : asset.uri
+      setScreenshot(uri ?? null)
+    } catch {
+      // A failed attach shouldn't block the report — the description is enough.
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return
+
+    const validation = validateFeedback({ description })
+    if (!validation.valid) {
+      setStatus('error')
+      setErrorMessage(validation.message || 'Please describe what happened before sending.')
+      return
+    }
+
+    setStatus('submitting')
+    setErrorMessage('')
+
+    const result = await feedbackClient.submit({
+      description,
+      contact: contact.trim() || undefined,
+      page: fromPage || undefined,
+      screenshot,
+      platform: Platform.OS,
+    })
+
+    if (result.success) {
+      setStatus('success')
+    } else {
+      setStatus('error')
+      setErrorMessage(result.error?.message || 'Something went wrong. Please try again.')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <View style={{ flex: 1, backgroundColor: c.bg, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+        <View
+          style={{
+            width: '100%',
+            maxWidth: 420,
+            borderWidth: 1,
+            borderColor: c.border,
+            borderRadius: 12,
+            backgroundColor: c.card,
+            padding: 24,
+            gap: 16,
+            alignItems: 'center',
+          }}
+        >
+          <View
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 24,
+              backgroundColor: c.successSoft,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <CheckCircle2 size={26} color={c.success} />
+          </View>
+          <Text style={{ fontSize: 20, fontWeight: '700', color: c.text, textAlign: 'center' }}>
+            Feedback received — thank you!
+          </Text>
+          <Text style={{ fontSize: 15, lineHeight: 22, color: c.muted, textAlign: 'center' }}>
+            Thanks for helping us make Janata better. The team will take a look at your report.
+          </Text>
+          <View style={{ width: '100%', gap: 10, marginTop: 4 }}>
+            <Pressable
+              accessibilityRole="button"
+              testID="feedback-send-another"
+              onPress={() => {
+                setDescription('')
+                setScreenshot(null)
+                setStatus('idle')
+                setErrorMessage('')
+              }}
+              style={{
+                minHeight: 48,
+                borderRadius: 8,
+                backgroundColor: c.accent,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text style={{ color: '#FFFFFF', fontSize: 15, fontWeight: '600' }}>Send more feedback</Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => router.back()}
+              style={{
+                minHeight: 44,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: c.border,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text style={{ color: c.text, fontSize: 15, fontWeight: '600' }}>Done</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: c.bg }}
+      contentContainerStyle={{ padding: 20, gap: 18, maxWidth: 560, width: '100%', alignSelf: 'center' }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            backgroundColor: c.card,
+            borderWidth: 1,
+            borderColor: c.border,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <MessageSquare size={20} color={c.accent} />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text style={{ fontSize: 22, fontWeight: '700', color: c.text }}>Send feedback</Text>
+          <Text style={{ fontSize: 14, lineHeight: 20, color: c.muted }}>
+            Hit a bug or have an idea? Tell us what happened.
+          </Text>
+        </View>
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ fontSize: 13, fontWeight: '600', color: c.muted }}>What happened?</Text>
+        <TextInput
+          testID="feedback-description"
+          value={description}
+          onChangeText={(text) => {
+            setDescription(text)
+            if (status === 'error') {
+              setStatus('idle')
+              setErrorMessage('')
+            }
+          }}
+          placeholder="Describe the bug or feedback. The more detail, the easier it is to fix."
+          placeholderTextColor={c.muted}
+          multiline
+          numberOfLines={6}
+          textAlignVertical="top"
+          editable={!isSubmitting}
+          style={{
+            minHeight: 130,
+            borderWidth: 1,
+            borderColor: c.border,
+            borderRadius: 10,
+            backgroundColor: c.card,
+            padding: 14,
+            fontSize: 15,
+            lineHeight: 21,
+            color: c.text,
+          }}
+        />
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ fontSize: 13, fontWeight: '600', color: c.muted }}>
+          Contact (so we can follow up)
+        </Text>
+        <TextInput
+          testID="feedback-contact"
+          value={contact}
+          onChangeText={setContact}
+          placeholder="you@example.com"
+          placeholderTextColor={c.muted}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          editable={!isSubmitting}
+          style={{
+            minHeight: 46,
+            borderWidth: 1,
+            borderColor: c.border,
+            borderRadius: 10,
+            backgroundColor: c.card,
+            paddingHorizontal: 14,
+            fontSize: 15,
+            color: c.text,
+          }}
+        />
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ fontSize: 13, fontWeight: '600', color: c.muted }}>Screenshot (optional)</Text>
+        {screenshot ? (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <Text style={{ flex: 1, fontSize: 14, color: c.text }}>Screenshot attached</Text>
+            <Pressable
+              accessibilityRole="button"
+              testID="feedback-remove-screenshot"
+              onPress={() => setScreenshot(null)}
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+            >
+              <X size={16} color={c.muted} />
+              <Text style={{ fontSize: 14, color: c.muted }}>Remove</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <Pressable
+            accessibilityRole="button"
+            testID="feedback-attach-screenshot"
+            onPress={handleAttachScreenshot}
+            disabled={isSubmitting}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              minHeight: 46,
+              borderRadius: 10,
+              borderWidth: 1,
+              borderStyle: 'dashed',
+              borderColor: c.border,
+              backgroundColor: c.card,
+            }}
+          >
+            <Camera size={18} color={c.muted} />
+            <Text style={{ fontSize: 14, color: c.muted }}>Attach a screenshot</Text>
+          </Pressable>
+        )}
+      </View>
+
+      {status === 'error' && errorMessage ? (
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 8,
+            borderWidth: 1,
+            borderColor: c.error,
+            backgroundColor: c.errorSoft,
+            borderRadius: 10,
+            padding: 12,
+          }}
+        >
+          <AlertCircle size={18} color={c.error} />
+          <Text style={{ flex: 1, fontSize: 14, color: c.error }}>{errorMessage}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        accessibilityRole="button"
+        testID="feedback-submit"
+        onPress={handleSubmit}
+        disabled={isSubmitting}
+        style={{
+          minHeight: 50,
+          borderRadius: 10,
+          backgroundColor: c.accent,
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'row',
+          gap: 10,
+          opacity: isSubmitting ? 0.7 : 1,
+        }}
+      >
+        {isSubmitting ? (
+          <ActivityIndicator testID="feedback-submitting" color="#FFFFFF" />
+        ) : null}
+        <Text style={{ color: '#FFFFFF', fontSize: 16, fontWeight: '700' }}>
+          {isSubmitting ? 'Sending…' : status === 'error' ? 'Try again' : 'Send feedback'}
+        </Text>
+      </Pressable>
+    </ScrollView>
+  )
+}

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   UserPlus,
   Bell,
+  MessageSquare,
 } from 'lucide-react-native'
 import { useUser, useTheme } from '../../components/contexts'
 import { Avatar, Text, Section, StackHeader } from '../../components/ui'
@@ -215,6 +216,27 @@ export default function PreferencesNative() {
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
                 <UserPlus size={20} color={textColor} />
                 <Text style={{ fontSize: 15, color: textColor }}>Invite Friends</Text>
+              </View>
+            </MenuRow>
+          </View>
+        </Section>
+
+        <Section title="FEEDBACK" titleColor={faintColor}>
+          <View
+            style={{
+              borderTopWidth: 1,
+              borderBottomWidth: 1,
+              borderColor,
+              marginHorizontal: -16,
+            }}
+          >
+            <MenuRow onPress={() => {
+              track('settings_feedback_pressed', { source: 'settings' })
+              router.push('/feedback?from=/settings')
+            }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+                <MessageSquare size={20} color={textColor} />
+                <Text style={{ fontSize: 15, color: textColor }}>Send Feedback</Text>
               </View>
             </MenuRow>
           </View>

--- a/packages/frontend/app/settings/index.web.tsx
+++ b/packages/frontend/app/settings/index.web.tsx
@@ -172,6 +172,23 @@ export default function Preferences() {
                 alignItems: 'center',
                 justifyContent: 'space-between',
                 padding: isNarrowWeb ? 20 : 28,
+                borderBottomWidth: 1,
+                borderBottomColor: borderColor,
+              }}
+              onPress={() => {
+                track('settings_feedback_pressed', { source: 'settings_web' })
+                router.push('/feedback?from=/settings')
+              }}
+            >
+              <Text style={{ fontSize: 15, color: textColor }}>Send Feedback</Text>
+              <ChevronRight size={18} color={iconColor} />
+            </Pressable>
+            <Pressable
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: isNarrowWeb ? 20 : 28,
               }}
               onPress={handleLogout}
             >

--- a/packages/frontend/src/__tests__/app/feedback.test.tsx
+++ b/packages/frontend/src/__tests__/app/feedback.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * UI-path tests for the in-app feedback screen — app/feedback.tsx
+ *
+ * Issue #542 — "Add simple user feedback capture path".
+ *
+ * The issue explicitly requires the user-facing UI (not just backend/schema
+ * plumbing): a feedback form, a submit action, and loading / success / error
+ * states. These tests render the real screen and drive it through that path.
+ *
+ * Contract the implementation must satisfy (queried below):
+ *   - a heading / title that identifies this as the feedback surface
+ *   - a multi-line description field with testID "feedback-description"
+ *   - a submit control with testID "feedback-submit"
+ *   - submitting an empty form does NOT call the network
+ *   - submitting a valid form calls feedbackClient.submit with the description,
+ *     shows a loading indicator while in-flight, then a success confirmation
+ *   - a failed submission surfaces a visible error (and lets the user retry)
+ *
+ * Heavy native/UI deps are stubbed following the WebBottomNav.test.tsx pattern.
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native'
+
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() })),
+  usePathname: jest.fn(() => '/feedback'),
+  useLocalSearchParams: jest.fn(() => ({})),
+  Stack: { Screen: () => null },
+}))
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaView: 'SafeAreaView',
+}))
+
+// User context may be read to pre-fill the contact field.
+jest.mock('../../../components/contexts', () => ({
+  useUser: jest.fn(() => ({ user: { username: 'kish', email: 'kish@example.com' } })),
+  useTheme: jest.fn(() => ({ isDark: false })),
+}))
+
+// Defensive stubs for optional presentation deps the screen may pull in.
+jest.mock('lucide-react-native', () => new Proxy({}, { get: () => 'Icon' }))
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}))
+jest.mock('expo-image', () => ({ Image: 'Image' }))
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(async () => ({ canceled: true })),
+  requestMediaLibraryPermissionsAsync: jest.fn(async () => ({ granted: true })),
+  MediaTypeOptions: { Images: 'Images' },
+}))
+
+// Keep validateFeedback real; only the network call is mocked.
+jest.mock('../../feedback/feedbackClient', () => {
+  const actual = jest.requireActual('../../feedback/feedbackClient') as Record<string, unknown>
+  return { ...actual, feedbackClient: { submit: jest.fn() } }
+})
+
+const { feedbackClient } = jest.requireMock('../../feedback/feedbackClient') as {
+  feedbackClient: { submit: jest.Mock<(input: unknown) => Promise<unknown>> }
+}
+
+const FeedbackScreen = require('../../../app/feedback').default
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('app/feedback screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    feedbackClient.submit.mockResolvedValue({ success: true, data: { id: 'fb_1' } })
+  })
+
+  it('renders the feedback capture form', () => {
+    render(<FeedbackScreen />)
+
+    // A title/heading that identifies the surface as feedback.
+    expect(screen.getAllByText(/feedback|report a bug|report an issue/i).length).toBeGreaterThan(0)
+    // The description field and the submit control.
+    expect(screen.getByTestId('feedback-description')).toBeTruthy()
+    expect(screen.getByTestId('feedback-submit')).toBeTruthy()
+  })
+
+  it('does not submit when the description is empty', () => {
+    render(<FeedbackScreen />)
+
+    fireEvent.press(screen.getByTestId('feedback-submit'))
+
+    expect(feedbackClient.submit).not.toHaveBeenCalled()
+  })
+
+  it('submits the typed feedback and shows a loading state then a success confirmation', async () => {
+    const d = deferred<{ success: true; data: unknown }>()
+    feedbackClient.submit.mockReturnValue(d.promise)
+
+    render(<FeedbackScreen />)
+
+    fireEvent.changeText(
+      screen.getByTestId('feedback-description'),
+      'The events list never finishes loading',
+    )
+    fireEvent.press(screen.getByTestId('feedback-submit'))
+
+    // Sends the description (other context fields may be added by the screen).
+    expect(feedbackClient.submit).toHaveBeenCalledTimes(1)
+    expect(feedbackClient.submit).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'The events list never finishes loading' }),
+    )
+
+    // While the request is in flight, a loading affordance is visible.
+    const loading =
+      screen.queryByText(/sending|submitting/i) || screen.queryByTestId('feedback-submitting')
+    expect(loading).toBeTruthy()
+
+    d.resolve({ success: true, data: { id: 'fb_1' } })
+
+    expect(
+      await screen.findByText(/thank|received|sent|submitted|success|got it/i),
+    ).toBeTruthy()
+  })
+
+  it('shows an error state when the submission fails', async () => {
+    feedbackClient.submit.mockResolvedValue({ success: false, error: { message: 'Server error' } })
+
+    render(<FeedbackScreen />)
+
+    fireEvent.changeText(screen.getByTestId('feedback-description'), 'Something is broken')
+    fireEvent.press(screen.getByTestId('feedback-submit'))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/wrong|try again|error|failed|could ?n.?t|unable/i),
+      ).toBeTruthy()
+    })
+  })
+})

--- a/packages/frontend/src/__tests__/feedbackClient.test.ts
+++ b/packages/frontend/src/__tests__/feedbackClient.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for src/feedback/feedbackClient.ts
+ *
+ * Issue #542 — "Add simple user feedback capture path".
+ *
+ * These tests lock the DATA-LAYER contract behind the in-app feedback UI:
+ * what gets sent to the backend when a beta tester submits feedback, and how
+ * success / error / network-failure outcomes are reported back to the UI so it
+ * can render loading / success / error states.
+ *
+ * Acceptance-criteria coverage:
+ *   - "Feedback includes enough context to triage: user/contact, platform,
+ *      page/flow, description, and optional screenshot." -> the submit payload
+ *      must carry description, contact, page, screenshot, and an
+ *      auto-captured platform.
+ *
+ * The feedback module is expected to mirror the existing client conventions
+ * (see src/auth/authClient.ts and src/auth/inviteClient.ts): a thin client
+ * that POSTs JSON via the global fetch and returns the project's AsyncResult
+ * shape ({ success: true, data } | { success: false, error }).
+ *
+ * Expected module surface (to be implemented):
+ *   export interface FeedbackInput {
+ *     description: string
+ *     contact?: string
+ *     page?: string
+ *     screenshot?: string | null
+ *     platform?: string
+ *   }
+ *   export function validateFeedback(input: FeedbackInput): { valid: boolean; message?: string }
+ *   export const feedbackClient: {
+ *     submit(input: FeedbackInput): Promise<
+ *       { success: true; data: unknown } | { success: false; error: { message: string } }
+ *     >
+ *   }
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { feedbackClient, validateFeedback } from '../feedback/feedbackClient'
+import type { FeedbackInput } from '../feedback/feedbackClient'
+
+// ── Global fetch mock (matches the convention in api.test.ts) ────────────
+const mockFetch = vi.fn()
+;(globalThis as any).fetch = mockFetch
+
+function mockResponse(body: any, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue(mockResponse({ success: true, id: 'fb_1' }))
+})
+
+// ── validateFeedback ─────────────────────────────────────────────────────
+// The UI uses this to gate the submit button / show inline validation, so the
+// "description" field must be required.
+
+describe('validateFeedback', () => {
+  it('rejects an empty description', () => {
+    const result = validateFeedback({ description: '' })
+    expect(result.valid).toBe(false)
+    expect(typeof result.message).toBe('string')
+    expect(result.message!.length).toBeGreaterThan(0)
+  })
+
+  it('rejects a whitespace-only description', () => {
+    const result = validateFeedback({ description: '   \n\t  ' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('accepts a non-empty description', () => {
+    const result = validateFeedback({ description: 'The feed screen is blank' })
+    expect(result.valid).toBe(true)
+  })
+})
+
+// ── feedbackClient.submit ────────────────────────────────────────────────
+
+describe('feedbackClient.submit', () => {
+  it('POSTs the feedback to a /feedback endpoint as JSON', async () => {
+    await feedbackClient.submit({ description: 'A bug report' })
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(String(url)).toMatch(/\/feedback/)
+    expect(init.method).toBe('POST')
+    // Sent as JSON so the backend can parse a structured feedback record.
+    expect(JSON.stringify(init.headers || {})).toMatch(/application\/json/i)
+  })
+
+  it('includes the full triage context in the request body', async () => {
+    const input: FeedbackInput = {
+      description: 'The map crashes when I tap a center pin',
+      contact: 'beta-tester@example.com',
+      page: '/explore',
+      screenshot: 'data:image/png;base64,AAAA',
+    }
+
+    await feedbackClient.submit(input)
+
+    const [, init] = mockFetch.mock.calls[0]
+    const body = JSON.parse(init.body as string)
+
+    expect(body.description).toBe(input.description)
+    expect(body.contact).toBe(input.contact)
+    expect(body.page).toBe(input.page)
+    expect(body.screenshot).toBe(input.screenshot)
+  })
+
+  it('auto-captures the platform when the caller does not provide one', async () => {
+    // setup.ts mocks react-native Platform.OS to "web"; the client should fill
+    // the platform automatically so triage always knows where feedback came
+    // from, even if the UI forgets to pass it.
+    await feedbackClient.submit({ description: 'no platform supplied' })
+
+    const [, init] = mockFetch.mock.calls[0]
+    const body = JSON.parse(init.body as string)
+    expect(body.platform).toBe('web')
+  })
+
+  it('resolves with success when the server accepts the feedback', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ success: true, id: 'fb_42' }, true, 201))
+
+    const result = await feedbackClient.submit({ description: 'works' })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBeTruthy()
+    }
+  })
+
+  it('resolves with an error result when the server rejects the request', async () => {
+    mockFetch.mockResolvedValue(mockResponse({ message: 'Server error' }, false, 500))
+
+    const result = await feedbackClient.submit({ description: 'boom' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(typeof result.error.message).toBe('string')
+      expect(result.error.message.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('resolves with an error result (does not throw) on network failure', async () => {
+    const abort = new Error('aborted')
+    // Named AbortError so the retry/withTimeout convention fails fast instead
+    // of backing off; a plain try/catch implementation also returns an error.
+    ;(abort as any).name = 'AbortError'
+    mockFetch.mockRejectedValue(abort)
+
+    const result = await feedbackClient.submit({ description: 'offline' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(typeof result.error.message).toBe('string')
+    }
+  }, 10000)
+})

--- a/packages/frontend/src/feedback/feedbackClient.ts
+++ b/packages/frontend/src/feedback/feedbackClient.ts
@@ -1,0 +1,147 @@
+/**
+ * feedbackClient.ts
+ *
+ * Client for the v2 beta user-feedback capture path (issue #542).
+ *
+ * Beta testers/admins need a low-friction way to submit bugs and product
+ * feedback from inside the app. This is the thin data layer behind the
+ * in-app feedback screen (app/feedback.tsx): it POSTs a structured feedback
+ * record so the team has one place to triage incoming reports.
+ *
+ * Mirrors the shape of authClient.ts / inviteClient.ts (withTimeout retries,
+ * AsyncResult). The submit payload carries everything needed to triage a
+ * report — description, who sent it, the platform, the page/flow they were on,
+ * and an optional screenshot.
+ */
+
+import { Platform } from 'react-native'
+import { API_BASE_URL, API_TIMEOUTS } from '../config/api'
+import type { AsyncResult, AuthError } from '../auth/types'
+
+const withTimeout = async (
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  retries = 2,
+): Promise<Response> => {
+  let lastError: Error | undefined
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(init.headers || {}),
+        },
+      })
+      clearTimeout(timeoutId)
+      return response
+    } catch (error: any) {
+      clearTimeout(timeoutId)
+      lastError = error
+      if (error?.name === 'AbortError' && attempt === 0) {
+        throw error
+      }
+      if (attempt < retries) {
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError || new Error('Network request failed')
+}
+
+const toError = (message: string, status?: number, code?: string): AuthError => ({
+  message,
+  status,
+  code,
+})
+
+const buildUrl = (path: string) => `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`
+
+const safeJson = async <T>(response: Response): Promise<T | null> => {
+  try {
+    return (await response.json()) as T
+  } catch {
+    return null
+  }
+}
+
+export interface FeedbackInput {
+  /** What the tester is reporting — the only required field. */
+  description: string
+  /** How to reach them for follow-up (email/username). Pre-filled from the user. */
+  contact?: string
+  /** The page/flow they were on when they hit the issue (e.g. "/explore"). */
+  page?: string
+  /** Optional screenshot, as a data URI. */
+  screenshot?: string | null
+  /** Where the feedback came from. Auto-captured when omitted. */
+  platform?: string
+}
+
+export interface FeedbackSubmitResponse {
+  success?: boolean
+  id?: string
+  message?: string
+}
+
+/**
+ * Gate for the submit button / inline validation. The description is the one
+ * field we genuinely need to triage, so an empty (or whitespace-only) one is
+ * rejected here before we touch the network.
+ */
+export function validateFeedback(input: FeedbackInput): { valid: boolean; message?: string } {
+  if (!input.description || input.description.trim().length === 0) {
+    return { valid: false, message: 'Please describe what happened before sending.' }
+  }
+  return { valid: true }
+}
+
+export const feedbackClient = {
+  /**
+   * Submit a beta feedback report. Auto-captures the platform when the caller
+   * doesn't pass one so triage always knows where a report came from. Returns
+   * the project's AsyncResult shape — never throws — so the UI can render
+   * loading / success / error states.
+   */
+  async submit(input: FeedbackInput): AsyncResult<FeedbackSubmitResponse> {
+    try {
+      const payload = {
+        description: input.description.trim(),
+        contact: input.contact,
+        page: input.page,
+        screenshot: input.screenshot ?? null,
+        platform: input.platform ?? Platform.OS,
+      }
+
+      const response = await withTimeout(
+        buildUrl('/feedback'),
+        {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        },
+        API_TIMEOUTS.standard,
+      )
+
+      const data = await safeJson<FeedbackSubmitResponse>(response)
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: toError(data?.message || 'Failed to send feedback', response.status),
+        }
+      }
+
+      return { success: true, data: data ?? { success: true } }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        return { success: false, error: toError('Request timeout. Please check your connection.') }
+      }
+      return { success: false, error: toError('Network error. Please try again.') }
+    }
+  },
+}


### PR DESCRIPTION
Automated KishOS software-factory run.

Refs #542
Issue: https://github.com/Project-Janata/Janata/issues/542

Human review required before merge. KishOS does not merge this PR automatically.

Factory spec:

Task: [Janata #542] v2 · beta · Add simple user feedback capture path

Software factory project: Janata
Repository: Project-Janata/Janata
GitHub issue: #542 https://github.com/Project-Janata/Janata/issues/542
Base branch: origin/v2
Labels: area:beta, enhancement, priority:p1, status:todo, v2

Factory rules:
- Work only inside the configured repository and keep the change focused on this issue.
- The KishOS dev gate owns the isolated worktree and verification.
- After verification passes, open a draft PR for human review. Do not merge.
- Do not perform release, App Store/TestFlight, credential, payment, or irreversible production actions.
- If a human dependency or credential blocks the work, gate the job with concrete next steps.
- If the project provides a Slack bridge, post the PR/update through that bridge after PR creation.

Issue-specific implementation instruction:
Build the actual user-facing in-app feedback UI. Include a visible entry point in the app, a feedback form/sheet/modal, submission behavior, loading/success/error states, and tests around the UI path. Do not satisfy this issue with only backend/schema plumbing or documentation.

Issue body:

## Context

Source: Janatha beta planning meeting, 2026-06-19.

As we start admin beta testing, testers need a low-friction way to submit bugs and product feedback. For now the team can log feedback in Slack, but beta users/admins should have a clearer capture path.

## Scope

Choose and implement the simplest useful feedback mechanism for beta. Options discussed:

- In-product feedback button/form.
- PostHog feedback widget or survey.
- Notion/form link shared with admins.
- Slack/Janatha agent flow that can roll up to GitHub/Notion.

This does not need to be a perfect ticketing system; it needs to make beta feedback easy to collect and triage.

## Acceptance criteria

- [ ] Admin beta testers have an obvious way to submit feedback.
- [ ] Feedback includes enough context to triage: user/contact, platform, page/flow, description, and optional screenshot.
- [ ] The team has one place to review incoming beta feedback.
- [ ] The admin invite blurb can link to or reference the feedback path.
- [ ] Concrete product bugs can be converted into GitHub issues without manual rework.

## Priority

Should be in place before sharing Janatha broadly with admin testers.